### PR TITLE
perf: do not resolve more types when GraphKind::CodeOnly

### DIFF
--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -293,6 +293,7 @@ pub fn js_parse_module(
     None
   };
   match deno_graph::parse_module(
+    GraphKind::All,
     &specifier,
     maybe_headers.as_ref(),
     content.into(),


### PR DESCRIPTION
It seems when GraphKind::CodeOnly we were doing a lot of extra work that we didn't need to do. This should make things faster when just running without type checking.

I noticed this while working on https://github.com/denoland/deno_graph/pull/304

Also closes #266