### PR TITLE
feat(type_tracing): store the traced referrers

### DIFF
--- a/src/type_tracer/analyzer.rs
+++ b/src/type_tracer/analyzer.rs
@@ -800,7 +800,7 @@ impl<'a, THandler: TypeTraceHandler> SymbolFiller<'a, THandler> {
                       name: FileDepName::Star,
                       specifier: src.value.to_string(),
                     }),
-                    range: n.range(),
+                    range: specifier.range(),
                   });
                   let symbol_id = symbol.symbol_id;
                   add_export(file_module, name, symbol_id);

--- a/src/type_tracer/mod.rs
+++ b/src/type_tracer/mod.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use deno_ast::LineAndColumnDisplay;
 use deno_ast::ModuleSpecifier;
 use indexmap::IndexMap;
+use indexmap::IndexSet;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -80,14 +81,14 @@ pub fn trace_public_types<'a, THandler: TypeTraceHandler>(
 pub enum ImportedExports {
   AllWithDefault,
   Star,
-  Named(Vec<String>),
+  Named(IndexSet<String>),
 }
 
 impl ImportedExports {
   pub(crate) fn from_file_dep_name(dep_name: &FileDepName) -> Self {
     match dep_name {
       FileDepName::Star => Self::Star,
-      FileDepName::Name(value) => Self::Named(vec![value.clone()]),
+      FileDepName::Name(value) => Self::Named(IndexSet::from([value.clone()])),
     }
   }
 
@@ -291,7 +292,7 @@ impl<'a, TReporter: TypeTraceHandler> Context<'a, TReporter> {
               if let Some(specifier) = maybe_specifier {
                 let mut found = self.trace_exports_inner(
                   &specifier,
-                  &ImportedExports::Named(vec![name.clone()]),
+                  &ImportedExports::Named(IndexSet::from([name.clone()])),
                   {
                     let mut visited = visited.clone();
                     visited.insert(specifier.clone());

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -21,6 +21,9 @@ use deno_semver::npm::NpmPackageReq;
 use deno_semver::Version;
 use futures::future::LocalBoxFuture;
 
+#[cfg(feature = "type_tracing")]
+mod type_tracing;
+
 #[tokio::test]
 async fn test_npm_version_not_found_then_found() {
   #[derive(Debug)]

--- a/tests/specs/type_tracing/Basic.txt
+++ b/tests/specs/type_tracing/Basic.txt
@@ -214,6 +214,7 @@ file:///mod.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 file:///a.ts: ModuleSymbol {
     module_id: ModuleId(
@@ -449,6 +450,16 @@ file:///a.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {
+        ModuleId(
+            0,
+        ): Named(
+            [
+                "D",
+                "A",
+            ],
+        ),
+    },
 }
 == export definitions ==
 [D]: file:///a.ts:173..198

--- a/tests/specs/type_tracing/Basic.txt
+++ b/tests/specs/type_tracing/Basic.txt
@@ -454,10 +454,10 @@ file:///a.ts: ModuleSymbol {
         ModuleId(
             0,
         ): Named(
-            [
+            {
                 "D",
                 "A",
-            ],
+            },
         ),
     },
 }

--- a/tests/specs/type_tracing/Classes01.txt
+++ b/tests/specs/type_tracing/Classes01.txt
@@ -462,6 +462,7 @@ file:///mod.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 == export definitions ==
 [A]: file:///mod.ts:0..26

--- a/tests/specs/type_tracing/ExportAssignment01.txt
+++ b/tests/specs/type_tracing/ExportAssignment01.txt
@@ -90,6 +90,7 @@ file:///mod.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 == export definitions ==
 [default]: file:///mod.ts:0..19

--- a/tests/specs/type_tracing/ExportAssignment01.txt
+++ b/tests/specs/type_tracing/ExportAssignment01.txt
@@ -64,10 +64,10 @@ file:///mod.ts: ModuleSymbol {
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            75,
+                            66,
                         ),
                         end: SourcePos(
-                            79,
+                            80,
                         ),
                     },
                     kind: Target(

--- a/tests/specs/type_tracing/ExportDefault01.txt
+++ b/tests/specs/type_tracing/ExportDefault01.txt
@@ -291,6 +291,7 @@ file:///mod.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 file:///a.ts: ModuleSymbol {
     module_id: ModuleId(
@@ -519,6 +520,18 @@ file:///a.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {
+        ModuleId(
+            0,
+        ): Named(
+            [
+                "C3",
+                "C2",
+                "C1",
+                "default",
+            ],
+        ),
+    },
 }
 file:///interface.ts: ModuleSymbol {
     module_id: ModuleId(
@@ -590,6 +603,15 @@ file:///interface.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {
+        ModuleId(
+            1,
+        ): Named(
+            [
+                "default",
+            ],
+        ),
+    },
 }
 file:///function.ts: ModuleSymbol {
     module_id: ModuleId(
@@ -654,6 +676,15 @@ file:///function.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {
+        ModuleId(
+            1,
+        ): Named(
+            [
+                "default",
+            ],
+        ),
+    },
 }
 file:///class.ts: ModuleSymbol {
     module_id: ModuleId(
@@ -718,6 +749,15 @@ file:///class.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {
+        ModuleId(
+            1,
+        ): Named(
+            [
+                "default",
+            ],
+        ),
+    },
 }
 == export definitions ==
 [C1]: file:///class.ts:0..29

