### PR TITLE
feat: `DefaultAstParser` that uses less memory and add `CapturingAstParser`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ pub use ast::AstParser;
 #[cfg(feature = "rust")]
 pub use ast::CapturingAstParser;
 #[cfg(feature = "rust")]
+pub use ast::DefaultAstParser;
+#[cfg(feature = "rust")]
 pub use ast::DefaultParsedAst;
 #[cfg(feature = "rust")]
 pub use ast::ParsedAst;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ mod text_encoding;
 #[cfg(feature = "rust")]
 pub use ast::AstParser;
 #[cfg(feature = "rust")]
-pub use ast::DefaultAstParser;
+pub use ast::CapturingAstParser;
 #[cfg(feature = "rust")]
 pub use ast::DefaultParsedAst;
 #[cfg(feature = "rust")]
@@ -389,7 +389,7 @@ mod tests {
       ModuleSpecifier::parse("file:///a/test01.ts").expect("bad url");
     let test02_specifier =
       ModuleSpecifier::parse("file:///a/test02.ts").expect("bad url");
-    let mut parser = crate::ast::DefaultAstParser::new();
+    let mut parser = crate::ast::CapturingAstParser::new();
     create_graph(
       root_specifier.clone(),
       &mut loader,


### PR DESCRIPTION
Just thought of this. Basically by default it won't build up so much in memory in a `HashMap`, but someone can provide a `CapturingAstParser` to store the ASTs.