### PR TITLE
feat(tracing): include fn implementation signatures in list of symbol declarations

### DIFF
--- a/src/type_tracer/cross_module.rs
+++ b/src/type_tracer/cross_module.rs
@@ -87,6 +87,14 @@ fn go_to_definitions_internal<'a>(
           kind: DefinitionKind::Definition,
         });
       }
+      SymbolDeclKind::DefinitionPrivateFnImpl(_) => {
+        definitions.push(Definition {
+          module,
+          symbol,
+          symbol_decl: decl,
+          kind: DefinitionKind::Definition,
+        });
+      }
       SymbolDeclKind::Target(target_id) => {
         if let Some(symbol) = module
           .esm()

--- a/tests/specs/type_tracing/DeclarationMerging01.txt
+++ b/tests/specs/type_tracing/DeclarationMerging01.txt
@@ -1,25 +1,28 @@
 # mod.ts
-export function test<T extends TypeParam = Default>(param: Param): Return {
+class Album {
+}
+namespace Album {
+  export class Label {}
 }
 
-class TypeParam {}
-class Param {}
-class Return {}
-class Default {}
-
-// the top two overloads should appear in the results
-export function overloaded<T extends OverloadTypeParam>(param: OverloadParam): OverloadReturn;
-export function overloaded(): string;
-export function overloaded<T extends PrivateTypeParam>(param: PrivateParam): PrivateReturn {
+enum Color {
+  red,
+  green,
+  blue,
+}
+namespace Color {
+  export function mixColor(colorName: string) {
+    // ...etc...
+  }
 }
 
-class OverloadTypeParam {}
-class OverloadParam {}
-class OverloadReturn {}
+function Test() {
+}
+namespace Test {
+  export function other() {}
+}
 
-class PrivateTypeParam {}
-class PrivateParam {}
-class PrivateReturn {}
+export { Album, Color, Test };
 
 # output
 file:///mod.ts: EsmModuleSymbol {
@@ -29,72 +32,40 @@ file:///mod.ts: EsmModuleSymbol {
     specifier: "file:///mod.ts",
     child_decls: {
         0,
-        1,
         2,
-        3,
         4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
     },
     exports: {
-        "test": 0,
-        "overloaded": 5,
+        "Album": 0,
+        "Color": 2,
+        "Test": 4,
     },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
-            "test",
+            "Album",
             #2,
         ): 0,
         (
-            "TypeParam",
-            #2,
+            "Label",
+            #3,
         ): 1,
         (
-            "Param",
+            "Color",
             #2,
         ): 2,
         (
-            "Return",
-            #2,
+            "mixColor",
+            #4,
         ): 3,
         (
-            "Default",
+            "Test",
             #2,
         ): 4,
         (
-            "overloaded",
-            #2,
+            "other",
+            #7,
         ): 5,
-        (
-            "OverloadTypeParam",
-            #2,
-        ): 6,
-        (
-            "OverloadParam",
-            #2,
-        ): 7,
-        (
-            "OverloadReturn",
-            #2,
-        ): 8,
-        (
-            "PrivateTypeParam",
-            #2,
-        ): 9,
-        (
-            "PrivateParam",
-            #2,
-        ): 10,
-        (
-            "PrivateReturn",
-            #2,
-        ): 11,
     },
     symbols: {
         0: Symbol {
@@ -107,7 +78,7 @@ file:///mod.ts: EsmModuleSymbol {
                             0,
                         ),
                         end: SourcePos(
-                            77,
+                            15,
                         ),
                     },
                     kind: Definition(
@@ -116,35 +87,58 @@ file:///mod.ts: EsmModuleSymbol {
                         ),
                     ),
                 },
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            16,
+                        ),
+                        end: SourcePos(
+                            59,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "<omitted>",
+                        ),
+                    ),
+                },
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            259,
+                        ),
+                        end: SourcePos(
+                            289,
+                        ),
+                    },
+                    kind: TargetSelf,
+                },
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            268,
+                        ),
+                        end: SourcePos(
+                            273,
+                        ),
+                    },
+                    kind: TargetSelf,
+                },
             ],
             deps: {
                 Id(
                     (
-                        "TypeParam",
-                        #2,
-                    ),
-                ),
-                Id(
-                    (
-                        "Default",
-                        #2,
-                    ),
-                ),
-                Id(
-                    (
-                        "Param",
-                        #2,
-                    ),
-                ),
-                Id(
-                    (
-                        "Return",
-                        #2,
+                        "Label",
+                        #3,
                     ),
                 ),
             },