--- a/tests/specs/type_tracing/ExportDefault01.txt
+++ b/tests/specs/type_tracing/ExportDefault01.txt
@@ -265,10 +265,10 @@ file:///mod.ts: ModuleSymbol {
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            94,
+                            79,
                         ),
                         end: SourcePos(
-                            98,
+                            99,
                         ),
                     },
                     kind: Target(
@@ -331,10 +331,10 @@ file:///a.ts: ModuleSymbol {
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            0,
+                            9,
                         ),
                         end: SourcePos(
-                            43,
+                            22,
                         ),
                     },
                     kind: FileRef(
@@ -357,10 +357,10 @@ file:///a.ts: ModuleSymbol {
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            44,
+                            53,
                         ),
                         end: SourcePos(
-                            90,
+                            66,
                         ),
                     },
                     kind: FileRef(
@@ -383,10 +383,10 @@ file:///a.ts: ModuleSymbol {
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            91,
+                            100,
                         ),
                         end: SourcePos(
-                            138,
+                            113,
                         ),
                     },
                     kind: FileRef(
@@ -524,12 +524,12 @@ file:///a.ts: ModuleSymbol {
         ModuleId(
             0,
         ): Named(
-            [
+            {
                 "C3",
                 "C2",
                 "C1",
                 "default",
-            ],
+            },
         ),
     },
 }
@@ -607,9 +607,9 @@ file:///interface.ts: ModuleSymbol {
         ModuleId(
             1,
         ): Named(
-            [
+            {
                 "default",
-            ],
+            },
         ),
     },
 }
@@ -680,9 +680,9 @@ file:///function.ts: ModuleSymbol {
         ModuleId(
             1,
         ): Named(
-            [
+            {
                 "default",
-            ],
+            },
         ),
     },
 }
@@ -753,9 +753,9 @@ file:///class.ts: ModuleSymbol {
         ModuleId(
             1,
         ): Named(
-            [
+            {
                 "default",
-            ],
+            },
         ),
     },
 }

--- a/tests/specs/type_tracing/ExportDefault02.txt
+++ b/tests/specs/type_tracing/ExportDefault02.txt
@@ -25,10 +25,10 @@ file:///mod.ts: ModuleSymbol {
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            15,
+                            0,
                         ),
                         end: SourcePos(
-                            19,
+                            20,
                         ),
                     },
                     kind: Target(

--- a/tests/specs/type_tracing/ExportDefault02.txt
+++ b/tests/specs/type_tracing/ExportDefault02.txt
@@ -86,6 +86,7 @@ file:///mod.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 == export definitions ==
 [default]: file:///mod.ts:21..34

--- a/tests/specs/type_tracing/ExportDefault03.txt
+++ b/tests/specs/type_tracing/ExportDefault03.txt
@@ -37,10 +37,10 @@ file:///mod.ts: ModuleSymbol {
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            0,
+                            9,
                         ),
                         end: SourcePos(
-                            42,
+                            25,
                         ),
                     },
                     kind: FileRef(
@@ -138,9 +138,9 @@ file:///a.ts: ModuleSymbol {
         ModuleId(
             0,
         ): Named(
-            [
+            {
                 "default",
-            ],
+            },
         ),
     },
 }
