### PR TITLE
feat: serialize and deserialize `Version` as string

### DIFF
--- a/src/semver/mod.rs
+++ b/src/semver/mod.rs
@@ -247,10 +247,10 @@ mod test {
   #[test]
   fn serialize_deserialize() {
     // should deserialize and serialize with loose parsing
-    let text = "= v 1.2.3-pre+build";
+    let text = "= v 1.2.3-pre.other+build.test";
     let version: Version =
       serde_json::from_str(&format!("\"{}\"", text)).unwrap();
     let serialized_version = serde_json::to_string(&version).unwrap();
-    assert_eq!(serialized_version, "\"1.2.3-pre+build\"");
+    assert_eq!(serialized_version, "\"1.2.3-pre.other+build.test\"");
   }
 }

--- a/src/semver/mod.rs
+++ b/src/semver/mod.rs
@@ -249,7 +249,7 @@ mod test {
     // should deserialize and serialize with loose parsing
     let text = "= v 1.2.3-pre.other+build.test";
     let version: Version =
-      serde_json::from_str(&format!("\"{}\"", text)).unwrap();
+      serde_json::from_str(&format!("\"{text}\"")).unwrap();
     let serialized_version = serde_json::to_string(&version).unwrap();
     assert_eq!(serialized_version, "\"1.2.3-pre.other+build.test\"");
   }


### PR DESCRIPTION
In the npm dependency resolution code we're constantly parsing strings to `Versions`. If we instead serialized/deserialized this as a string then we could use `Version` on the npm package info struct directly in order to parse the versions a single time.