### PR TITLE
fix: pass range to on_resolve_bare_builtin_node_module

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1568,7 +1568,10 @@ fn resolve(
         ModuleSpecifier::parse(&format!("node:{}", specifier_text))
       {
         if npm_resolver.resolve_builtin_node_module(&specifier).is_ok() {
-          npm_resolver.on_resolve_bare_builtin_node_module(specifier_text);
+          npm_resolver.on_resolve_bare_builtin_node_module(
+            specifier_text,
+            &referrer_range,
+          );
           return Resolution::from_resolve_result(
             Ok(specifier),
             specifier_text,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1093,11 +1093,17 @@ console.log(a);
       }
     }
 
-    fn on_resolve_bare_builtin_node_module(&self, module_name: &str) {
-      eprintln!(
-        "Warning: Resolving bare specifier \"{}\" to \"node:{}\".",
-        module_name, module_name
-      );
+    fn on_resolve_bare_builtin_node_module(
+      &self,
+      module_name: &str,
+      range: &Range,
+    ) {
+      let Range {
+        specifier, start, ..
+      } = range;
+      let line = start.line + 1;
+      let column = start.character;
+      eprintln!("Warning: Resolving \"{module_name}\" as \"node:{module_name}\" at {specifier}:{line}:{column}. If you want to use a built-in Node module, add a \"node:\" prefix.");
     }
 
     fn load_and_cache_npm_package_info(

--- a/src/source.rs
+++ b/src/source.rs
@@ -223,7 +223,11 @@ pub trait NpmResolver: fmt::Debug {
 
   /// The callback when a bare specifier is resolved to a builtin node module.
   /// (Note: used for printing warnings to discourage that usage of bare specifiers)
-  fn on_resolve_bare_builtin_node_module(&self, module_name: &str);
+  fn on_resolve_bare_builtin_node_module(
+    &self,
+    module_name: &str,
+    range: &Range,
+  );
 
   /// This tells the implementation to asynchronously load within itself the
   /// npm registry package information so that synchronous resolution can occur

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -20,6 +20,7 @@ use deno_graph::BuildOptions;
 use deno_graph::GraphKind;
 use deno_graph::ModuleGraph;
 use deno_graph::NpmPackageReqResolution;
+use deno_graph::Range;
 use deno_semver::package::PackageNv;
 use deno_semver::package::PackageReq;
 use deno_semver::Version;
@@ -149,7 +150,12 @@ async fn test_npm_version_not_found_then_found() {
       Ok(None)
     }
 
-    fn on_resolve_bare_builtin_node_module(&self, _module_name: &str) {}
+    fn on_resolve_bare_builtin_node_module(
+      &self,
+      _module_name: &str,
+      _range: &Range,
+    ) {
+    }
 
     fn load_and_cache_npm_package_info(
       &self,


### PR DESCRIPTION
This PR passes `Range` to `on_resolve_bare_builtin_node_module`. This is necessary to implement https://github.com/denoland/deno/pull/20728