### PR TITLE
docs(README): update MemoryLoader example

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ fn main() {
   let future = async move {
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph.build(roots, &mut loader, Default::default()).await;
-    println!("{:?}", graph);
+    println!("{:#?}", graph);
   };
   block_on(future)
 }

--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ loading them is not practical or desirable.
 A minimal example would look like this:
 
 ```rust
-use deno_graph::create_graph;
 use deno_graph::ModuleSpecifier;
+use deno_graph::ModuleGraph;
+use deno_graph::GraphKind;
 use deno_graph::source::MemoryLoader;
 use deno_graph::source::Source;
 use futures::executor::block_on;
@@ -98,7 +99,7 @@ fn main() {
   let future = async move {
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph.build(roots, &mut loader, Default::default()).await;
-    println!("{}", graph);
+    println!("{:?}", graph);
   };
   block_on(future)
 }


### PR DESCRIPTION
The example in README looks outdated. This PR updates it.