### PR TITLE
feat: resolve node builtin module without node: scheme

### DIFF
--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -156,7 +156,7 @@ impl Resolver for JsResolver {
       ModuleSpecifier::parse(&value)
         .map_err(|err| ResolveError::Specifier(SpecifierError::InvalidUrl(err)))
     } else {
-      resolve_import(specifier, referrer, None).map_err(|err| err.into())
+      resolve_import(specifier, referrer).map_err(|err| err.into())
     }
   }
 

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -295,6 +295,7 @@ pub fn js_parse_module(
     content.into(),
     maybe_resolver.as_ref().map(|r| r as &dyn Resolver),
     None,
+    None,
   ) {
     Ok(module) => {
       let serializer =

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -155,7 +155,7 @@ impl Resolver for JsResolver {
       };
       Ok(ModuleSpecifier::parse(&value)?)
     } else {
-      resolve_import(specifier, referrer).map_err(|err| err.into())
+      resolve_import(specifier, referrer, None).map_err(|err| err.into())
     }
   }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -824,6 +824,7 @@ impl GraphImport {
     referrer: &ModuleSpecifier,
     imports: Vec<String>,
     maybe_resolver: Option<&dyn Resolver>,
+    maybe_npm_resolver: Option<&dyn NpmResolver>,
   ) -> Self {
     let dependencies = imports
       .into_iter()
@@ -833,7 +834,8 @@ impl GraphImport {
           start: Position::zeroed(),
           end: Position::zeroed(),
         };
-        let maybe_type = resolve(&import, referrer_range, maybe_resolver);
+        let maybe_type =
+          resolve(&import, referrer_range, maybe_resolver, maybe_npm_resolver);
         (
           import,
           Dependency {
@@ -1552,12 +1554,17 @@ fn resolve(
   specifier_text: &str,
   referrer_range: Range,
   maybe_resolver: Option<&dyn Resolver>,
+  maybe_npm_resolver: Option<&dyn NpmResolver>,
 ) -> Resolution {
   let response = if let Some(resolver) = maybe_resolver {
     resolver.resolve(specifier_text, &referrer_range.specifier)
   } else {
-    resolve_import(specifier_text, &referrer_range.specifier, None)
-      .map_err(|err| err.into())
+    resolve_import(
+      specifier_text,
+      &referrer_range.specifier,
+      maybe_npm_resolver,
+    )
+    .map_err(|err| err.into())
   };
   Resolution::from_resolve_result(response, specifier_text, referrer_range)
 }
@@ -1622,6 +1629,7 @@ pub(crate) fn parse_module(
   module_analyzer: &dyn ModuleAnalyzer,
   is_root: bool,
   is_dynamic_branch: bool,
+  maybe_npm_resolver: Option<&dyn NpmResolver>,
 ) -> Result<Module, ModuleGraphError> {
   let media_type =
     MediaType::from_specifier_and_headers(specifier, maybe_headers);
@@ -1688,6 +1696,7 @@ pub(crate) fn parse_module(
             module_info,
             content,
             maybe_resolver,
+            maybe_npm_resolver,
           )))
         }
         Err(diagnostic) => Err(ModuleGraphError::ModuleError(
@@ -1710,6 +1719,7 @@ pub(crate) fn parse_module(
             module_info,
             content,
             maybe_resolver,
+            maybe_npm_resolver,
           )))
         }
         Err(diagnostic) => Err(ModuleGraphError::ModuleError(
@@ -1734,6 +1744,7 @@ pub(crate) fn parse_esm_module_from_module_info(
   module_info: ModuleInfo,
   source: Arc<str>,
   maybe_resolver: Option<&dyn Resolver>,
+  maybe_npm_resolver: Option<&dyn NpmResolver>,
 ) -> EsmModule {
   let mut module = EsmModule::new(specifier.clone(), source);
   module.media_type = media_type;
@@ -1749,8 +1760,12 @@ pub(crate) fn parse_esm_module_from_module_info(
         let range =
           Range::from_position_range(module.specifier.clone(), specifier.range);
         if dep.maybe_type.is_none() {
-          dep.maybe_type =
-            resolve(&specifier.text, range.clone(), maybe_resolver);
+          dep.maybe_type = resolve(
+            &specifier.text,
+            range.clone(),
+            maybe_resolver,
+            maybe_npm_resolver,
+          );
         }
         dep.imports.push(Import {
           specifier: specifier.text,
@@ -1763,8 +1778,12 @@ pub(crate) fn parse_esm_module_from_module_info(
       TypeScriptReference::Types(specifier) => {
         let range =
           Range::from_position_range(module.specifier.clone(), specifier.range);
-        let dep_resolution =
-          resolve(&specifier.text, range.clone(), maybe_resolver);
+        let dep_resolution = resolve(
+          &specifier.text,
+          range.clone(),
+          maybe_resolver,
+          maybe_npm_resolver,
+        );
         if is_untyped(&module.media_type) {
           module.maybe_types_dependency = Some(TypesDependency {
             specifier: specifier.text.clone(),
@@ -1825,8 +1844,12 @@ pub(crate) fn parse_esm_module_from_module_info(
         import_source.range,
       );
       if dep.maybe_code.is_none() {
-        dep.maybe_code =
-          resolve(&specifier_text, range.clone(), maybe_resolver);
+        dep.maybe_code = resolve(
+          &specifier_text,
+          range.clone(),
+          maybe_resolver,
+          maybe_npm_resolver,
+        );
       }
       dep.imports.push(Import {
         specifier: specifier_text,
@@ -1847,7 +1870,12 @@ pub(crate) fn parse_esm_module_from_module_info(
     let range =
       Range::from_position_range(module.specifier.clone(), specifier.range);
     if dep.maybe_type.is_none() {
-      dep.maybe_type = resolve(&specifier.text, range.clone(), maybe_resolver);
+      dep.maybe_type = resolve(
+        &specifier.text,
+        range.clone(),
+        maybe_resolver,
+        maybe_npm_resolver,
+      );
     }
     dep.imports.push(Import {
       specifier: specifier.text,
@@ -1869,7 +1897,12 @@ pub(crate) fn parse_esm_module_from_module_info(
         };
         module.maybe_types_dependency = Some(TypesDependency {
           specifier: types_header.to_string(),
-          dependency: resolve(types_header, range, maybe_resolver),
+          dependency: resolve(
+            types_header,
+            range,
+            maybe_resolver,
+            maybe_npm_resolver,
+          ),
         });
       }
     }
@@ -1931,8 +1964,12 @@ pub(crate) fn parse_esm_module_from_module_info(
       module.specifier.clone(),
       desc.specifier_range.clone(),
     );
-    let dep_resolution =
-      resolve(&desc.specifier, range.clone(), maybe_resolver);
+    let dep_resolution = resolve(
+      &desc.specifier,
+      range.clone(),
+      maybe_resolver,
+      maybe_npm_resolver,
+    );
     if matches!(
       desc.kind,
       DependencyKind::ImportType | DependencyKind::ExportType
@@ -1975,6 +2012,7 @@ pub(crate) fn parse_esm_module_from_module_info(
           &pragma.specifier,
           Range::from_position_range(specifier, pragma.range),
           maybe_resolver,
+          maybe_npm_resolver,
         )
       } else {
         Resolution::None
@@ -2351,7 +2389,8 @@ impl<'a, 'graph> Builder<'a, 'graph> {
     for referrer_imports in imports {
       let referrer = referrer_imports.referrer;
       let imports = referrer_imports.imports;
-      let graph_import = GraphImport::new(&referrer, imports, self.resolver);
+      let graph_import =
+        GraphImport::new(&referrer, imports, self.resolver, self.npm_resolver);
       for dep in graph_import.dependencies.values() {
         if let Resolution::Ok(resolved) = &dep.maybe_type {
           self.load(
@@ -3159,6 +3198,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
         .unwrap_or(self.module_analyzer),
       is_root,
       self.in_dynamic_branch,
+      self.npm_resolver,
     ) {
       Ok(module) => ModuleSlot::Module(module),
       Err(err) => ModuleSlot::Err(err),
@@ -3617,6 +3657,7 @@ mod tests {
       &module_analyzer,
       true,
       false,
+      None,
     )
     .unwrap();
     let module = module.esm().unwrap();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1570,7 +1570,7 @@ fn resolve(
       .as_ref()
       .and_then(|specifier| {
         maybe_npm_resolver.and_then(|npm_resolver| {
-          npm_resolver.resolve_builtin_node_module(&specifier).ok()
+          npm_resolver.resolve_builtin_node_module(specifier).ok()
         })
       })
       .flatten()

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1564,18 +1564,17 @@ fn resolve(
   use SpecifierError::*;
   if let Err(Specifier(ImportPrefixMissing(_, _))) = response.as_ref() {
     if let Some(npm_resolver) = maybe_npm_resolver {
-      let maybe_specifier =
-        ModuleSpecifier::parse(&format!("node:{}", specifier_text)).ok();
-      let maybe_mod_name = maybe_specifier.as_ref().and_then(|s| {
-        npm_resolver.resolve_builtin_node_module(s).ok().flatten()
-      });
-      if maybe_mod_name.is_some() {
-        npm_resolver.on_resolve_bare_builtin_node_module(specifier_text);
-        return Resolution::from_resolve_result(
-          Ok(maybe_specifier.unwrap()),
-          specifier_text,
-          referrer_range,
-        );
+      if let Ok(specifier) =
+        ModuleSpecifier::parse(&format!("node:{}", specifier_text))
+      {
+        if npm_resolver.resolve_builtin_node_module(&specifier).is_ok() {
+          npm_resolver.on_resolve_bare_builtin_node_module(specifier_text);
+          return Resolution::from_resolve_result(
+            Ok(specifier),
+            specifier_text,
+            referrer_range,
+          );
+        }
       }
     }
   }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1556,7 +1556,7 @@ fn resolve(
   let response = if let Some(resolver) = maybe_resolver {
     resolver.resolve(specifier_text, &referrer_range.specifier)
   } else {
-    resolve_import(specifier_text, &referrer_range.specifier)
+    resolve_import(specifier_text, &referrer_range.specifier, None)
       .map_err(|err| err.into())
   };
   Resolution::from_resolve_result(response, specifier_text, referrer_range)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1083,14 +1083,14 @@ console.log(a);
   impl NpmResolver for MockNpmResolver {
     fn resolve_builtin_node_module(
       &self,
-      _specifier: &deno_ast::ModuleSpecifier,
+      specifier: &deno_ast::ModuleSpecifier,
     ) -> anyhow::Result<Option<String>, source::UnknownBuiltInNodeModuleError>
     {
-      Ok(None)
-    }
-
-    fn is_builtin_node_module_name(&self, module_name: &str) -> bool {
-      module_name == "path"
+      if specifier.to_string() == "node:path" {
+        Ok(Some("path".to_string()))
+      } else {
+        Ok(None)
+      }
     }
 
     fn on_resolve_bare_builtin_node_module(&self, module_name: &str) {
@@ -1150,12 +1150,7 @@ console.log(a);
         },
       )
       .await;
-    let result = graph.valid();
-    assert!(result.is_err());
-    assert_eq!(
-      result.unwrap_err().to_string(),
-      "Module not found \"node:path\"."
-    );
+    assert!(graph.valid().is_ok());
     assert_eq!(
       json!(graph),
       json!({
@@ -1164,6 +1159,7 @@ console.log(a);
         ],
         "modules": [
           {
+            "kind": "esm",
             "dependencies": [
               {
                 "specifier": "path",
@@ -1182,14 +1178,14 @@ console.log(a);
                 },
               }
             ],
-            "kind": "esm",
-            "mediaType": "TypeScript",
             "size": 14,
+            "mediaType": "TypeScript",
             "specifier": "file:///a/test.ts"
           },
           {
-            "error": "Module not found \"node:path\".",
-            "specifier": "node:path"
+            "kind": "node",
+            "specifier": "node:path",
+            "moduleName": "path",
           }
         ],
         "redirects": {}

--- a/src/module_specifier.rs
+++ b/src/module_specifier.rs
@@ -1,7 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-use crate::source::NpmResolver;
-use anyhow::Result;
 use std::error::Error;
 use std::fmt;
 use std::path::PathBuf;
@@ -55,27 +53,13 @@ fn specifier_from_path(_path: PathBuf) -> ModuleSpecifier {
 pub fn resolve_import(
   specifier: &str,
   referrer: &ModuleSpecifier,
-  maybe_npm_resolver: Option<&dyn NpmResolver>,
 ) -> Result<ModuleSpecifier, SpecifierError> {
   let url = match ModuleSpecifier::parse(specifier) {
     // 1. Apply the URL parser to specifier.
-    //    If the result is not failure, return the result.
+    //    If the result is not failure, return he result.
     Ok(url) => url,
 
-    // 2. If specifier is a node specifier without node: scheme, return
-    //    the specifier with node: scheme added.
-    Err(ParseError::RelativeUrlWithoutBase)
-      if maybe_npm_resolver.map_or(false, |npm_resolver| {
-        npm_resolver.is_builtin_node_module_name(specifier)
-      }) =>
-    {
-      maybe_npm_resolver
-        .unwrap()
-        .on_resolve_bare_builtin_node_module(specifier);
-      return Ok(ModuleSpecifier::parse(&format!("node:{specifier}")).unwrap());
-    }
-
-    // 3. If specifier does not start with the character U+002F SOLIDUS (/),
+    // 2. If specifier does not start with the character U+002F SOLIDUS (/),
     //    the two-character sequence U+002E FULL STOP, U+002F SOLIDUS (./),
     //    or the three-character sequence U+002E FULL STOP, U+002E FULL STOP,
     //    U+002F SOLIDUS (../), return failure.
@@ -90,7 +74,7 @@ pub fn resolve_import(
       ));
     }
 
-    // 4. Return the result of applying the URL parser to specifier with base
+    // 3. Return the result of applying the URL parser to specifier with base
     //    URL as the base URL.
     Err(ParseError::RelativeUrlWithoutBase) => {
       let referrer = if referrer.as_str() == EMPTY_SPECIFIER {

--- a/src/source.rs
+++ b/src/source.rs
@@ -170,7 +170,7 @@ pub trait Resolver: fmt::Debug {
     specifier_text: &str,
     referrer: &ModuleSpecifier,
   ) -> Result<ModuleSpecifier, ResolveError> {
-    Ok(resolve_import(specifier_text, referrer, None)?)
+    Ok(resolve_import(specifier_text, referrer)?)
   }
 
   /// Given a module specifier, return an optional tuple which provides a module
@@ -220,9 +220,6 @@ pub trait NpmResolver: fmt::Debug {
     &self,
     specifier: &ModuleSpecifier,
   ) -> Result<Option<String>, UnknownBuiltInNodeModuleError>;
-
-  /// Returns true if the given str is a builtin node module name (ex. "fs").
-  fn is_builtin_node_module_name(&self, module_name: &str) -> bool;
 
   /// The callback when a bare specifier is resolved to a builtin node module.
   /// (Note: used for printing warnings to discourage that usage of bare specifiers)
@@ -472,7 +469,7 @@ pub mod tests {
           return Ok(resolved_specifier.clone());
         }
       }
-      Ok(resolve_import(specifier, referrer, None)?)
+      Ok(resolve_import(specifier, referrer)?)
     }
 
     fn resolve_types(

--- a/src/source.rs
+++ b/src/source.rs
@@ -162,7 +162,7 @@ pub trait Resolver: fmt::Debug {
     specifier_text: &str,
     referrer: &ModuleSpecifier,
   ) -> Result<ModuleSpecifier, Error> {
-    Ok(resolve_import(specifier_text, referrer)?)
+    Ok(resolve_import(specifier_text, referrer, None)?)
   }
 
   /// Given a module specifier, return an optional tuple which provides a module
@@ -212,6 +212,13 @@ pub trait NpmResolver: fmt::Debug {
     &self,
     specifier: &ModuleSpecifier,
   ) -> Result<Option<String>, UnknownBuiltInNodeModuleError>;
+
+  /// Returns true if the given str is a builtin node module name (ex. "fs").
+  fn is_builtin_node_module_name(&self, module_name: &str) -> bool;
+
+  /// The callback when a bare specifier is resolved to a builtin node module.
+  /// (Note: used for printing warnings to discourage that usage of bare specifiers)
+  fn on_resolve_bare_builtin_node_module(&self, module_name: &str);
 
   /// This tells the implementation to asynchronously load within itself the
   /// npm registry package information so that synchronous resolution can occur
@@ -457,7 +464,7 @@ pub mod tests {
           return Ok(resolved_specifier.clone());
         }
       }
-      Ok(resolve_import(specifier, referrer)?)
+      Ok(resolve_import(specifier, referrer, None)?)
     }
 
     fn resolve_types(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -149,10 +149,6 @@ async fn test_npm_version_not_found_then_found() {
       Ok(None)
     }
 
-    fn is_builtin_node_module_name(&self, _module_name: &str) -> bool {
-      false
-    }
-
     fn on_resolve_bare_builtin_node_module(&self, _module_name: &str) {}
 
     fn load_and_cache_npm_package_info(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -149,6 +149,12 @@ async fn test_npm_version_not_found_then_found() {
       Ok(None)
     }
 
+    fn is_builtin_node_module_name(&self, _module_name: &str) -> bool {
+      false
+    }
+
+    fn on_resolve_bare_builtin_node_module(&self, _module_name: &str) {}
+
     fn load_and_cache_npm_package_info(
       &self,
       _package_name: &str,


### PR DESCRIPTION
part of https://github.com/denoland/deno/issues/20566

This PR updates the resolution of bare specifiers. If the module specifier is node builtin module as a bare specifier, resolve it as `node:<module_name>`. Also it prints the warning message like `Warning: Resolving "path" as "node:path". If you want to use a built-in Node module, add a "node:" prefix.`