@@ -209,9 +209,9 @@ file:///b.ts: ModuleSymbol {
         ModuleId(
             1,
         ): Named(
-            [
+            {
                 "B",
-            ],
+            },
         ),
     },
 }

--- a/tests/specs/type_tracing/ExportDefault03.txt
+++ b/tests/specs/type_tracing/ExportDefault03.txt
@@ -77,6 +77,7 @@ file:///mod.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 file:///a.ts: ModuleSymbol {
     module_id: ModuleId(
@@ -133,6 +134,15 @@ file:///a.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {
+        ModuleId(
+            0,
+        ): Named(
+            [
+                "default",
+            ],
+        ),
+    },
 }
 file:///b.ts: ModuleSymbol {
     module_id: ModuleId(
@@ -195,6 +205,15 @@ file:///b.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {
+        ModuleId(
+            1,
+        ): Named(
+            [
+                "B",
+            ],
+        ),
+    },
 }
 == export definitions ==
 [Test]: file:///mod.ts:44..64

--- a/tests/specs/type_tracing/ExportDefault04.txt
+++ b/tests/specs/type_tracing/ExportDefault04.txt
@@ -12,6 +12,7 @@ file:///mod.ts: ModuleSymbol {
     swc_id_to_symbol_id: {},
     symbols: {},
     traced_re_exports: {},
+    traced_referrers: {},
 }
 
 # diagnostics

--- a/tests/specs/type_tracing/ExportDefault04.txt
+++ b/tests/specs/type_tracing/ExportDefault04.txt
@@ -22,7 +22,7 @@ file:///mod.ts: ModuleSymbol {
     "specifier": "file:///mod.ts",
     "line_and_column": {
       "line_number": 1,
-      "column_number": 16
+      "column_number": 1
     }
   }
 ]

