### PR TITLE
feat: add ModuleGraphError::TypesResolutionError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3912,7 +3912,7 @@ export function a(a: A): B {
       ) -> Result<ModuleSpecifier, crate::source::ResolveError> {
         match mode {
           ResolutionMode::Execution => {
-            Ok(resolve_import(&specifier_text, referrer)?)
+            Ok(resolve_import(specifier_text, referrer)?)
           }
           ResolutionMode::Types => Err(crate::source::ResolveError::Other(
             anyhow::anyhow!("Failed."),


### PR DESCRIPTION
Adds a new `TypesResolutionError` so that it's easier to identify which resolution errors are for type checking or not and enhance the error messages.

FYI @nayeemrmn. For some reason I can't add you as a reviewer.