### PR TITLE
feat: expose js api with wasm feature

### DIFF
--- a/src/js_graph.rs
+++ b/src/js_graph.rs
@@ -15,7 +15,7 @@ use anyhow::Result;
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
-pub(crate) struct JsLoader {
+pub struct JsLoader {
   load: js_sys::Function,
   maybe_cache_info: Option<js_sys::Function>,
 }
@@ -71,7 +71,7 @@ impl Loader for JsLoader {
 }
 
 #[derive(Debug)]
-pub(crate) struct JsLocker {
+pub struct JsLocker {
   maybe_check: Option<js_sys::Function>,
   maybe_get_checksum: Option<js_sys::Function>,
 }
@@ -122,7 +122,7 @@ impl Locker for JsLocker {
 }
 
 #[derive(Debug)]
-pub(crate) struct JsResolver {
+pub struct JsResolver {
   resolve: js_sys::Function,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,12 @@ pub use graph::ModuleGraph;
 #[cfg(feature = "rust")]
 pub use graph::ModuleGraphError;
 use graph::ModuleSlot;
+#[cfg(feature = "wasm")]
+pub use js_graph::JsLoader;
+#[cfg(feature = "wasm")]
+pub use js_graph::JsLocker;
+#[cfg(feature = "wasm")]
+pub use js_graph::JsResolver;
 #[cfg(feature = "rust")]
 pub use media_type::MediaType;
 #[cfg(feature = "rust")]


### PR DESCRIPTION
I realised that I needed to expose a couple of structs when using in other crates which are targetting web assembly as well.