### PR TITLE
feat: support restarting npm resolution on resolution failure

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1974,6 +1974,7 @@ pub(crate) struct AssertTypeWithRange {
   kind: String,
 }
 
+// todo(dsherret): remove the tuple
 type PendingNpmRegistryInfoLoadFutures = FuturesUnordered<
   LocalBoxFuture<'static, (String, Result<(), Arc<anyhow::Error>>)>,
 >;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2589,7 +2589,7 @@ impl<'a> NpmSpecifierResolver<'a> {
                 pending_npm_registry_info_loads.clear();
                 self.pending_info.clear();
 
-                // refill the pending npm registry info
+                // reload all the npm registry information
                 for package_name in self.pending_npm_by_name.keys() {
                   let package_name = package_name.clone();
                   let fut =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ pub use graph::WalkOptions;
 pub use module_specifier::resolve_import;
 pub use module_specifier::ModuleSpecifier;
 pub use module_specifier::SpecifierError;
+pub use source::NpmPackageReqResolution;
 
 #[derive(Debug, Clone)]
 pub struct ReferrerImports {

--- a/src/source.rs
+++ b/src/source.rs
@@ -133,6 +133,26 @@ pub struct UnknownBuiltInNodeModuleError {
   pub module_name: String,
 }
 
+#[derive(Debug)]
+pub enum NpmPackageReqResolution {
+  Ok(NpmPackageNv),
+  Err(anyhow::Error),
+  /// Error was encountered, but instruct deno_graph to ask for
+  /// the registry information again. This is useful to use when
+  /// a user specifies a npm specifier that doesn't match any version
+  /// found in a cache and you want to cache bust the registry information.
+  ///
+  /// When the implementation provides this, it should cache bust its
+  /// cached/loaded npm registry information and deno_graph will
+  /// call `load_and_cache_npm_package_info` for every package again
+  /// then re-attempt resolution.
+  ///
+  /// deno_graph will restart only once per build call to prevent accidental,
+  /// infinite loops, but the implementation should ensure this is only
+  /// returned once per session.
+  ReloadRegistryInfo(anyhow::Error),
+}
+
 pub trait NpmResolver: fmt::Debug {
   /// Gets the builtin node module name from the specifier (ex. "node:fs" -> "fs").
   fn resolve_builtin_node_module(
@@ -145,11 +165,12 @@ pub trait NpmResolver: fmt::Debug {
   /// afterwards.
   fn load_and_cache_npm_package_info(
     &self,
-    _package_name: &str,
-  ) -> LocalBoxFuture<'static, Result<(), String>>;
+    package_name: &str,
+  ) -> LocalBoxFuture<'static, Result<(), anyhow::Error>>;
 
-  /// Resolves an npm package requirement to a resolved npm package identifier.
-  fn resolve_npm(&self, _package_req: &NpmPackageReq) -> Result<NpmPackageNv>;
+  /// Resolves an npm package requirement to a resolved npm package name and version.
+  fn resolve_npm(&self, package_req: &NpmPackageReq)
+    -> NpmPackageReqResolution;
 }
 
 pub fn load_data_url(
@@ -173,6 +194,7 @@ pub fn load_data_url(
 
 /// An implementation of the loader attribute where the responses are provided
 /// ahead of time. This is useful for testing or
+#[derive(Default)]
 pub struct MemoryLoader {
   sources: HashMap<ModuleSpecifier, Result<LoadResponse, Error>>,
   cache_info: HashMap<ModuleSpecifier, CacheInfo>,
@@ -188,6 +210,30 @@ pub enum Source<S> {
   Err(Error),
 }
 
+impl<S: AsRef<str>> Source<S> {
+  fn into_result(self) -> Result<LoadResponse, Error> {
+    match self {
+      Source::Module {
+        specifier,
+        maybe_headers,
+        content,
+      } => Ok(LoadResponse::Module {
+        specifier: ModuleSpecifier::parse(specifier.as_ref()).unwrap(),
+        maybe_headers: maybe_headers.map(|h| {
+          h.into_iter()
+            .map(|(k, v)| (k.as_ref().to_string(), v.as_ref().to_string()))
+            .collect()
+        }),
+        content: content.as_ref().into(),
+      }),
+      Source::External(specifier) => Ok(LoadResponse::External {
+        specifier: ModuleSpecifier::parse(specifier.as_ref()).unwrap(),
+      }),
+      Source::Err(error) => Err(error),
+    }
+  }
+}
+
 pub type MemoryLoaderSources<S> = Vec<(S, Source<S>)>;
 
 impl MemoryLoader {
@@ -200,28 +246,7 @@ impl MemoryLoader {
         .into_iter()
         .map(|(s, r)| {
           let specifier = ModuleSpecifier::parse(s.as_ref()).unwrap();
-          let result = match r {
-            Source::Module {
-              specifier,
-              maybe_headers,
-              content,
-            } => Ok(LoadResponse::Module {
-              specifier: ModuleSpecifier::parse(specifier.as_ref()).unwrap(),
-              maybe_headers: maybe_headers.map(|h| {
-                h.into_iter()
-                  .map(|(k, v)| {
-                    (k.as_ref().to_string(), v.as_ref().to_string())
-                  })
-                  .collect()
-              }),
-              content: content.as_ref().into(),
-            }),
-            Source::External(specifier) => Ok(LoadResponse::External {
-              specifier: ModuleSpecifier::parse(specifier.as_ref()).unwrap(),
-            }),
-            Source::Err(error) => Err(error),
-          };
-          (specifier, result)
+          (specifier, r.into_result())
         })
         .collect(),
       cache_info: cache_info
@@ -232,6 +257,30 @@ impl MemoryLoader {
         })
         .collect(),
     }
+  }
+
+  pub fn add_source<S: AsRef<str>>(
+    &mut self,
+    specifier: impl AsRef<str>,
+    source: Source<S>,
+  ) {
+    let specifier = ModuleSpecifier::parse(specifier.as_ref()).unwrap();
+    self.sources.insert(specifier, source.into_result());
+  }
+
+  pub fn add_source_with_text(
+    &mut self,
+    specifier: impl AsRef<str>,
+    source: impl AsRef<str>,
+  ) {
+    self.add_source(
+      specifier.as_ref(),
+      Source::Module {
+        specifier: specifier.as_ref().to_string(),
+        maybe_headers: None,
+        content: source.as_ref().to_string(),
+      },
+    );
   }
 }
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -163,6 +163,10 @@ pub trait NpmResolver: fmt::Debug {
   /// This tells the implementation to asynchronously load within itself the
   /// npm registry package information so that synchronous resolution can occur
   /// afterwards.
+  ///
+  /// WARNING: deno_graph will stop executing these futures when a
+  /// `NpmPackageReqResolution::ReloadRegistryInfo` is returned from
+  /// `resolve_npm`. The implementation should be resilient to this.
   fn load_and_cache_npm_package_info(
     &self,
     package_name: &str,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,124 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// todo(dsherret): move the integration-like tests to this file because it
+// helps ensure we're testing the public API and ensures we export types
+// out of deno_graph that should be public
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use anyhow::anyhow;
+use deno_ast::ModuleSpecifier;
+use deno_graph::source::MemoryLoader;
+use deno_graph::source::NpmResolver;
+use deno_graph::source::UnknownBuiltInNodeModuleError;
+use deno_graph::BuildOptions;
+use deno_graph::ModuleGraph;
+use deno_graph::NpmPackageReqResolution;
+use deno_semver::npm::NpmPackageNv;
+use deno_semver::npm::NpmPackageReq;
+use deno_semver::Version;
+use futures::future::LocalBoxFuture;
+
+#[tokio::test]
+async fn test_npm_version_not_found_then_found() {
+  #[derive(Debug)]
+  struct TestNpmResolver {
+    made_first_request: Rc<RefCell<bool>>,
+    should_never_succeed: bool,
+    number_times_load_called: Rc<RefCell<u32>>,
+  }
+
+  impl NpmResolver for TestNpmResolver {
+    fn resolve_builtin_node_module(
+      &self,
+      _specifier: &ModuleSpecifier,
+    ) -> Result<Option<String>, UnknownBuiltInNodeModuleError> {
+      Ok(None)
+    }
+
+    fn load_and_cache_npm_package_info(
+      &self,
+      _package_name: &str,
+    ) -> LocalBoxFuture<'static, Result<(), anyhow::Error>> {
+      *self.number_times_load_called.borrow_mut() += 1;
+      Box::pin(futures::future::ready(Ok(())))
+    }
+
+    fn resolve_npm(
+      &self,
+      package_req: &NpmPackageReq,
+    ) -> NpmPackageReqResolution {
+      let mut value = self.made_first_request.borrow_mut();
+      if *value && !self.should_never_succeed {
+        assert_eq!(*self.number_times_load_called.borrow(), 2);
+        NpmPackageReqResolution::Ok(NpmPackageNv {
+          name: package_req.name.clone(),
+          version: Version::parse_from_npm("1.0.0").unwrap(),
+        })
+      } else {
+        *value = true;
+        NpmPackageReqResolution::ReloadRegistryInfo(anyhow!(
+          "failed to resolve"
+        ))
+      }
+    }
+  }
+
+  let mut loader = MemoryLoader::default();
+  loader.add_source_with_text("file:///main.ts", "import 'npm:foo@1.0';");
+  let root = ModuleSpecifier::parse("file:///main.ts").unwrap();
+
+  {
+    let npm_resolver = TestNpmResolver {
+      made_first_request: Rc::new(RefCell::new(false)),
+      number_times_load_called: Rc::new(RefCell::new(0)),
+      should_never_succeed: false,
+    };
+
+    let mut graph = ModuleGraph::default();
+    graph
+      .build(
+        vec![root.clone()],
+        &mut loader,
+        BuildOptions {
+          npm_resolver: Some(&npm_resolver),
+          ..Default::default()
+        },
+      )
+      .await;
+    assert!(graph.valid().is_ok());
+    assert_eq!(
+      graph
+        .modules()
+        .map(|m| m.specifier().to_string())
+        .collect::<Vec<_>>(),
+      vec![root.as_str(), "npm:foo@1.0.0"]
+    );
+  }
+
+  // now try never succeeding
+  {
+    let npm_resolver = TestNpmResolver {
+      made_first_request: Rc::new(RefCell::new(false)),
+      number_times_load_called: Rc::new(RefCell::new(0)),
+      should_never_succeed: true,
+    };
+
+    let mut graph = ModuleGraph::default();
+    graph
+      .build(
+        vec![root.clone()],
+        &mut loader,
+        BuildOptions {
+          npm_resolver: Some(&npm_resolver),
+          ..Default::default()
+        },
+      )
+      .await;
+    assert_eq!(
+      graph.valid().err().unwrap().to_string(),
+      "failed to resolve"
+    );
+  }
+}


### PR DESCRIPTION
This is going to help with cache busting npm specifiers more aggressively in the CLI.

CLI PR: https://github.com/denoland/deno/pull/18636