### PR TITLE
feat: make properties on `Dependency` public

### DIFF
--- a/lib/deno_graph.generated.js
+++ b/lib/deno_graph.generated.js
@@ -219,12 +219,11 @@ function isLikeNone(x) {
   return x === undefined || x === null;
 }
 /**
-* @param {string} specifier
-* @param {any} maybe_headers
-* @param {string} content
-* @param {Function | undefined} maybe_resolve
-* @returns {Module}
-*/
+ * @param {string} specifier
+ * @param {any} maybe_headers
+ * @param {string} content
+ * @param {Function | undefined} maybe_resolve
+ * @returns {Module} */
 export function parseModule(specifier, maybe_headers, content, maybe_resolve) {
   var ptr0 = passStringToWasm0(
     specifier,
@@ -250,14 +249,13 @@ export function parseModule(specifier, maybe_headers, content, maybe_resolve) {
 }
 
 /**
-* @param {string} root_specifier
-* @param {Function} load
-* @param {Function | undefined} maybe_cache_info
-* @param {Function | undefined} maybe_resolve
-* @param {Function | undefined} maybe_check
-* @param {Function | undefined} maybe_get_checksum
-* @returns {any}
-*/
+ * @param {string} root_specifier
+ * @param {Function} load
+ * @param {Function | undefined} maybe_cache_info
+ * @param {Function | undefined} maybe_resolve
+ * @param {Function | undefined} maybe_check
+ * @param {Function | undefined} maybe_get_checksum
+ * @returns {any} */
 export function createGraph(
   root_specifier,
   load,
@@ -303,8 +301,7 @@ function __wbg_adapter_66(arg0, arg1, arg2, arg3) {
 const ModuleFinalization = new FinalizationRegistry((ptr) =>
   wasm.__wbg_module_free(ptr)
 );
-/**
-*/
+/**/
 export class Module {
   static __wrap(ptr) {
     const obj = Object.create(Module.prototype);
@@ -325,15 +322,15 @@ export class Module {
     wasm.__wbg_module_free(ptr);
   }
   /**
-    * @returns {any}
-    */
+   * @returns {any}
+   */
   get cacheInfo() {
     var ret = wasm.module_cacheInfo(this.ptr);
     return takeObject(ret);
   }
   /**
-    * @returns {string | undefined}
-    */
+   * @returns {string | undefined}
+   */
   get checksum() {
     try {
       const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
@@ -351,15 +348,15 @@ export class Module {
     }
   }
   /**
-    * @returns {any}
-    */
+   * @returns {any}
+   */
   get dependencies() {
     var ret = wasm.module_dependencies(this.ptr);
     return takeObject(ret);
   }
   /**
-    * @returns {string}
-    */
+   * @returns {string}
+   */
   get mediaType() {
     try {
       const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
@@ -373,15 +370,15 @@ export class Module {
     }
   }
   /**
-    * @returns {number}
-    */
+   * @returns {number}
+   */
   get size() {
     var ret = wasm.module_size(this.ptr);
     return ret >>> 0;
   }
   /**
-    * @returns {string}
-    */
+   * @returns {string}
+   */
   get source() {
     try {
       const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
@@ -395,8 +392,8 @@ export class Module {
     }
   }
   /**
-    * @returns {string}
-    */
+   * @returns {string}
+   */
   get specifier() {
     try {
       const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
@@ -410,15 +407,15 @@ export class Module {
     }
   }
   /**
-    * @returns {any}
-    */
+   * @returns {any}
+   */
   get typesDependency() {
     var ret = wasm.module_typesDependency(this.ptr);
     return takeObject(ret);
   }
   /**
-    * @returns {any}
-    */
+   * @returns {any}
+   */
   toJSON() {
     var ret = wasm.module_toJSON(this.ptr);
     return takeObject(ret);
@@ -428,8 +425,7 @@ export class Module {
 const ModuleGraphFinalization = new FinalizationRegistry((ptr) =>
   wasm.__wbg_modulegraph_free(ptr)
 );
-/**
-*/
+/**/
 export class ModuleGraph {
   static __wrap(ptr) {
     const obj = Object.create(ModuleGraph.prototype);
@@ -450,8 +446,8 @@ export class ModuleGraph {
     wasm.__wbg_modulegraph_free(ptr);
   }
   /**
-    * @returns {string}
-    */
+   * @returns {string}
+   */
   get root() {
     try {
       const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
@@ -465,9 +461,9 @@ export class ModuleGraph {
     }
   }
   /**
-    * @param {string} specifier
-    * @returns {Module | undefined}
-    */
+   * @param {string} specifier
+   * @returns {Module | undefined}
+   */
   get(specifier) {
     var ptr0 = passStringToWasm0(
       specifier,
@@ -478,22 +474,21 @@ export class ModuleGraph {
     var ret = wasm.modulegraph_get(this.ptr, ptr0, len0);
     return ret === 0 ? undefined : Module.__wrap(ret);
   }
-  /**
-    */
+  /**/
   lock() {
     wasm.modulegraph_lock(this.ptr);
   }
   /**
-    * @returns {Array<any>}
-    */
+   * @returns {Array<any>}
+   */
   get modules() {
     var ret = wasm.modulegraph_modules(this.ptr);
     return takeObject(ret);
   }
   /**
-    * @param {string} specifier
-    * @returns {string}
-    */
+   * @param {string} specifier
+   * @returns {string}
+   */
   resolve(specifier) {
     try {
       const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
@@ -513,10 +508,10 @@ export class ModuleGraph {
     }
   }
   /**
-    * @param {string} specifier
-    * @param {string} referrer
-    * @returns {string | undefined}
-    */
+   * @param {string} specifier
+   * @param {string} referrer
+   * @returns {string | undefined}
+   */
   resolveDependency(specifier, referrer) {
     try {
       const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
@@ -553,16 +548,16 @@ export class ModuleGraph {
     }
   }
   /**
-    * @returns {any}
-    */
+   * @returns {any}
+   */
   toJSON() {
     var ret = wasm.modulegraph_toJSON(this.ptr);
     return takeObject(ret);
   }
   /**
-    * @param {boolean | undefined} maybe_no_color
-    * @returns {string}
-    */
+   * @param {boolean | undefined} maybe_no_color
+   * @returns {string}
+   */
   toString(maybe_no_color) {
     try {
       const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -203,6 +203,6 @@ export class ModuleGraph {
    * `true` and not provide ANSI color escape sequences.
    *
    * @param noColor An optional flag indicating if ANSI color escape codes
-   *                should be included in the returned string.*/
+   *                should be included in the returned string. */
   toString(noColor?: boolean): string;
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -171,9 +171,9 @@ fn is_false(v: &bool) -> bool {
 #[serde(rename_all = "camelCase")]
 pub struct Dependency {
   #[serde(rename = "code", skip_serializing_if = "Resolved::is_none")]
-  pub(crate) maybe_code: Resolved,
+  pub maybe_code: Resolved,
   #[serde(rename = "type", skip_serializing_if = "Resolved::is_none")]
-  pub(crate) maybe_type: Resolved,
+  pub maybe_type: Resolved,
   #[serde(skip_serializing_if = "is_false")]
   pub is_dynamic: bool,
 }


### PR DESCRIPTION
I couldn't figure out how to access this information. I need it to get a module's dependencies (Edit: Actually, I just found a better solution to my problem that doesn't require this, but maybe we should have this anyway? I'm not sure why these are internal).