### PR TITLE
chore: maybe fix release script's ability to bypass status checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,4 +34,4 @@ jobs:
         run: |
           git config user.email "denobot@users.noreply.github.com"
           git config user.name "denobot"
-          deno run -A https://raw.githubusercontent.com/denoland/automation/0.14.1/tasks/publish_release.ts --${{github.event.inputs.releaseKind}}
+          deno run -A https://raw.githubusercontent.com/denoland/automation/0.14.2/tasks/publish_release.ts --${{github.event.inputs.releaseKind}}


### PR DESCRIPTION
This is my last attempt before temporarily giving up on this. This change makes the version bump script use `--force-with-lease`, which might allow bypassing the status checks (for this script, we don't care about status checks because it's just bumping the version, which should succeed status checks).