--- a/tests/specs/type_tracing/ExportStar01.txt
+++ b/tests/specs/type_tracing/ExportStar01.txt
@@ -1,0 +1,539 @@
+# mod.ts
+export * as namespace from "./a.ts";
+
+# a.ts
+export { default as C1 } from "./class.ts";
+export { default as C2 } from "./function.ts";
+export { default as C3 } from "./interface.ts";
+
+export default class Test {
+    prop: A;
+}
+
+class A {
+    a: number;
+    b: B;
+}
+
+class B {
+    b: number;
+    #c: C;
+}
+
+class C {
+}
+
+# class.ts
+export default class Test {
+}
+
+# interface.ts
+export default interface Test {
+}
+
+# function.ts
+export default function Test() {
+}
+
+# output
+file:///mod.ts: ModuleSymbol {
+    module_id: ModuleId(
+        0,
+    ),
+    specifier: "file:///mod.ts",
+    exports: {
+        "namespace": 0,
+    },
+    re_exports: [],
+    swc_id_to_symbol_id: {},
+    symbols: {
+        0: Symbol {
+            symbol_id: 0,
+            is_public: true,
+            decls: {
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            7,
+                        ),
+                        end: SourcePos(
+                            21,
+                        ),
+                    },
+                    kind: FileRef(
+                        FileDep {
+                            name: Star,
+                            specifier: "./a.ts",
+                        },
+                    ),
+                },
+            },
+            deps: {},
+            exports: {},
+        },
+    },
+    traced_re_exports: {},
+    traced_referrers: {},
+}
+file:///a.ts: ModuleSymbol {
+    module_id: ModuleId(
+        1,
+    ),
+    specifier: "file:///a.ts",
+    exports: {
+        "C1": 0,
+        "C2": 1,
+        "C3": 2,
+        "default": 3,
+    },
+    re_exports: [],
+    swc_id_to_symbol_id: {
+        (
+            Atom('Test' type=inline),
+            #2,
+        ): 4,
+        (
+            Atom('A' type=inline),
+            #2,
+        ): 5,
+        (
+            Atom('B' type=inline),
+            #2,
+        ): 6,
+        (
+            Atom('C' type=inline),
+            #2,
+        ): 7,
+    },
+    symbols: {
+        0: Symbol {
+            symbol_id: 0,
+            is_public: true,
+            decls: {
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            9,
+                        ),
+                        end: SourcePos(
+                            22,
+                        ),
+                    },
+                    kind: FileRef(
+                        FileDep {
+                            name: Name(
+                                "default",
+                            ),
+                            specifier: "./class.ts",
+                        },
+                    ),
+                },
+            },
+            deps: {},
+            exports: {},
+        },
+        1: Symbol {
+            symbol_id: 1,
+            is_public: true,
+            decls: {
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            53,
+                        ),
+                        end: SourcePos(
+                            66,
+                        ),
+                    },
+                    kind: FileRef(
+                        FileDep {
+                            name: Name(
+                                "default",
+                            ),
+                            specifier: "./function.ts",
+                        },
+                    ),
+                },
+            },
+            deps: {},
+            exports: {},
+        },
+        2: Symbol {
+            symbol_id: 2,
+            is_public: true,
+            decls: {
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            100,
+                        ),
+                        end: SourcePos(
+                            113,
+                        ),
+                    },
+                    kind: FileRef(
+                        FileDep {
+                            name: Name(
+                                "default",
+                            ),
+                            specifier: "./interface.ts",
+                        },
+                    ),
+                },
+            },
+            deps: {},
+            exports: {},
+        },
+        3: Symbol {
+            symbol_id: 3,
+            is_public: false,
+            decls: {
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            140,
+                        ),
+                        end: SourcePos(
+                            182,
+                        ),
+                    },
+                    kind: Definition,
+                },
+            },
+            deps: {
+                Id(
+                    (
+                        Atom('Test' type=inline),
+                        #2,
+                    ),
+                ),
+            },
+            exports: {},
+        },
+        4: Symbol {
+            symbol_id: 4,
+            is_public: false,
+            decls: {
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            161,
+                        ),
+                        end: SourcePos(
+                            165,
+                        ),
+                    },
+                    kind: Definition,
+                },
+            },
+            deps: {
+                Id(
+                    (
+                        Atom('A' type=inline),
+                        #2,
+                    ),
+                ),
+            },
+            exports: {},
+        },
+        5: Symbol {
+            symbol_id: 5,
+            is_public: false,
+            decls: {
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            184,
+                        ),
+                        end: SourcePos(
+                            220,
+                        ),
+                    },
+                    kind: Definition,
+                },
+            },
+            deps: {
+                Id(
+                    (
+                        Atom('B' type=inline),
+                        #2,
+                    ),
+                ),
+            },
+            exports: {},
+        },
+        6: Symbol {
+            symbol_id: 6,
+            is_public: false,
+            decls: {
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            222,
+                        ),
+                        end: SourcePos(
+                            259,
+                        ),
+                    },
+                    kind: Definition,
+                },
+            },
+            deps: {},
+            exports: {},
+        },
+        7: Symbol {
+            symbol_id: 7,
+            is_public: false,
+            decls: {
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            261,
+                        ),
+                        end: SourcePos(
+                            272,
+                        ),
+                    },
+                    kind: Definition,
+                },
+            },
+            deps: {},
+            exports: {},
+        },
+    },
+    traced_re_exports: {},
+    traced_referrers: {
+        ModuleId(
+            0,
+        ): Star,
+    },
+}
+file:///class.ts: ModuleSymbol {
+    module_id: ModuleId(
+        2,
+    ),
+    specifier: "file:///class.ts",
+    exports: {
+        "default": 0,
+    },
+    re_exports: [],
+    swc_id_to_symbol_id: {
+        (
+            Atom('Test' type=inline),
+            #2,
+        ): 1,
+    },
+    symbols: {
+        0: Symbol {
+            symbol_id: 0,
+            is_public: true,
+            decls: {
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            29,
+                        ),
+                    },
+                    kind: Definition,
+                },
+            },
+            deps: {
+                Id(
+                    (
+                        Atom('Test' type=inline),
+                        #2,
+                    ),
+                ),
+            },
+            exports: {},
+        },
+        1: Symbol {
+            symbol_id: 1,
+            is_public: true,
+            decls: {
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            21,
+                        ),
+                        end: SourcePos(
+                            25,
+                        ),
+                    },
+                    kind: Definition,
+                },
+            },
+            deps: {},
+            exports: {},
+        },
+    },
+    traced_re_exports: {},
+    traced_referrers: {
+        ModuleId(
+            1,
+        ): Named(
+            {
+                "default",
+            },
+        ),
+    },
+}
+file:///function.ts: ModuleSymbol {
+    module_id: ModuleId(
+        3,
+    ),
+    specifier: "file:///function.ts",
+    exports: {
+        "default": 0,
+    },
+    re_exports: [],
+    swc_id_to_symbol_id: {
+        (
+            Atom('Test' type=inline),
+            #2,
+        ): 1,
+    },
+    symbols: {
+        0: Symbol {
+            symbol_id: 0,
+            is_public: true,
+            decls: {
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            34,
+                        ),
+                    },
+                    kind: Definition,
+                },
+            },
+            deps: {
+                Id(
+                    (
+                        Atom('Test' type=inline),
+                        #2,
+                    ),
+                ),
+            },
+            exports: {},
+        },
+        1: Symbol {
+            symbol_id: 1,
+            is_public: true,
+            decls: {
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            24,
+                        ),
+                        end: SourcePos(
+                            28,
+                        ),
+                    },
+                    kind: Definition,
+                },
+            },
+            deps: {},
+            exports: {},
+        },
+    },
+    traced_re_exports: {},
+    traced_referrers: {
+        ModuleId(
+            1,
+        ): Named(
+            {
+                "default",
+            },
+        ),
+    },
+}
+file:///interface.ts: ModuleSymbol {
+    module_id: ModuleId(
+        4,
+    ),
+    specifier: "file:///interface.ts",
+    exports: {
+        "default": 0,
+    },
+    re_exports: [],
+    swc_id_to_symbol_id: {
+        (
+            Atom('Test' type=inline),
+            #2,
+        ): 1,
+    },
+    symbols: {
+        0: Symbol {
+            symbol_id: 0,
+            is_public: true,
+            decls: {
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            33,
+                        ),
+                    },
+                    kind: Definition,
+                },
+            },
+            deps: {
+                Id(
+                    (
+                        Atom('Test' type=inline),
+                        #2,
+                    ),
+                ),
+            },
+            exports: {},
+        },
+        1: Symbol {
+            symbol_id: 1,
+            is_public: true,
+            decls: {
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            25,
+                        ),
+                        end: SourcePos(
+                            29,
+                        ),
+                    },
+                    kind: Definition,
+                },
+            },
+            deps: {
+                Id(
+                    (
+                        Atom('Test' type=inline),
+                        #2,
+                    ),
+                ),
+            },
+            exports: {},
+        },
+    },
+    traced_re_exports: {},
+    traced_referrers: {
+        ModuleId(
+            1,
+        ): Named(
+            {
+                "default",
+            },
+        ),
+    },
+}
+== export definitions ==
+[namespace]: file:///mod.ts:7..21
+  * as namespace

