### PR TITLE
fix: check all import ranges in Dependency::includes()

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2847,7 +2847,7 @@ mod tests {
         character: 21,
       }),
       Some(&Range {
-        specifier: specifier.clone(),
+        specifier: specifier,
         start: Position {
           line: 1,
           character: 19

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2847,7 +2847,7 @@ mod tests {
         character: 21,
       }),
       Some(&Range {
-        specifier: specifier,
+        specifier,
         start: Position {
           line: 1,
           character: 19


### PR DESCRIPTION
This is preventing the LSP hover text on repeated imports from including certain dependency information: https://github.com/denoland/deno/blob/5a524a9a5a7fac0d16b2cbe2df1142dc419df7fc/cli/lsp/documents.rs#L603.