-            child_decls: {},
-            exports: {},
+            child_decls: {
+                1,
+            },
+            exports: {
+                "Label": 1,
+            },
         },
         1: Symbol {
             symbol_id: 1,
@@ -153,10 +147,10 @@ file:///mod.ts: EsmModuleSymbol {
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            79,
+                            36,
                         ),
                         end: SourcePos(
-                            97,
+                            57,
                         ),
                     },
                     kind: Definition(
@@ -177,10 +171,10 @@ file:///mod.ts: EsmModuleSymbol {
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            98,
+                            61,
                         ),
                         end: SourcePos(
-                            112,
+                            99,
                         ),
                     },
                     kind: Definition(
@@ -189,10 +183,58 @@ file:///mod.ts: EsmModuleSymbol {
                         ),
                     ),
                 },
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            100,
+                        ),
+                        end: SourcePos(
+                            188,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "<omitted>",
+                        ),
+                    ),
+                },
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            259,
+                        ),
+                        end: SourcePos(
+                            289,
+                        ),
+                    },
+                    kind: TargetSelf,
+                },
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            275,
+                        ),
+                        end: SourcePos(
+                            280,
+                        ),
+                    },
+                    kind: TargetSelf,
+                },
             ],
-            deps: {},
-            child_decls: {},
-            exports: {},
+            deps: {
+                Id(
+                    (
+                        "mixColor",
+                        #4,
+                    ),
+                ),
+            },
+            child_decls: {
+                3,
+            },
+            exports: {
+                "mixColor": 3,
+            },
         },
         3: Symbol {
             symbol_id: 3,
@@ -201,10 +243,10 @@ file:///mod.ts: EsmModuleSymbol {
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            113,
+                            120,
                         ),
                         end: SourcePos(
-                            128,
+                            186,
                         ),
                     },
                     kind: Definition(
@@ -225,10 +267,10 @@ file:///mod.ts: EsmModuleSymbol {
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            129,
+                            190,
                         ),
                         end: SourcePos(
-                            145,
+                            209,
                         ),
                     },
                     kind: Definition(
@@ -237,10 +279,58 @@ file:///mod.ts: EsmModuleSymbol {
                         ),
                     ),
                 },
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            210,
+                        ),
+                        end: SourcePos(
+                            257,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "<omitted>",
+                        ),
+                    ),
+                },
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            259,
+                        ),
+                        end: SourcePos(
+                            289,
+                        ),
+                    },
+                    kind: TargetSelf,
+                },
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            282,
+                        ),
+                        end: SourcePos(
+                            286,
+                        ),
+                    },
+                    kind: TargetSelf,
+                },
             ],
