### PR TITLE
feat(resolver): add resolution mode

### DIFF
--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -13,6 +13,7 @@ use deno_graph::source::CacheInfo;
 use deno_graph::source::CacheSetting;
 use deno_graph::source::LoadFuture;
 use deno_graph::source::Loader;
+use deno_graph::source::ResolutionMode;
 use deno_graph::source::ResolveError;
 use deno_graph::source::Resolver;
 use deno_graph::source::DEFAULT_JSX_IMPORT_SOURCE_MODULE;
@@ -140,6 +141,7 @@ impl Resolver for JsResolver {
     &self,
     specifier: &str,
     referrer: &ModuleSpecifier,
+    _mode: ResolutionMode,
   ) -> Result<ModuleSpecifier, ResolveError> {
     if let Some(resolve) = &self.maybe_resolve {
       let this = JsValue::null();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,7 @@ pub fn parse_module_from_ast(
 #[cfg(test)]
 mod tests {
   use crate::graph::ResolutionResolved;
+  use crate::source::ResolutionMode;
 
   use super::*;
   use pretty_assertions::assert_eq;
@@ -1146,6 +1147,7 @@ console.log(a);
       &self,
       specifier_text: &str,
       referrer: &deno_ast::ModuleSpecifier,
+      _mode: ResolutionMode,
     ) -> Result<deno_ast::ModuleSpecifier, source::ResolveError> {
       use import_map::ImportMapError;
       Err(source::ResolveError::Other(

--- a/src/source.rs
+++ b/src/source.rs
@@ -145,6 +145,15 @@ pub enum ResolveError {
   Other(#[from] anyhow::Error),
 }
 
+/// The kind of resolution currently being done by deno_graph.
+#[derive(Debug, Clone, Copy)]
+pub enum ResolutionMode {
+  /// Resolving for code that will be executed.
+  Execution,
+  /// Resolving for code that will be used for type information.
+  Types,
+}
+
 /// A trait which allows the module graph to resolve specifiers and type only
 /// dependencies. This can be use to provide import maps and override other
 /// default resolution logic used by `deno_graph`.
@@ -169,6 +178,7 @@ pub trait Resolver: fmt::Debug {
     &self,
     specifier_text: &str,
     referrer: &ModuleSpecifier,
+    _mode: ResolutionMode,
   ) -> Result<ModuleSpecifier, ResolveError> {
     Ok(resolve_import(specifier_text, referrer)?)
   }
@@ -472,6 +482,7 @@ pub mod tests {
       &self,
       specifier: &str,
       referrer: &ModuleSpecifier,
+      _mode: ResolutionMode,
     ) -> Result<ModuleSpecifier, ResolveError> {
       if let Some(map) = self.map.get(referrer) {
         if let Some(resolved_specifier) = map.get(specifier) {


### PR DESCRIPTION
This is necessary for BYONM so that I can tell if "types" resolution is currently being done or "code"/"execution" resolution. With node resolution we could end up at different files based on what resolution is being done (unlike with Deno resolution, which is much simpler).