### PR TITLE
fix: add is_bare_node_specifier_enabled to NpmResolver trait

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1561,7 +1561,7 @@ fn resolve(
       .map_err(|err| err.into())
   };
   if let Some(npm_resolver) = maybe_npm_resolver {
-    if npm_resolver.is_bare_node_specifier_enabled() {
+    if npm_resolver.enables_bare_builtin_node_module() {
       use import_map::ImportMapError;
       use ResolveError::*;
       use SpecifierError::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1208,7 +1208,7 @@ console.log(a);
       "redirects": {}
     });
     let mock_npm_resolver = MockNpmResolver {
-      is_bare_node_specifier_enabled: true
+      is_bare_node_specifier_enabled: true,
     };
     let mock_import_map_resolver = MockImportMapResolver {};
 
@@ -1254,7 +1254,7 @@ console.log(a);
     assert_eq!(json!(graph), expectation);
 
     let mock_npm_resolver = MockNpmResolver {
-      is_bare_node_specifier_enabled: false
+      is_bare_node_specifier_enabled: false,
     };
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
@@ -1269,7 +1269,10 @@ console.log(a);
       .await;
     let res = graph.valid();
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().to_string(), "Relative import path \"path\" not prefixed with / or ./ or ../");
+    assert_eq!(
+      res.unwrap_err().to_string(),
+      "Relative import path \"path\" not prefixed with / or ./ or ../"
+    );
   }
 
   #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1079,7 +1079,7 @@ console.log(a);
 
   #[derive(Debug, Clone)]
   struct MockNpmResolver {
-    is_bare_node_specifier_enabled: bool,
+    enables_bare_builtin_node_module: bool,
   }
 
   impl NpmResolver for MockNpmResolver {
@@ -1125,8 +1125,8 @@ console.log(a);
       todo!()
     }
 
-    fn is_bare_node_specifier_enabled(&self) -> bool {
-      self.is_bare_node_specifier_enabled
+    fn enables_bare_builtin_node_module(&self) -> bool {
+      self.enables_bare_builtin_node_module
     }
   }
 
@@ -1208,7 +1208,7 @@ console.log(a);
       "redirects": {}
     });
     let mock_npm_resolver = MockNpmResolver {
-      is_bare_node_specifier_enabled: true,
+      enables_bare_builtin_node_module: true,
     };
     let mock_import_map_resolver = MockImportMapResolver {};
 
@@ -1254,7 +1254,7 @@ console.log(a);
     assert_eq!(json!(graph), expectation);
 
     let mock_npm_resolver = MockNpmResolver {
-      is_bare_node_specifier_enabled: false,
+      enables_bare_builtin_node_module: false,
     };
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph

--- a/src/source.rs
+++ b/src/source.rs
@@ -245,7 +245,7 @@ pub trait NpmResolver: fmt::Debug {
   fn resolve_npm(&self, package_req: &PackageReq) -> NpmPackageReqResolution;
 
   /// Returns true when bare node specifier resoluion is enabled
-  fn is_bare_node_specifier_enabled(&self) -> bool {
+  fn enables_bare_builtin_node_module(&self) -> bool {
     false
   }
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -243,6 +243,11 @@ pub trait NpmResolver: fmt::Debug {
 
   /// Resolves an npm package requirement to a resolved npm package name and version.
   fn resolve_npm(&self, package_req: &PackageReq) -> NpmPackageReqResolution;
+
+  /// Returns true when bare node specifier resoluion is enabled
+  fn is_bare_node_specifier_enabled(&self) -> bool {
+    false
+  }
 }
 
 pub fn load_data_url(


### PR DESCRIPTION
This PR adds `is_bare_node_specifier_enabled` to `NpmResolver` to enable feature flagging of bare node specifier resolution.

related https://github.com/denoland/deno/pull/20728