-            deps: {},
-            child_decls: {},
-            exports: {},
+            deps: {
+                Id(
+                    (
+                        "other",
+                        #7,
+                    ),
+                ),
+            },
+            child_decls: {
+                5,
+            },
+            exports: {
+                "other": 5,
+            },
         },
         5: Symbol {
             symbol_id: 5,
@@ -249,203 +339,10 @@ file:///mod.ts: EsmModuleSymbol {
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            201,
+                            229,
                         ),
                         end: SourcePos(
-                            295,
-                        ),
-                    },
-                    kind: Definition(
-                        SymbolNode(
-                            "<omitted>",
-                        ),
-                    ),
-                },
-                SymbolDecl {
-                    range: SourceRange {
-                        start: SourcePos(
-                            296,
-                        ),
-                        end: SourcePos(
-                            333,
-                        ),
-                    },
-                    kind: Definition(
-                        SymbolNode(
-                            "<omitted>",
-                        ),
-                    ),
-                },
-                SymbolDecl {
-                    range: SourceRange {
-                        start: SourcePos(
-                            334,
-                        ),
-                        end: SourcePos(
-                            428,
-                        ),
-                    },
-                    kind: PrivateFnImplSignature(
-                        SymbolNode(
-                            "<omitted>",
-                        ),
-                    ),
-                },
-            ],
-            deps: {
-                Id(
-                    (
-                        "OverloadTypeParam",
-                        #2,
-                    ),
-                ),
-                Id(
-                    (
-                        "OverloadParam",
-                        #2,
-                    ),
-                ),
-                Id(
-                    (
-                        "OverloadReturn",
-                        #2,
-                    ),
-                ),
-            },
-            child_decls: {},
-            exports: {},
-        },
-        6: Symbol {
-            symbol_id: 6,
-            is_public: true,
-            decls: [
-                SymbolDecl {
-                    range: SourceRange {
-                        start: SourcePos(
-                            430,
-                        ),
-                        end: SourcePos(
-                            456,
-                        ),
-                    },
-                    kind: Definition(
-                        SymbolNode(
-                            "<omitted>",
-                        ),
-                    ),
-                },
-            ],
-            deps: {},
-            child_decls: {},
-            exports: {},
-        },
-        7: Symbol {
-            symbol_id: 7,
-            is_public: true,
-            decls: [
-                SymbolDecl {
-                    range: SourceRange {
-                        start: SourcePos(
-                            457,
-                        ),
-                        end: SourcePos(
-                            479,
-                        ),
-                    },
-                    kind: Definition(
-                        SymbolNode(
-                            "<omitted>",
-                        ),
-                    ),
-                },
-            ],
-            deps: {},
-            child_decls: {},
-            exports: {},
-        },
-        8: Symbol {
-            symbol_id: 8,
-            is_public: true,
-            decls: [
-                SymbolDecl {
-                    range: SourceRange {
-                        start: SourcePos(
-                            480,
-                        ),
-                        end: SourcePos(
-                            503,
-                        ),
-                    },
-                    kind: Definition(
-                        SymbolNode(
-                            "<omitted>",
-                        ),
-                    ),
-                },
-            ],
-            deps: {},
-            child_decls: {},
-            exports: {},
-        },
-        9: Symbol {
-            symbol_id: 9,
-            is_public: false,
-            decls: [
-                SymbolDecl {
-                    range: SourceRange {
-                        start: SourcePos(
-                            505,
-                        ),
-                        end: SourcePos(
-                            530,
-                        ),
-                    },
-                    kind: Definition(
-                        SymbolNode(
-                            "<omitted>",
-                        ),
-                    ),
-                },
-            ],
-            deps: {},
-            child_decls: {},
-            exports: {},
-        },
-        10: Symbol {
-            symbol_id: 10,
-            is_public: false,
-            decls: [
-                SymbolDecl {
-                    range: SourceRange {
-                        start: SourcePos(
-                            531,
-                        ),
-                        end: SourcePos(
-                            552,
-                        ),
-                    },
-                    kind: Definition(
-                        SymbolNode(
-                            "<omitted>",
-                        ),
-                    ),
-                },
-            ],
-            deps: {},
-            child_decls: {},
-            exports: {},
-        },
-        11: Symbol {
-            symbol_id: 11,
-            is_public: false,
-            decls: [
-                SymbolDecl {
-                    range: SourceRange {
-                        start: SourcePos(
-                            553,
-                        ),
-                        end: SourcePos(
-                            575,
+                            255,
                         ),
                     },
                     kind: Definition(
@@ -464,13 +361,29 @@ file:///mod.ts: EsmModuleSymbol {
     traced_referrers: {},
 }
 == export definitions ==
-[overloaded]: file:///mod.ts:201..295
-  export function overloaded<T extends OverloadTypeParam>(param: OverloadParam): OverloadReturn;
-file:///mod.ts:296..333
-  export function overloaded(): string;
-file:///mod.ts:334..428
-  export function overloaded<T extends PrivateTypeParam>(param: PrivateParam): PrivateReturn {
+[Album]: file:///mod.ts:0..15
+  class Album {
   }
-[test]: file:///mod.ts:0..77
-  export function test<T extends TypeParam = Default>(param: Param): Return {
+file:///mod.ts:16..59
+  namespace Album {
+    export class Label {}
+  }
+[Color]: file:///mod.ts:61..99
+  enum Color {
+    red,
+  ...
+    blue,
+  }
+file:///mod.ts:100..188
+  namespace Color {
+    export function mixColor(colorName: string) {
+  ...
+    }
+  }
+[Test]: file:///mod.ts:190..209
+  function Test() {
+  }
+file:///mod.ts:210..257
+  namespace Test {
+    export function other() {}
   }

--- a/tests/specs/type_tracing/FunctionOverloads01.txt
+++ b/tests/specs/type_tracing/FunctionOverloads01.txt
@@ -1,0 +1,272 @@
+# mod.ts
+export function test(value: number);
+export function test(value: string);
+export function test(value: string | number) {
+}
+
+namespace Inner {
+  export function inner(value: number);
+  export function inner(value: string);
+  export function inner(value: string | number) {
+  }
+}
+
+import InnerInner = Inner.inner;
+export { InnerInner };
+
+# output
+file:///mod.ts: EsmModuleSymbol {
+    module_id: ModuleId(
+        0,
+    ),
+    specifier: "file:///mod.ts",
+    child_decls: {
+        0,
+        1,
+    },
+    exports: {
+        "test": 0,
+        "InnerInner": 3,
+    },
+    re_exports: [],
+    swc_id_to_symbol_id: {
+        (
+            "test",
+            #2,
+        ): 0,
+        (
+            "Inner",
+            #2,
+        ): 1,
+        (
+            "inner",
+            #6,
+        ): 2,
+        (
+            "InnerInner",
+            #2,
+        ): 3,
+    },
+    symbols: {
+        0: Symbol {
+            symbol_id: 0,
+            is_public: true,
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            36,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "<omitted>",
+                        ),
+                    ),
+                },
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            37,
+                        ),
+                        end: SourcePos(
+                            73,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "<omitted>",
+                        ),
+                    ),
+                },
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            74,
+                        ),
+                        end: SourcePos(
+                            122,
+                        ),
+                    },
+                    kind: PrivateFnImplSignature(
+                        SymbolNode(
+                            "<omitted>",
+                        ),
+                    ),
+                },
+            ],
+            deps: {},
+            child_decls: {},
+            exports: {},
+        },
+        1: Symbol {
+            symbol_id: 1,
+            is_public: false,
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            124,
+                        ),
+                        end: SourcePos(
+                            277,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "<omitted>",
+                        ),
+                    ),
+                },
+            ],
+            deps: {
+                Id(
+                    (
+                        "inner",
+                        #6,
+                    ),
+                ),
+            },
+            child_decls: {
+                2,
+            },
+            exports: {
+                "inner": 2,
+            },
+        },
+        2: Symbol {
+            symbol_id: 2,
+            is_public: true,
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            144,
+                        ),
+                        end: SourcePos(
+                            181,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "<omitted>",
+                        ),
+                    ),
+                },
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            184,
+                        ),
+                        end: SourcePos(
+                            221,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "<omitted>",
+                        ),
+                    ),
+                },
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            224,
+                        ),
+                        end: SourcePos(
+                            275,
+                        ),
+                    },
+                    kind: PrivateFnImplSignature(
+                        SymbolNode(
+                            "<omitted>",
+                        ),
+                    ),
+                },
+            ],
+            deps: {},
+            child_decls: {},
+            exports: {},
+        },
+        3: Symbol {
+            symbol_id: 3,
+            is_public: true,
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            279,
+                        ),
+                        end: SourcePos(
+                            311,
+                        ),
+                    },
+                    kind: QualifiedTarget(
+                        (
+                            "Inner",
+                            #2,
+                        ),
+                        [
+                            "inner",
+                        ],
+                    ),
+                },
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            312,
+                        ),
+                        end: SourcePos(
+                            334,
+                        ),
+                    },
+                    kind: TargetSelf,
+                },
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            321,
+                        ),
+                        end: SourcePos(
+                            331,
+                        ),
+                    },
+                    kind: TargetSelf,
+                },
+            ],
+            deps: {
+                QualifiedId(
+                    (
+                        "Inner",
+                        #2,
+                    ),
+                    [
+                        "inner",
+                    ],
+                ),
+            },
+            child_decls: {},
+            exports: {},
+        },
+    },
+    traced_re_exports: {},
+    traced_referrers: {},
+}
+== export definitions ==
+[InnerInner]: file:///mod.ts:144..181
+  export function inner(value: number);
+file:///mod.ts:184..221
+  export function inner(value: string);
+file:///mod.ts:224..275
+  export function inner(value: string | number) {
+    }
+[test]: file:///mod.ts:0..36
+  export function test(value: number);
+file:///mod.ts:37..73
+  export function test(value: string);
+file:///mod.ts:74..122
+  export function test(value: string | number) {
+  }

--- a/tests/specs/type_tracing/FunctionOverloads01.txt
+++ b/tests/specs/type_tracing/FunctionOverloads01.txt
@@ -91,7 +91,7 @@ file:///mod.ts: EsmModuleSymbol {
                             122,
                         ),
                     },
-                    kind: PrivateFnImplSignature(
+                    kind: DefinitionPrivateFnImpl(
                         SymbolNode(
                             "<omitted>",
                         ),
@@ -180,7 +180,7 @@ file:///mod.ts: EsmModuleSymbol {
                             275,
                         ),
                     },
-                    kind: PrivateFnImplSignature(
+                    kind: DefinitionPrivateFnImpl(
                         SymbolNode(
                             "<omitted>",
                         ),

--- a/tests/specs/type_tracing/Functions01.txt
+++ b/tests/specs/type_tracing/Functions01.txt
@@ -285,7 +285,7 @@ file:///mod.ts: EsmModuleSymbol {
                             428,
                         ),
                     },
-                    kind: PrivateFnImplSignature(
+                    kind: DefinitionPrivateFnImpl(
                         SymbolNode(
                             "<omitted>",
                         ),


### PR DESCRIPTION
This is for deno_doc for analyzing implementation signatures.