### PR TITLE
Make source::Loader easier to use

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1525,7 +1525,7 @@ impl<'a> Builder<'a> {
       let fut = self
         .loader
         .load(&specifier, is_dynamic)
-        .map(move |res| (specifier.clone(), res));
+        .map(move |res| (specifier, res));
       self.pending.push(Box::pin(fut));
     }
   }

--- a/src/js_graph.rs
+++ b/src/js_graph.rs
@@ -57,7 +57,7 @@ impl Loader for JsLoader {
     is_dynamic: bool,
   ) -> LoadFuture {
     if specifier.scheme() == "data" {
-      Box::pin(future::ready((specifier.clone(), load_data_url(specifier))))
+      Box::pin(future::ready(load_data_url(specifier)))
     } else {
       let specifier = specifier.clone();
       let context = JsValue::null();
@@ -74,12 +74,9 @@ impl Loader for JsLoader {
           }
           Err(err) => Err(err),
         };
-        (
-          specifier,
-          response
-            .map(|value| value.into_serde().unwrap())
-            .map_err(|_| anyhow!("load rejected or errored")),
-        )
+        response
+          .map(|value| value.into_serde().unwrap())
+          .map_err(|_| anyhow!("load rejected or errored"))
       };
       Box::pin(f)
     }

--- a/src/source.rs
+++ b/src/source.rs
@@ -54,7 +54,7 @@ pub struct LoadResponse {
   pub content: Arc<String>,
 }
 
-pub type LoadResult = (ModuleSpecifier, Result<Option<LoadResponse>>);
+pub type LoadResult = Result<Option<LoadResponse>>;
 pub type LoadFuture = Pin<Box<dyn Future<Output = LoadResult> + 'static>>;
 
 /// A trait which allows asynchronous loading of source files into a module
@@ -205,7 +205,7 @@ impl Loader for MemoryLoader {
       None if specifier.scheme() == "data" => load_data_url(specifier),
       _ => Ok(None),
     };
-    Box::pin(future::ready((specifier.clone(), response)))
+    Box::pin(future::ready(response))
   }
 }
 


### PR DESCRIPTION
This commit removes the need to explicitly return the passed in
specifier from the returned source::Loader::load function at the cost of
one extra heap allocation.
