### PR TITLE
refactor: load module content an owned value

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2058,7 +2058,7 @@ mod tests {
     let slot = parse_module(
       &specifier,
       None,
-      content.into(),
+      content,
       None,
       Some(&ModuleKind::Esm),
       None,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -133,6 +133,7 @@ pub enum ModuleGraphError {
     actual_media_type: MediaType,
     expected_media_type: MediaType,
   },
+  ConflictingAssertions(ModuleSpecifier),
   LoadingErr(ModuleSpecifier, Arc<anyhow::Error>),
   Missing(ModuleSpecifier),
   ParseErr(ModuleSpecifier, deno_ast::Diagnostic),
@@ -163,6 +164,9 @@ impl Clone for ModuleGraphError {
         actual_media_type: *actual_media_type,
         expected_media_type: *expected_media_type,
       },
+      Self::ConflictingAssertions(specifier) => {
+        Self::ConflictingAssertions(specifier.clone())
+      }
       Self::UnsupportedImportAssertionType(specifier, kind) => {
         Self::UnsupportedImportAssertionType(specifier.clone(), kind.clone())
       }
@@ -184,7 +188,8 @@ impl ModuleGraphError {
       | Self::InvalidSource(s, _)
       | Self::UnsupportedMediaType(s, _)
       | Self::UnsupportedImportAssertionType(s, _)
-      | Self::Missing(s) => s,
+      | Self::Missing(s)
+      | Self::ConflictingAssertions(s) => s,
       Self::InvalidTypeAssertion { specifier, .. } => specifier,
     }
   }
@@ -201,6 +206,7 @@ impl fmt::Display for ModuleGraphError {
       Self::InvalidSource(specifier, Some(filename)) => write!(f, "The source code is invalid, as it does not match the expected hash in the lock file.\n  Specifier: {}\n  Lock file: {}", specifier, filename),
       Self::InvalidSource(specifier, None) => write!(f, "The source code is invalid, as it does not match the expected hash in the lock file.\n  Specifier: {}", specifier),
       Self::InvalidTypeAssertion { specifier, actual_media_type, expected_media_type } => write!(f, "Expected a {} module, but identified a {} module.\n  Specifier: {}", expected_media_type, actual_media_type, specifier),
+      Self::ConflictingAssertions(specifier) => write!(f, "Module \"{specifier}\" was imported with conflicting assertions."),
       Self::UnsupportedMediaType(specifier, MediaType::Json) => write!(f, "Expected a JavaScript or TypeScript module, but identified a Json module. Consider importing Json modules with an import assertion with the type of \"json\".\n  Specifier: {}", specifier),
       Self::UnsupportedMediaType(specifier, media_type) => write!(f, "Expected a JavaScript or TypeScript module, but identified a {} module. Importing these types of modules is currently not supported.\n  Specifier: {}", media_type, specifier),
       Self::UnsupportedImportAssertionType(_, kind) => write!(f, "The import assertion type of \"{}\" is unsupported.", kind),
@@ -1559,15 +1565,7 @@ impl<'a> Builder<'a> {
         Some((specifier, kind, Ok(Some(response)))) => {
           let assert_types =
             self.pending_assert_types.remove(&specifier).unwrap();
-          for maybe_assert_type in assert_types {
-            self.visit(
-              &specifier,
-              &kind,
-              &response,
-              &build_kind,
-              maybe_assert_type,
-            )
-          }
+          self.visit(&specifier, &kind, &response, &build_kind, assert_types);
           Some(specifier)
         }
         Some((specifier, _, Ok(None))) => {
@@ -1700,23 +1698,35 @@ impl<'a> Builder<'a> {
     kind: &ModuleKind,
     response: &LoadResponse,
     build_kind: &BuildKind,
-    maybe_assert_type: Option<String>,
+    assert_types: HashSet<Option<String>>,
   ) {
     let (specifier, module_slot) = match response {
       LoadResponse::BuiltIn { specifier } => {
-        self.check_specifier(requested_specifier, specifier);
-        let module_slot = ModuleSlot::Module(Module::new_without_source(
-          specifier.clone(),
-          ModuleKind::BuiltIn,
-        ));
+        self.check_specifier(requested_specifier, &specifier);
+        let module_slot = if assert_types.len() != 1 {
+          ModuleSlot::Err(ModuleGraphError::ConflictingAssertions(
+            specifier.clone(),
+          ))
+        } else {
+          ModuleSlot::Module(Module::new_without_source(
+            specifier.clone(),
+            ModuleKind::BuiltIn,
+          ))
+        };
         (specifier, module_slot)
       }
       LoadResponse::External { specifier } => {
-        self.check_specifier(requested_specifier, specifier);
-        let module_slot = ModuleSlot::Module(Module::new_without_source(
-          specifier.clone(),
-          ModuleKind::External,
-        ));
+        self.check_specifier(requested_specifier, &specifier);
+        let module_slot = if assert_types.len() != 1 {
+          ModuleSlot::Err(ModuleGraphError::ConflictingAssertions(
+            specifier.clone(),
+          ))
+        } else {
+          ModuleSlot::Module(Module::new_without_source(
+            specifier.clone(),
+            ModuleKind::External,
+          ))
+        };
         (specifier, module_slot)
       }
       LoadResponse::Module {
@@ -1724,18 +1734,22 @@ impl<'a> Builder<'a> {
         content,
         maybe_headers,
       } => {
-        self.check_specifier(requested_specifier, specifier);
-        (
-          specifier,
+        self.check_specifier(requested_specifier, &specifier);
+        let module_slot = if assert_types.len() != 1 {
+          ModuleSlot::Err(ModuleGraphError::ConflictingAssertions(
+            specifier.clone(),
+          ))
+        } else {
           self.visit_module(
-            specifier,
+            &specifier,
             kind,
             maybe_headers.as_ref(),
             content.clone(),
             build_kind,
-            maybe_assert_type,
-          ),
-        )
+            assert_types.into_iter().next().unwrap(),
+          )
+        };
+        (specifier, module_slot)
       }
     };
     self

--- a/src/info.rs
+++ b/src/info.rs
@@ -249,6 +249,9 @@ impl ModuleGraphError {
       Self::InvalidTypeAssertion { .. } => {
         fmt_error_msg(f, prefix, last, specifier, "(invalid import assertion)")
       }
+      Self::ConflictingAssertions { .. } => {
+        fmt_error_msg(f, prefix, last, specifier, "(conflicting assertions)")
+      }
       Self::LoadingErr(_, _) => {
         fmt_error_msg(f, prefix, last, specifier, "(loading error)")
       }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@ use source::Resolver;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::sync::Arc;
 
 cfg_if! {
   if #[cfg(feature = "rust")] {
@@ -149,7 +148,7 @@ cfg_if! {
     pub fn parse_module(
       specifier: &ModuleSpecifier,
       maybe_headers: Option<&HashMap<String, String>>,
-      content: Arc<String>,
+      content: String,
       maybe_kind: Option<&ModuleKind>,
       maybe_resolver: Option<&dyn Resolver>,
       maybe_parser: Option<&dyn SourceParser>,
@@ -294,7 +293,7 @@ cfg_if! {
       match graph::parse_module(
         &specifier,
         maybe_headers.as_ref(),
-        Arc::new(content),
+        content,
         None,
         maybe_kind.as_ref(),
         maybe_resolver.as_ref().map(|r| r as &dyn Resolver),
@@ -2817,15 +2816,13 @@ export function a(a) {
     let result = parse_module(
       &specifier,
       None,
-      Arc::new(
-        r#"
+      r#"
     import { a } from "./a.ts";
     import * as b from "./b.ts";
     export { c } from "./c.ts";
     const d = await import("./d.ts");
     "#
-        .to_string(),
-      ),
+      .to_string(),
       None,
       None,
       None,
@@ -2843,13 +2840,11 @@ export function a(a) {
     let result = parse_module(
       &specifier,
       None,
-      Arc::new(
-        r#"
+      r#"
     import a from "./a.json" assert { type: "json" };
     await import("./b.json", { assert: { type: "json" } });
     "#
-        .to_string(),
-      ),
+      .to_string(),
       Some(&ModuleKind::Esm),
       None,
       None,
@@ -2910,16 +2905,14 @@ export function a(a) {
     let result = parse_module(
       &specifier,
       None,
-      Arc::new(
-        r#"
+      r#"
     /** @jsxImportSource https://example.com/preact */
 
     export function A() {
       return <div>Hello Deno</div>;
     }
     "#
-        .to_string(),
-      ),
+      .to_string(),
       Some(&ModuleKind::Esm),
       None,
       None,
@@ -2956,12 +2949,10 @@ export function a(a) {
     let result = parse_module(
       &specifier,
       maybe_headers,
-      Arc::new(
-        r#"declare interface A {
+      r#"declare interface A {
   a: string;
 }"#
-          .to_string(),
-      ),
+        .to_string(),
       Some(&ModuleKind::Esm),
       None,
       None,
@@ -2975,8 +2966,7 @@ export function a(a) {
     let result = parse_module(
       &specifier,
       None,
-      Arc::new(
-        r#"
+      r#"
 /**
  * Some js doc
  *
@@ -2987,8 +2977,7 @@ export function a(a) {
   return;
 }
 "#
-        .to_string(),
-      ),
+      .to_string(),
       Some(&ModuleKind::Esm),
       None,
       None,
@@ -3046,8 +3035,7 @@ export function a(a) {
     let result = parse_module(
       &specifier,
       None,
-      Arc::new(
-        r#"
+      r#"
 /**
  * Some js doc
  *
@@ -3058,8 +3046,7 @@ export function a(a: A): B {
   return;
 }
 "#
-        .to_string(),
-      ),
+      .to_string(),
       Some(&ModuleKind::Esm),
       None,
       None,

--- a/src/source.rs
+++ b/src/source.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 use std::fmt;
 use std::path::PathBuf;
 use std::pin::Pin;
-use std::sync::Arc;
 
 pub static DEFAULT_JSX_IMPORT_SOURCE_MODULE: &str = "jsx-runtime";
 
@@ -56,7 +55,7 @@ pub enum LoadResponse {
   /// A loaded module.
   Module {
     /// The content of the remote module.
-    content: Arc<String>,
+    content: String,
     /// The final specifier of the module.
     specifier: ModuleSpecifier,
     /// If the module is a remote module, the headers should be returned as a
@@ -213,7 +212,7 @@ pub fn load_data_url(
   Ok(Some(LoadResponse::Module {
     specifier: specifier.clone(),
     maybe_headers: Some(headers),
-    content: Arc::new(content),
+    content,
   }))
 }
 
@@ -265,7 +264,7 @@ impl MemoryLoader {
                   })
                   .collect()
               }),
-              content: Arc::new(content.as_ref().to_string()),
+              content: content.as_ref().to_string(),
             }),
             Source::BuiltIn(specifier) => Ok(LoadResponse::BuiltIn {
               specifier: ModuleSpecifier::parse(specifier.as_ref()).unwrap(),


### PR DESCRIPTION
This is a pre-requisite for WASM imports that additionally allows us to
minimize clones when doing things like BOM stripping.