--- a/tests/specs/type_tracing/Functions01.txt
+++ b/tests/specs/type_tracing/Functions01.txt
@@ -368,6 +368,7 @@ file:///mod.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 == export definitions ==
 [overloaded]: file:///mod.ts:201..295

--- a/tests/specs/type_tracing/ImportEquals01.txt
+++ b/tests/specs/type_tracing/ImportEquals01.txt
@@ -117,6 +117,7 @@ file:///mod.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 == export definitions ==
 [MyExport]: file:///mod.ts:57..81

--- a/tests/specs/type_tracing/ImportEquals02.txt
+++ b/tests/specs/type_tracing/ImportEquals02.txt
@@ -189,6 +189,7 @@ file:///mod.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 file:///a.ts: ModuleSymbol {
     module_id: ModuleId(
@@ -391,6 +392,7 @@ file:///a.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 == export definitions ==
 [MyExport]: file:///a.ts:18..65

--- a/tests/specs/type_tracing/ImportType01.txt
+++ b/tests/specs/type_tracing/ImportType01.txt
@@ -68,6 +68,7 @@ file:///mod.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 file:///a.ts: ModuleSymbol {
     module_id: ModuleId(
@@ -151,6 +152,7 @@ file:///a.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 == export definitions ==
 [Test]: file:///mod.ts:0..55

--- a/tests/specs/type_tracing/ImportType02.txt
+++ b/tests/specs/type_tracing/ImportType02.txt
@@ -59,6 +59,7 @@ file:///mod.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 file:///a.ts: ModuleSymbol {
     module_id: ModuleId(
@@ -160,6 +161,11 @@ file:///a.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {
+        ModuleId(
+            1,
+        ): AllWithDefault,
+    },
 }
 == export definitions ==
 [Test]: file:///mod.ts:0..43

--- a/tests/specs/type_tracing/Interfaces01.txt
+++ b/tests/specs/type_tracing/Interfaces01.txt
@@ -340,6 +340,7 @@ file:///mod.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 == export definitions ==
 [Main]: file:///mod.ts:17..142

--- a/tests/specs/type_tracing/Interfaces02.txt
+++ b/tests/specs/type_tracing/Interfaces02.txt
@@ -197,6 +197,7 @@ file:///mod.ts: ModuleSymbol {
             symbol_id: 0,
         },
     },
