### PR TITLE
fix: check bare node specifier for ImportMapError::UnmappedBareSpecifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "deno_ast",
  "deno_semver",
  "futures",
+ "import_map",
  "indexmap 2.0.0",
  "monch",
  "once_cell",
@@ -414,6 +415,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "import_map"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632089ec08bd62e807311104122fb26d5c911ab172e2b9864be154a575979e29"
+dependencies = [
+ "cfg-if",
+ "indexmap 1.9.3",
+ "log",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +436,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ data-url = "0.3.0"
 deno_ast = { version = "0.29.0", features = ["dep_graph", "module_specifier"] }
 deno_semver = "0.5.0"
 futures = "0.3.26"
+import_map = "0.15.0"
 indexmap = { version = "2", features = ["serde"] }
 monch = "0.4.3"
 once_cell = "1.16.0"

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1560,9 +1560,13 @@ fn resolve(
     resolve_import(specifier_text, &referrer_range.specifier)
       .map_err(|err| err.into())
   };
+  use import_map::ImportMapError;
   use ResolveError::*;
   use SpecifierError::*;
-  if let Err(Specifier(ImportPrefixMissing(_, _))) = response.as_ref() {
+  let res_ref = response.as_ref();
+  if matches!(res_ref, Err(Specifier(ImportPrefixMissing(_, _))))
+    || matches!(res_ref, Err(Other(e)) if matches!(e.downcast_ref::<ImportMapError>(), Some(&ImportMapError::UnmappedBareSpecifier(_, _))))
+  {
     if let Some(npm_resolver) = maybe_npm_resolver {
       if let Ok(specifier) =
         ModuleSpecifier::parse(&format!("node:{}", specifier_text))


### PR DESCRIPTION
This PR adds bare node specifier check when the `ResolveError` from `resolver.resolve` is `Other(ImportMapError::UnmappedBareSpecifier(_, _))`.

By this change, we can keep more detailed error message from `ImportMapError`, for example, like `Relative import path "unmapped" not prefixed with / or ./ or ../ and not in import map from "file://[WILDCARD]/092_import_map_unmapped_bare_specifier.ts"`

related https://github.com/denoland/deno/pull/20728