### PR TITLE
chore: update devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,6 +11,6 @@ ENV PATH=${DENO_INSTALL}/bin:${PATH} \
     DENO_DIR=${DENO_INSTALL}/.cache/deno
 
 RUN rustup target add wasm32-unknown-unknown
-RUN cargo install -f wasm-bindgen-cli --version 0.2.78
+RUN cargo install -f wasm-bindgen-cli --version 0.2.79
 
 RUN chown -R vscode /usr/local/cargo


### PR DESCRIPTION
This updates the version of the wasm-bindgen-cli to match the version needed by the `Cargo.toml`.