+    traced_referrers: {},
 }
 file:///a.ts: ModuleSymbol {
     module_id: ModuleId(
@@ -323,6 +324,7 @@ file:///a.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 == export definitions ==
 [A1]: file:///a.ts:0..33

--- a/tests/specs/type_tracing/ModuleExportNameStr01.txt
+++ b/tests/specs/type_tracing/ModuleExportNameStr01.txt
@@ -52,6 +52,7 @@ file:///mod.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 file:///a.ts: ModuleSymbol {
     module_id: ModuleId(
@@ -108,6 +109,15 @@ file:///a.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {
+        ModuleId(
+            0,
+        ): Named(
+            [
+                "someName",
+            ],
+        ),
+    },
 }
 file:///b.ts: ModuleSymbol {
     module_id: ModuleId(
@@ -148,6 +158,15 @@ file:///b.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {
+        ModuleId(
+            1,
+        ): Named(
+            [
+                "some-name",
+            ],
+        ),
+    },
 }
 file:///c.ts: ModuleSymbol {
     module_id: ModuleId(
@@ -186,6 +205,15 @@ file:///c.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {
+        ModuleId(
+            2,
+        ): Named(
+            [
+                "MyClass",
+            ],
+        ),
+    },
 }
 == export definitions ==
 [someOtherName]: file:///c.ts:0..23

--- a/tests/specs/type_tracing/ModuleExportNameStr01.txt
+++ b/tests/specs/type_tracing/ModuleExportNameStr01.txt
@@ -31,10 +31,10 @@ file:///mod.ts: ModuleSymbol {
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            0,
+                            9,
                         ),
                         end: SourcePos(
-                            55,
+                            38,
                         ),
                     },
                     kind: FileRef(
@@ -113,9 +113,9 @@ file:///a.ts: ModuleSymbol {
         ModuleId(
             0,
         ): Named(
-            [
+            {
                 "someName",
-            ],
+            },
         ),
     },
 }
@@ -137,10 +137,10 @@ file:///b.ts: ModuleSymbol {
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            0,
+                            9,
                         ),
                         end: SourcePos(
-                            48,
+                            31,
                         ),
                     },
                     kind: FileRef(
@@ -162,9 +162,9 @@ file:///b.ts: ModuleSymbol {
         ModuleId(
             1,
         ): Named(
-            [
+            {
                 "some-name",
-            ],
+            },
         ),
     },
 }
@@ -209,9 +209,9 @@ file:///c.ts: ModuleSymbol {
         ModuleId(
             2,
         ): Named(
-            [
+            {
                 "MyClass",
-            ],
+            },
         ),
     },
 }

--- a/tests/specs/type_tracing/TsExternalModuleRef01.txt
+++ b/tests/specs/type_tracing/TsExternalModuleRef01.txt
@@ -186,10 +186,10 @@ file:///a.ts: ModuleSymbol {
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            61,
+                            52,
                         ),
                         end: SourcePos(
-                            72,
+                            73,
                         ),
                     },
                     kind: Target(

--- a/tests/specs/type_tracing/TsExternalModuleRef01.txt
+++ b/tests/specs/type_tracing/TsExternalModuleRef01.txt
@@ -94,6 +94,7 @@ file:///mod.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 file:///a.ts: ModuleSymbol {
     module_id: ModuleId(
@@ -211,6 +212,7 @@ file:///a.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 == export definitions ==
 [Test]: file:///mod.ts:31..61

--- a/tests/specs/type_tracing/TsExternalModuleRef02.txt
+++ b/tests/specs/type_tracing/TsExternalModuleRef02.txt
@@ -76,10 +76,10 @@ file:///mod.ts: ModuleSymbol {
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            46,
+                            31,
                         ),
                         end: SourcePos(
-                            47,
+                            48,
                         ),
                     },
                     kind: Target(
@@ -194,10 +194,10 @@ file:///a.ts: ModuleSymbol {
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            61,
+                            52,
                         ),
                         end: SourcePos(
-                            72,
+                            73,
                         ),
                     },
                     kind: Target(
@@ -224,9 +224,9 @@ file:///a.ts: ModuleSymbol {
         ModuleId(
             0,
         ): Named(
-            [
+            {
                 "default",
-            ],
+            },
         ),
     },
 }

--- a/tests/specs/type_tracing/TsExternalModuleRef02.txt
+++ b/tests/specs/type_tracing/TsExternalModuleRef02.txt
@@ -102,6 +102,7 @@ file:///mod.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 file:///a.ts: ModuleSymbol {
     module_id: ModuleId(
@@ -219,6 +220,15 @@ file:///a.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {
+        ModuleId(
+            0,
+        ): Named(
+            [
+                "default",
+            ],
+        ),
+    },
 }
 == export definitions ==
 [default]: file:///a.ts:0..50

--- a/tests/specs/type_tracing/TsNamespaceExport01.txt
+++ b/tests/specs/type_tracing/TsNamespaceExport01.txt
@@ -45,6 +45,7 @@ file:///mod.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 == export definitions ==
 [isPrime]: file:///mod.ts:0..56

--- a/tests/specs/type_tracing/TsQualifiedName01.txt
+++ b/tests/specs/type_tracing/TsQualifiedName01.txt
@@ -146,6 +146,7 @@ file:///mod.ts: ModuleSymbol {
         },
     },
     traced_re_exports: {},
+    traced_referrers: {},
 }
 == export definitions ==
 [Test]: file:///mod.ts:0..37

--- a/tests/type_tracing/mod.rs
+++ b/tests/type_tracing/mod.rs
@@ -1,5 +1,3 @@
 mod in_memory_loader;
 mod test_builder;
-
-pub use in_memory_loader::InMemoryLoader;
-pub use test_builder::TestBuilder;
+mod tests;

--- a/tests/type_tracing/test_builder.rs
+++ b/tests/type_tracing/test_builder.rs
@@ -15,7 +15,7 @@ use deno_graph::DefaultModuleParser;
 use deno_graph::GraphKind;
 use deno_graph::ModuleGraph;
 
-use super::InMemoryLoader;
+use super::in_memory_loader::InMemoryLoader;
 
 #[derive(Default)]
 struct TestTypeTraceHandler {

--- a/tests/type_tracing/tests.rs
+++ b/tests/type_tracing/tests.rs
@@ -3,10 +3,8 @@ use std::path::PathBuf;
 
 use pretty_assertions::assert_eq;
 
+use super::test_builder::TestBuilder;
 use deno_graph::type_tracer::TypeTraceDiagnostic;
-use type_tracing::TestBuilder;
-
-mod type_tracing;
 
 #[tokio::test]
 async fn test_type_tracing_specs() {


### PR DESCRIPTION
Improves the functionality in https://github.com/denoland/deno_graph/pull/278 to store the traced referrers. This is useful for declaration emit in order to tell which modules import a remote dependency and what names they import.