### PR TITLE
feat(symbols): ability to get where a "go to definition" failed and add a symbol for each module

### DIFF
--- a/src/source.rs
+++ b/src/source.rs
@@ -355,6 +355,13 @@ impl MemoryLoader {
     self.sources.insert(specifier, source.into_result());
   }
 
+  pub fn add_external_source(&mut self, specifier: impl AsRef<str>) {
+    self.add_source(
+      specifier.as_ref(),
+      Source::External(specifier.as_ref().to_string()),
+    );
+  }
+
   pub fn add_source_with_text(
     &mut self,
     specifier: impl AsRef<str>,

--- a/src/symbols/analyzer.rs
+++ b/src/symbols/analyzer.rs
@@ -34,6 +34,7 @@ use super::collections::AdditiveOnlyMap;
 use super::collections::AdditiveOnlyMapForCopyValues;
 use super::cross_module;
 use super::cross_module::Definition;
+use super::cross_module::DefinitionOrUnresolved;
 use super::cross_module::DefinitionPath;
 use super::cross_module::ExportsAndReExports;
 use super::ResolvedSymbolDepEntry;
@@ -113,6 +114,18 @@ impl<'a> RootSymbol<'a> {
       .find_definition_paths(module, symbol)
       .into_iter()
       .flat_map(|d| d.into_definitions())
+  }
+
+  /// Goes to the definitions of the specified symbol.
+  pub fn go_to_definitions_or_unresolveds<'b>(
+    &'b self,
+    module: ModuleInfoRef<'b>,
+    symbol: &'b Symbol,
+  ) -> impl Iterator<Item = DefinitionOrUnresolved<'b>> {
+    self
+      .find_definition_paths(module, symbol)
+      .into_iter()
+      .flat_map(|d| d.into_definitions_or_unresolveds())
   }
 
   /// Finds the graph paths to the definition of the specified symbol.
@@ -1149,7 +1162,7 @@ impl ModuleBuilder {
     module_symbol: &SymbolMut,
     symbol_decl: SymbolDecl,
   ) -> SymbolId {
-    if let Some(symbol_id) = module_symbol.get_export(&"default".to_string()) {
+    if let Some(symbol_id) = module_symbol.get_export("default") {
       let default_export_symbol = self.symbols.get(&symbol_id).unwrap();
       default_export_symbol.add_decl(symbol_decl);
       symbol_id
@@ -1244,7 +1257,7 @@ impl<'a> SymbolFiller<'a> {
         continue; // don't fill the types on implementation signatures as they're private
       }
 
-      self.fill_module_item(module_item, &module_symbol);
+      self.fill_module_item(module_item, module_symbol);
     }
   }
 

--- a/src/symbols/cross_module.rs
+++ b/src/symbols/cross_module.rs
@@ -63,7 +63,7 @@ impl<'a> Definition<'a> {
 pub enum DefinitionUnresolvedKind<'a> {
   /// Could not resolve the swc Id.
   Id(&'a deno_ast::swc::ast::Id),
-  /// Could not resolve the specifier relative this module via deno_graph.
+  /// Could not resolve the specifier relative to this module via deno_graph.
   Specifier(&'a str),
   /// Could not resolve the part on the symbol.
   Part(&'a str),

--- a/src/symbols/mod.rs
+++ b/src/symbols/mod.rs
@@ -19,7 +19,10 @@ pub use self::analyzer::UniqueSymbolId;
 pub use self::cross_module::Definition;
 pub use self::cross_module::DefinitionKind;
 pub use self::cross_module::DefinitionPath;
+pub use self::cross_module::ExportsAndReExports;
+pub use self::cross_module::ResolvedExportOrReExport;
 pub use self::cross_module::ResolvedSymbolDepEntry;
+pub use self::cross_module::UnresolvedSpecifier;
 
 mod analyzer;
 mod collections;

--- a/src/symbols/mod.rs
+++ b/src/symbols/mod.rs
@@ -18,6 +18,7 @@ pub use self::analyzer::SymbolNodeRef;
 pub use self::analyzer::UniqueSymbolId;
 pub use self::cross_module::Definition;
 pub use self::cross_module::DefinitionKind;
+pub use self::cross_module::DefinitionOrUnresolved;
 pub use self::cross_module::DefinitionPath;
 pub use self::cross_module::ExportsAndReExports;
 pub use self::cross_module::ResolvedExportOrReExport;

--- a/src/symbols/mod.rs
+++ b/src/symbols/mod.rs
@@ -1,13 +1,13 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-pub use self::analyzer::EsmModuleSymbol;
+pub use self::analyzer::EsmModuleInfo;
 pub use self::analyzer::ExportDeclRef;
 pub use self::analyzer::FileDep;
 pub use self::analyzer::FileDepName;
-pub use self::analyzer::JsonModuleSymbol;
+pub use self::analyzer::JsonModuleInfo;
 pub use self::analyzer::ModuleId;
-pub use self::analyzer::ModuleSymbol;
-pub use self::analyzer::ModuleSymbolRef;
+pub use self::analyzer::ModuleInfo;
+pub use self::analyzer::ModuleInfoRef;
 pub use self::analyzer::RootSymbol;
 pub use self::analyzer::Symbol;
 pub use self::analyzer::SymbolDecl;

--- a/tests/helpers/test_builder.rs
+++ b/tests/helpers/test_builder.rs
@@ -233,11 +233,21 @@ impl TestBuilder {
             }
           };
         let exports = entrypoint_symbol.exports(&root_symbol);
-        if !exports.is_empty() {
+        if !exports.resolved.is_empty() {
           output_text.push_str("== export definitions ==\n");
-          for (name, (module_symbol, symbol_id)) in exports {
-            let position = get_symbol_text(module_symbol, symbol_id);
+          for (name, resolved) in exports.resolved {
+            let position = get_symbol_text(resolved.module, resolved.symbol_id);
             output_text.push_str(&format!("[{}]: {}\n", name, position));
+          }
+        }
+        if !exports.unresolved_specifiers.is_empty() {
+          output_text.push_str("== failed unresolved specifiers ==\n");
+          for unresolved in exports.unresolved_specifiers {
+            output_text.push_str(&format!(
+              "[{}]: {}\n",
+              unresolved.referrer.specifier(),
+              unresolved.specifier
+            ));
           }
         }
         output_text

--- a/tests/helpers/test_builder.rs
+++ b/tests/helpers/test_builder.rs
@@ -160,7 +160,7 @@ impl TestBuilder {
 
   #[cfg(feature = "symbols")]
   pub async fn symbols(&mut self) -> anyhow::Result<symbols::SymbolsResult> {
-    use deno_graph::symbols::ModuleSymbolRef;
+    use deno_graph::symbols::ModuleInfoRef;
 
     let build_result = self.build_for_symbols().await;
     let graph = &build_result.graph;
@@ -185,13 +185,13 @@ impl TestBuilder {
             "{}: {}\n",
             specifier.as_str(),
             match module {
-              ModuleSymbolRef::Esm(m) => format!("{:#?}", m),
-              ModuleSymbolRef::Json(m) => format!("{:#?}", m),
+              ModuleInfoRef::Esm(m) => format!("{:#?}", m),
+              ModuleInfoRef::Json(m) => format!("{:#?}", m),
             }
           ));
         }
         let get_symbol_text =
-          |module_symbol: deno_graph::symbols::ModuleSymbolRef,
+          |module_symbol: deno_graph::symbols::ModuleInfoRef,
            symbol_id: deno_graph::symbols::SymbolId| {
             let symbol = module_symbol.symbol(symbol_id).unwrap();
             let definitions = root_symbol

--- a/tests/helpers/test_builder.rs
+++ b/tests/helpers/test_builder.rs
@@ -234,31 +234,22 @@ impl TestBuilder {
                   }
                   DefinitionOrUnresolved::Unresolved(unresolved) => results
                     .push(format!(
-                      "{} - FAILED: {:#?}",
+                      "{}\n  Unresolved {:?} ({:?})",
                       unresolved.module.specifier(),
-                      unresolved.kind
+                      unresolved.kind,
+                      unresolved.parts,
                     )),
                 }
               }
               results.join("\n")
             }
           };
-        let exports = entrypoint_symbol.exports(&root_symbol);
-        if !exports.resolved.is_empty() {
+        let exports = entrypoint_symbol.exports(&root_symbol).resolved;
+        if !exports.is_empty() {
           output_text.push_str("== export definitions ==\n");
-          for (name, resolved) in exports.resolved {
+          for (name, resolved) in exports {
             let position = get_symbol_text(resolved.module, resolved.symbol_id);
             output_text.push_str(&format!("[{}]: {}\n", name, position));
-          }
-        }
-        if !exports.unresolved_specifiers.is_empty() {
-          output_text.push_str("== failed unresolved specifiers ==\n");
-          for unresolved in exports.unresolved_specifiers {
-            output_text.push_str(&format!(
-              "[{}]: {}\n",
-              unresolved.referrer.specifier(),
-              unresolved.specifier
-            ));
           }
         }
         output_text

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -173,19 +173,22 @@ export class MyClass {
     .await;
 
   let root_symbol = result.root_symbol();
-  let module_symbol = root_symbol
+  let module = root_symbol
     .get_module_from_specifier(
       &ModuleSpecifier::parse("file:///mod.ts").unwrap(),
     )
     .unwrap();
-  let exports = module_symbol.exports(&root_symbol);
-  let (module, my_type_symbol_id) = exports.get("MyType").unwrap();
-  let my_type_symbol = module.symbol(*my_type_symbol_id).unwrap();
+  let exports = module.exports(&root_symbol);
+  let resolved_my_type = exports.resolved.get("MyType").unwrap();
+  let my_type_symbol = resolved_my_type.symbol();
   let deps = my_type_symbol.deps().collect::<Vec<_>>();
   assert_eq!(deps.len(), 1);
   let dep = &deps[0];
-  let mut resolved_deps =
-    root_symbol.resolve_symbol_dep(*module, my_type_symbol, dep);
+  let mut resolved_deps = root_symbol.resolve_symbol_dep(
+    resolved_my_type.module,
+    my_type_symbol,
+    dep,
+  );
   assert_eq!(resolved_deps.len(), 1);
   let resolved_dep = resolved_deps.remove(0);
   let path = match resolved_dep {

--- a/tests/specs/symbols/Basic.txt
+++ b/tests/specs/symbols/Basic.txt
@@ -27,7 +27,7 @@ export default class C {
 export type D = typeof C;
 
 # output
-file:///a.ts: EsmModuleSymbol {
+file:///a.ts: EsmModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -347,7 +347,7 @@ file:///a.ts: EsmModuleSymbol {
         },
     },
 }
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/Basic.txt
+++ b/tests/specs/symbols/Basic.txt
@@ -32,45 +32,32 @@ file:///a.ts: EsmModuleSymbol {
         1,
     ),
     specifier: "file:///a.ts",
-    child_ids: {
-        0,
-        2,
-        4,
-        6,
-        8,
-    },
-    exports: {
-        "A": 4,
-        "B": 6,
-        "default": 7,
-        "D": 8,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "AInner",
             #2,
-        ): 0,
+        ): 1,
         (
             "AInnerUnused",
             #2,
-        ): 2,
+        ): 3,
         (
             "A",
             #2,
-        ): 4,
+        ): 5,
         (
             "B",
             #2,
-        ): 6,
+        ): 7,
         (
             "C",
             #2,
-        ): 7,
+        ): 8,
         (
             "D",
             #2,
-        ): 8,
+        ): 9,
     },
     symbols: {
         0: Symbol {
@@ -78,6 +65,28 @@ file:///a.ts: EsmModuleSymbol {
                 1,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+                3,
+                5,
+                7,
+                9,
+            },
+            exports: {
+                "A": 5,
+                "B": 7,
+                "default": 8,
+                "D": 9,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                1,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -99,14 +108,14 @@ file:///a.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                1,
+                2,
             },
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -129,11 +138,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -155,14 +164,14 @@ file:///a.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                3,
+                4,
             },
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -185,11 +194,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        4: Symbol {
+        5: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 4,
+            symbol_id: 5,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -211,14 +220,14 @@ file:///a.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                5,
+                6,
             },
         },
-        5: Symbol {
+        6: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 5,
+            symbol_id: 6,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -248,11 +257,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        6: Symbol {
+        7: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 6,
+            symbol_id: 7,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -275,11 +284,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        7: Symbol {
+        8: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 7,
+            symbol_id: 8,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -302,11 +311,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        8: Symbol {
+        9: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 8,
+            symbol_id: 9,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -343,36 +352,28 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        3,
-        5,
-    },
-    exports: {
-        "ExportA": 4,
-        "D": 2,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "A",
             #2,
-        ): 0,
+        ): 1,
         (
             "B",
             #2,
-        ): 1,
+        ): 2,
         (
             "D",
             #2,
-        ): 2,
+        ): 3,
         (
             "ExportA",
             #2,
-        ): 4,
+        ): 5,
         (
             "test",
             #2,
-        ): 5,
+        ): 6,
     },
     symbols: {
         0: Symbol {
@@ -380,6 +381,23 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                4,
+                6,
+            },
+            exports: {
+                "ExportA": 5,
+                "D": 3,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -405,11 +423,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -435,11 +453,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -487,11 +505,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -517,11 +535,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        4: Symbol {
+        5: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 4,
+            symbol_id: 5,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -551,11 +569,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        5: Symbol {
+        6: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 5,
+            symbol_id: 6,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/Basic.txt
+++ b/tests/specs/symbols/Basic.txt
@@ -65,7 +65,23 @@ file:///a.ts: EsmModuleInfo {
                 1,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            198,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "interface AInner {\n  prop: string;\n}\n\ninterface AInnerUnused {\n  prop2: string;\n}\n\nexport class A {\n  prop: AInner;\n}\n\nexport type B = string;\n\nexport default class C {\n};\n\nexport type D = typeof C;",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,
@@ -381,7 +397,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            100,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "import { A, B, D } from \"./a.ts\";\n\nexport const ExportA: typeof A = A;\n\nconst test: B;\nexport { D };",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 4,

--- a/tests/specs/symbols/Classes01.txt
+++ b/tests/specs/symbols/Classes01.txt
@@ -128,7 +128,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            859,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export class A {\n  b: B;\n  constructor(c: C) {\n  }\n}\n\ninterface C {}\n\nclass BBase {\n\n}\n\ninterface IBase {\n}\n\nclass B extends BBase implements IBase {\n  private constructor(prop: CtorProp) {}\n  prop: PropValue;\n  method(): ReturnValue {\n  }\n\n  method2(other: Param): void {\n  }\n\n  private asdf(private: PrivateParam): PrivateReturn {\n  }\n\n  private prop: PrivateProp;\n\n  methodOverload(param: OverloadParam): OverloadReturn;\n  methodOverload(param: PrivateImplementationParam): PrivateImplementationReturn {\n  }\n\n  #private: PrivateProp;\n  #privateMethod(private: PrivateParam): PrivateReturn {\n  }\n}\n\nclass PropValue {}\nclass ReturnValue {}\nclass Param {}\nclass PrivateParam {}\nclass PrivateReturn {}\nclass PrivateProp {}\nclass CtorProp {}\nclass OverloadParam {}\nclass OverloadReturn {}\nclass PrivateImplementationParam {}\nclass PrivateImplementationReturn {}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/Classes01.txt
+++ b/tests/specs/symbols/Classes01.txt
@@ -55,93 +55,72 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        0,
-        3,
-        4,
-        5,
-        6,
-        12,
-        13,
-        14,
-        15,
-        16,
-        17,
-        18,
-        19,
-        20,
-        21,
-        22,
-    },
-    exports: {
-        "A": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "A",
             #2,
-        ): 0,
+        ): 1,
         (
             "C",
             #2,
-        ): 3,
+        ): 4,
         (
             "BBase",
             #2,
-        ): 4,
+        ): 5,
         (
             "IBase",
             #2,
-        ): 5,
+        ): 6,
         (
             "B",
             #2,
-        ): 6,
+        ): 7,
         (
             "PropValue",
             #2,
-        ): 12,
+        ): 13,
         (
             "ReturnValue",
             #2,
-        ): 13,
+        ): 14,
         (
             "Param",
             #2,
-        ): 14,
+        ): 15,
         (
             "PrivateParam",
             #2,
-        ): 15,
+        ): 16,
         (
             "PrivateReturn",
             #2,
-        ): 16,
+        ): 17,
         (
             "PrivateProp",
             #2,
-        ): 17,
+        ): 18,
         (
             "CtorProp",
             #2,
-        ): 18,
+        ): 19,
         (
             "OverloadParam",
             #2,
-        ): 19,
+        ): 20,
         (
             "OverloadReturn",
             #2,
-        ): 20,
+        ): 21,
         (
             "PrivateImplementationParam",
             #2,
-        ): 21,
+        ): 22,
         (
             "PrivateImplementationReturn",
             #2,
-        ): 22,
+        ): 23,
     },
     symbols: {
         0: Symbol {
@@ -149,6 +128,36 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+                4,
+                5,
+                6,
+                7,
+                13,
+                14,
+                15,
+                16,
+                17,
+                18,
+                19,
+                20,
+                21,
+                22,
+                23,
+            },
+            exports: {
+                "A": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -170,15 +179,15 @@ file:///mod.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                1,
                 2,
+                3,
             },
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -208,11 +217,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -242,11 +251,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -269,11 +278,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        4: Symbol {
+        5: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 4,
+            symbol_id: 5,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -296,11 +305,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        5: Symbol {
+        6: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 5,
+            symbol_id: 6,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -323,11 +332,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        6: Symbol {
+        7: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 6,
+            symbol_id: 7,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -362,18 +371,18 @@ file:///mod.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                7,
                 8,
                 9,
                 10,
                 11,
+                12,
             },
         },
-        7: Symbol {
+        8: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 7,
+            symbol_id: 8,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -403,11 +412,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        8: Symbol {
+        9: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 8,
+            symbol_id: 9,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -437,11 +446,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        9: Symbol {
+        10: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 9,
+            symbol_id: 10,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -471,11 +480,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        10: Symbol {
+        11: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 10,
+            symbol_id: 11,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -511,11 +520,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        11: Symbol {
+        12: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 11,
+            symbol_id: 12,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -551,11 +560,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        12: Symbol {
+        13: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 12,
+            symbol_id: 13,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -578,11 +587,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        13: Symbol {
+        14: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 13,
+            symbol_id: 14,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -605,11 +614,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        14: Symbol {
+        15: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 14,
+            symbol_id: 15,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -632,11 +641,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        15: Symbol {
+        16: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 15,
+            symbol_id: 16,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -659,11 +668,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        16: Symbol {
+        17: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 16,
+            symbol_id: 17,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -686,11 +695,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        17: Symbol {
+        18: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 17,
+            symbol_id: 18,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -713,11 +722,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        18: Symbol {
+        19: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 18,
+            symbol_id: 19,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -740,11 +749,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        19: Symbol {
+        20: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 19,
+            symbol_id: 20,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -767,11 +776,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        20: Symbol {
+        21: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 20,
+            symbol_id: 21,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -794,11 +803,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        21: Symbol {
+        22: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 21,
+            symbol_id: 22,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -821,11 +830,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        22: Symbol {
+        23: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 22,
+            symbol_id: 23,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/Classes01.txt
+++ b/tests/specs/symbols/Classes01.txt
@@ -50,7 +50,7 @@ class PrivateImplementationParam {}
 class PrivateImplementationReturn {}
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/DeclarationMerging01.txt
+++ b/tests/specs/symbols/DeclarationMerging01.txt
@@ -25,7 +25,7 @@ namespace Test {
 export { Album, Color, Test };
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/DeclarationMerging01.txt
+++ b/tests/specs/symbols/DeclarationMerging01.txt
@@ -30,42 +30,32 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        0,
-        2,
-        4,
-    },
-    exports: {
-        "Album": 0,
-        "Color": 2,
-        "Test": 4,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "Album",
             #2,
-        ): 0,
+        ): 1,
         (
             "Label",
             #3,
-        ): 1,
+        ): 2,
         (
             "Color",
             #2,
-        ): 2,
+        ): 3,
         (
             "mixColor",
             #4,
-        ): 3,
+        ): 4,
         (
             "Test",
             #2,
-        ): 4,
+        ): 5,
         (
             "other",
             #7,
-        ): 5,
+        ): 6,
     },
     symbols: {
         0: Symbol {
@@ -73,6 +63,25 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+                3,
+                5,
+            },
+            exports: {
+                "Album": 1,
+                "Color": 3,
+                "Test": 5,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -136,18 +145,18 @@ file:///mod.ts: EsmModuleSymbol {
                 ),
             },
             child_ids: {
-                1,
+                2,
             },
             exports: {
-                "Label": 1,
+                "Label": 2,
             },
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -170,11 +179,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -238,18 +247,18 @@ file:///mod.ts: EsmModuleSymbol {
                 ),
             },
             child_ids: {
-                3,
+                4,
             },
             exports: {
-                "mixColor": 3,
+                "mixColor": 4,
             },
             members: {},
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -272,11 +281,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        4: Symbol {
+        5: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 4,
+            symbol_id: 5,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -340,18 +349,18 @@ file:///mod.ts: EsmModuleSymbol {
                 ),
             },
             child_ids: {
-                5,
+                6,
             },
             exports: {
-                "other": 5,
+                "other": 6,
             },
             members: {},
         },
-        5: Symbol {
+        6: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 5,
+            symbol_id: 6,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/DeclarationMerging01.txt
+++ b/tests/specs/symbols/DeclarationMerging01.txt
@@ -63,7 +63,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            289,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "class Album {\n}\nnamespace Album {\n  export class Label {}\n}\n\nenum Color {\n  red,\n  green,\n  blue,\n}\nnamespace Color {\n  export function mixColor(colorName: string) {\n    // ...etc...\n  }\n}\n\nfunction Test() {\n}\nnamespace Test {\n  export function other() {}\n}\n\nexport { Album, Color, Test };",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/ExportAssignment01.txt
+++ b/tests/specs/symbols/ExportAssignment01.txt
@@ -11,18 +11,12 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        0,
-    },
-    exports: {
-        "default": 1,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "test",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -30,6 +24,21 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+            },
+            exports: {
+                "default": 2,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -68,11 +77,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/ExportAssignment01.txt
+++ b/tests/specs/symbols/ExportAssignment01.txt
@@ -6,7 +6,7 @@ function test() {
 export = test;
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportAssignment01.txt
+++ b/tests/specs/symbols/ExportAssignment01.txt
@@ -24,7 +24,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            80,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "function test() {\n}\n\n// this will be treated as an export default\nexport = test;",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/ExportDefault01.txt
+++ b/tests/specs/symbols/ExportDefault01.txt
@@ -71,7 +71,23 @@ file:///a.ts: EsmModuleInfo {
                 1,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            272,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export { default as C1 } from \"./class.ts\";\nexport { default as C2 } from \"./function.ts\";\nexport { default as C3 } from \"./interface.ts\";\n\nexport default class Test {\n    prop: A;\n}\n\nclass A {\n    a: number;\n    b: B;\n}\n\nclass B {\n    b: number;\n    #c: C;\n}\n\nclass C {\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 6,
@@ -433,7 +449,23 @@ file:///class.ts: EsmModuleInfo {
                 2,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            29,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export default class Test {\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {},
             exports: {
@@ -488,7 +520,23 @@ file:///function.ts: EsmModuleInfo {
                 3,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            34,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export default function Test() {\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {},
             exports: {
@@ -543,7 +591,23 @@ file:///interface.ts: EsmModuleInfo {
                 4,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            33,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export default interface Test {\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {},
             exports: {
@@ -610,7 +674,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            131,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "import Test from \"./a.ts\";\nimport { C1, C2, C3 as CInterface } from \"./a.ts\";\n\nexport default Test;\n\nexport { C1, C2, CInterface };",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {},
             exports: {

--- a/tests/specs/symbols/ExportDefault01.txt
+++ b/tests/specs/symbols/ExportDefault01.txt
@@ -41,7 +41,7 @@ export default function Test() {
 }
 
 # output
-file:///a.ts: EsmModuleSymbol {
+file:///a.ts: EsmModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -415,7 +415,7 @@ file:///a.ts: EsmModuleSymbol {
         },
     },
 }
-file:///class.ts: EsmModuleSymbol {
+file:///class.ts: EsmModuleInfo {
     module_id: ModuleId(
         2,
     ),
@@ -470,7 +470,7 @@ file:///class.ts: EsmModuleSymbol {
         },
     },
 }
-file:///function.ts: EsmModuleSymbol {
+file:///function.ts: EsmModuleInfo {
     module_id: ModuleId(
         3,
     ),
@@ -525,7 +525,7 @@ file:///function.ts: EsmModuleSymbol {
         },
     },
 }
-file:///interface.ts: EsmModuleSymbol {
+file:///interface.ts: EsmModuleInfo {
     module_id: ModuleId(
         4,
     ),
@@ -580,7 +580,7 @@ file:///interface.ts: EsmModuleSymbol {
         },
     },
 }
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportDefault01.txt
+++ b/tests/specs/symbols/ExportDefault01.txt
@@ -46,35 +46,24 @@ file:///a.ts: EsmModuleSymbol {
         1,
     ),
     specifier: "file:///a.ts",
-    child_ids: {
-        5,
-        8,
-        10,
-    },
-    exports: {
-        "C1": 0,
-        "C2": 1,
-        "C3": 2,
-        "default": 3,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "Test",
             #2,
-        ): 3,
+        ): 4,
         (
             "A",
             #2,
-        ): 5,
+        ): 6,
         (
             "B",
             #2,
-        ): 8,
+        ): 9,
         (
             "C",
             #2,
-        ): 10,
+        ): 11,
     },
     symbols: {
         0: Symbol {
@@ -82,6 +71,26 @@ file:///a.ts: EsmModuleSymbol {
                 1,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                6,
+                9,
+                11,
+            },
+            exports: {
+                "C1": 1,
+                "C2": 2,
+                "C3": 3,
+                "default": 4,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                1,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -107,11 +116,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -137,11 +146,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -167,11 +176,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -193,14 +202,14 @@ file:///a.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                4,
+                5,
             },
         },
-        4: Symbol {
+        5: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 4,
+            symbol_id: 5,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -230,11 +239,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        5: Symbol {
+        6: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 5,
+            symbol_id: 6,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -256,15 +265,15 @@ file:///a.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                6,
                 7,
+                8,
             },
         },
-        6: Symbol {
+        7: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 6,
+            symbol_id: 7,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -287,11 +296,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        7: Symbol {
+        8: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 7,
+            symbol_id: 8,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -321,11 +330,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        8: Symbol {
+        9: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 8,
+            symbol_id: 9,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -347,14 +356,14 @@ file:///a.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                9,
+                10,
             },
         },
-        9: Symbol {
+        10: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 9,
+            symbol_id: 10,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -377,11 +386,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        10: Symbol {
+        11: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 10,
+            symbol_id: 11,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -411,16 +420,12 @@ file:///class.ts: EsmModuleSymbol {
         2,
     ),
     specifier: "file:///class.ts",
-    child_ids: {},
-    exports: {
-        "default": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "Test",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -428,6 +433,19 @@ file:///class.ts: EsmModuleSymbol {
                 2,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {},
+            exports: {
+                "default": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                2,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -457,16 +475,12 @@ file:///function.ts: EsmModuleSymbol {
         3,
     ),
     specifier: "file:///function.ts",
-    child_ids: {},
-    exports: {
-        "default": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "Test",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -474,6 +488,19 @@ file:///function.ts: EsmModuleSymbol {
                 3,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {},
+            exports: {
+                "default": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                3,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -503,16 +530,12 @@ file:///interface.ts: EsmModuleSymbol {
         4,
     ),
     specifier: "file:///interface.ts",
-    child_ids: {},
-    exports: {
-        "default": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "Test",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -520,6 +543,19 @@ file:///interface.ts: EsmModuleSymbol {
                 4,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {},
+            exports: {
+                "default": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                4,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -549,31 +585,24 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {},
-    exports: {
-        "default": 4,
-        "C1": 1,
-        "C2": 2,
-        "CInterface": 3,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "Test",
             #2,
-        ): 0,
+        ): 1,
         (
             "C1",
             #2,
-        ): 1,
+        ): 2,
         (
             "C2",
             #2,
-        ): 2,
+        ): 3,
         (
             "CInterface",
             #2,
-        ): 3,
+        ): 4,
     },
     symbols: {
         0: Symbol {
@@ -581,6 +610,22 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {},
+            exports: {
+                "default": 5,
+                "C1": 2,
+                "C2": 3,
+                "CInterface": 4,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -622,11 +667,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -674,11 +719,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -726,11 +771,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -778,11 +823,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        4: Symbol {
+        5: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 4,
+            symbol_id: 5,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/ExportDefault02.txt
+++ b/tests/specs/symbols/ExportDefault02.txt
@@ -2,7 +2,7 @@
 export default Test; class Test {}
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportDefault02.txt
+++ b/tests/specs/symbols/ExportDefault02.txt
@@ -20,7 +20,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            34,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export default Test; class Test {}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 2,

--- a/tests/specs/symbols/ExportDefault02.txt
+++ b/tests/specs/symbols/ExportDefault02.txt
@@ -7,18 +7,12 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        1,
-    },
-    exports: {
-        "default": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "Test",
             #2,
-        ): 1,
+        ): 2,
     },
     symbols: {
         0: Symbol {
@@ -26,6 +20,21 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                2,
+            },
+            exports: {
+                "default": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -56,11 +65,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/ExportDefault03.txt
+++ b/tests/specs/symbols/ExportDefault03.txt
@@ -31,7 +31,23 @@ file:///a.ts: EsmModuleInfo {
                 1,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            64,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "import { B as Test } from \"./b.ts\";\n\nexport { Test as default };",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {},
             exports: {
@@ -104,7 +120,23 @@ file:///b.ts: EsmModuleInfo {
                 2,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            36,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export class B {}\nexport class B1 {}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,
@@ -190,7 +222,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            64,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export { default as Test2 } from \"./a.ts\";\n\nexport class Test {}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 2,

--- a/tests/specs/symbols/ExportDefault03.txt
+++ b/tests/specs/symbols/ExportDefault03.txt
@@ -18,16 +18,12 @@ file:///a.ts: EsmModuleSymbol {
         1,
     ),
     specifier: "file:///a.ts",
-    child_ids: {},
-    exports: {
-        "default": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "Test",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -35,6 +31,19 @@ file:///a.ts: EsmModuleSymbol {
                 1,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {},
+            exports: {
+                "default": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                1,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -78,24 +87,16 @@ file:///b.ts: EsmModuleSymbol {
         2,
     ),
     specifier: "file:///b.ts",
-    child_ids: {
-        0,
-        1,
-    },
-    exports: {
-        "B": 0,
-        "B1": 1,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "B",
             #2,
-        ): 0,
+        ): 1,
         (
             "B1",
             #2,
-        ): 1,
+        ): 2,
     },
     symbols: {
         0: Symbol {
@@ -103,6 +104,23 @@ file:///b.ts: EsmModuleSymbol {
                 2,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+                2,
+            },
+            exports: {
+                "B": 1,
+                "B1": 2,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                2,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -125,11 +143,11 @@ file:///b.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 2,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -159,19 +177,12 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        1,
-    },
-    exports: {
-        "Test2": 0,
-        "Test": 1,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "Test",
             #2,
-        ): 1,
+        ): 2,
     },
     symbols: {
         0: Symbol {
@@ -179,6 +190,22 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                2,
+            },
+            exports: {
+                "Test2": 1,
+                "Test": 2,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -204,11 +231,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/ExportDefault03.txt
+++ b/tests/specs/symbols/ExportDefault03.txt
@@ -13,7 +13,7 @@ export class B {}
 export class B1 {}
 
 # output
-file:///a.ts: EsmModuleSymbol {
+file:///a.ts: EsmModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -82,7 +82,7 @@ file:///a.ts: EsmModuleSymbol {
         },
     },
 }
-file:///b.ts: EsmModuleSymbol {
+file:///b.ts: EsmModuleInfo {
     module_id: ModuleId(
         2,
     ),
@@ -172,7 +172,7 @@ file:///b.ts: EsmModuleSymbol {
         },
     },
 }
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportDefault04.txt
+++ b/tests/specs/symbols/ExportDefault04.txt
@@ -7,11 +7,21 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {},
-    exports: {},
     re_exports: [],
     swc_id_to_symbol_id: {},
-    symbols: {},
+    symbols: {
+        0: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {},
+            exports: {},
+            members: {},
+        },
+    },
 }
 
 # diagnostics

--- a/tests/specs/symbols/ExportDefault04.txt
+++ b/tests/specs/symbols/ExportDefault04.txt
@@ -15,7 +15,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            21,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export default 1 + 1;",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {},
             exports: {},

--- a/tests/specs/symbols/ExportDefault04.txt
+++ b/tests/specs/symbols/ExportDefault04.txt
@@ -2,7 +2,7 @@
 export default 1 + 1;
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportDefaultLiteral01.txt
+++ b/tests/specs/symbols/ExportDefaultLiteral01.txt
@@ -2,7 +2,7 @@
 export default 1;
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportDefaultLiteral01.txt
+++ b/tests/specs/symbols/ExportDefaultLiteral01.txt
@@ -7,10 +7,6 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {},
-    exports: {
-        "default": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {},
     symbols: {
@@ -19,6 +15,19 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {},
+            exports: {
+                "default": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/ExportDefaultLiteral01.txt
+++ b/tests/specs/symbols/ExportDefaultLiteral01.txt
@@ -15,7 +15,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            17,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export default 1;",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {},
             exports: {

--- a/tests/specs/symbols/ExportDefaultLiteral02.txt
+++ b/tests/specs/symbols/ExportDefaultLiteral02.txt
@@ -15,7 +15,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            22,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export default \"test\";",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {},
             exports: {

--- a/tests/specs/symbols/ExportDefaultLiteral02.txt
+++ b/tests/specs/symbols/ExportDefaultLiteral02.txt
@@ -2,7 +2,7 @@
 export default "test";
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportDefaultLiteral02.txt
+++ b/tests/specs/symbols/ExportDefaultLiteral02.txt
@@ -7,10 +7,6 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {},
-    exports: {
-        "default": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {},
     symbols: {
@@ -19,6 +15,19 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {},
+            exports: {
+                "default": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/ExportDestructured.txt
+++ b/tests/specs/symbols/ExportDestructured.txt
@@ -20,33 +20,24 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        0,
-        1,
-        2,
-    },
-    exports: {
-        "a": 3,
-        "b": 4,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "c",
             #2,
-        ): 0,
+        ): 1,
         (
             "d",
             #2,
-        ): 1,
+        ): 2,
         (
             "a",
             #2,
-        ): 3,
+        ): 4,
         (
             "b",
             #2,
-        ): 4,
+        ): 5,
     },
     symbols: {
         0: Symbol {
@@ -54,6 +45,24 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+                2,
+                3,
+            },
+            exports: {
+                "a": 4,
+                "b": 5,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -76,11 +85,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -116,11 +125,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -152,11 +161,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -192,11 +201,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        4: Symbol {
+        5: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 4,
+            symbol_id: 5,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/ExportDestructured.txt
+++ b/tests/specs/symbols/ExportDestructured.txt
@@ -15,7 +15,7 @@ export const {
 } = c;
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportDestructured.txt
+++ b/tests/specs/symbols/ExportDestructured.txt
@@ -45,7 +45,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            233,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "const c = { a: \"a\", b: 2 };\nconst d: { f: string; g: number; } = { f: \"f\", g: 2 };\n\nexport const {\n  /** export a doc */\n  a,\n  /** export b doc */\n  b,\n}: {\n  /** type alias doc */\n  a: string;\n  /** other doc */\n  b: number;\n} = c;",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/ExportStar01.txt
+++ b/tests/specs/symbols/ExportStar01.txt
@@ -41,35 +41,24 @@ file:///a.ts: EsmModuleSymbol {
         1,
     ),
     specifier: "file:///a.ts",
-    child_ids: {
-        5,
-        8,
-        10,
-    },
-    exports: {
-        "C1": 0,
-        "C2": 1,
-        "C3": 2,
-        "default": 3,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "Test",
             #2,
-        ): 3,
+        ): 4,
         (
             "A",
             #2,
-        ): 5,
+        ): 6,
         (
             "B",
             #2,
-        ): 8,
+        ): 9,
         (
             "C",
             #2,
-        ): 10,
+        ): 11,
     },
     symbols: {
         0: Symbol {
@@ -77,6 +66,26 @@ file:///a.ts: EsmModuleSymbol {
                 1,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                6,
+                9,
+                11,
+            },
+            exports: {
+                "C1": 1,
+                "C2": 2,
+                "C3": 3,
+                "default": 4,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                1,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -102,11 +111,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -132,11 +141,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -162,11 +171,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -188,14 +197,14 @@ file:///a.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                4,
+                5,
             },
         },
-        4: Symbol {
+        5: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 4,
+            symbol_id: 5,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -225,11 +234,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        5: Symbol {
+        6: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 5,
+            symbol_id: 6,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -251,15 +260,15 @@ file:///a.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                6,
                 7,
+                8,
             },
         },
-        6: Symbol {
+        7: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 6,
+            symbol_id: 7,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -282,11 +291,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        7: Symbol {
+        8: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 7,
+            symbol_id: 8,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -316,11 +325,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        8: Symbol {
+        9: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 8,
+            symbol_id: 9,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -342,14 +351,14 @@ file:///a.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                9,
+                10,
             },
         },
-        9: Symbol {
+        10: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 9,
+            symbol_id: 10,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -372,11 +381,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        10: Symbol {
+        11: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 10,
+            symbol_id: 11,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -406,16 +415,12 @@ file:///class.ts: EsmModuleSymbol {
         2,
     ),
     specifier: "file:///class.ts",
-    child_ids: {},
-    exports: {
-        "default": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "Test",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -423,6 +428,19 @@ file:///class.ts: EsmModuleSymbol {
                 2,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {},
+            exports: {
+                "default": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                2,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -452,16 +470,12 @@ file:///function.ts: EsmModuleSymbol {
         3,
     ),
     specifier: "file:///function.ts",
-    child_ids: {},
-    exports: {
-        "default": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "Test",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -469,6 +483,19 @@ file:///function.ts: EsmModuleSymbol {
                 3,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {},
+            exports: {
+                "default": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                3,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -498,16 +525,12 @@ file:///interface.ts: EsmModuleSymbol {
         4,
     ),
     specifier: "file:///interface.ts",
-    child_ids: {},
-    exports: {
-        "default": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "Test",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -515,6 +538,19 @@ file:///interface.ts: EsmModuleSymbol {
                 4,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {},
+            exports: {
+                "default": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                4,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -544,10 +580,6 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {},
-    exports: {
-        "namespace": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {},
     symbols: {
@@ -556,6 +588,19 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {},
+            exports: {
+                "namespace": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/ExportStar01.txt
+++ b/tests/specs/symbols/ExportStar01.txt
@@ -66,7 +66,23 @@ file:///a.ts: EsmModuleInfo {
                 1,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            272,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export { default as C1 } from \"./class.ts\";\nexport { default as C2 } from \"./function.ts\";\nexport { default as C3 } from \"./interface.ts\";\n\nexport default class Test {\n    prop: A;\n}\n\nclass A {\n    a: number;\n    b: B;\n}\n\nclass B {\n    b: number;\n    #c: C;\n}\n\nclass C {\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 6,
@@ -428,7 +444,23 @@ file:///class.ts: EsmModuleInfo {
                 2,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            29,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export default class Test {\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {},
             exports: {
@@ -483,7 +515,23 @@ file:///function.ts: EsmModuleInfo {
                 3,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            34,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export default function Test() {\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {},
             exports: {
@@ -538,7 +586,23 @@ file:///interface.ts: EsmModuleInfo {
                 4,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            33,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export default interface Test {\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {},
             exports: {
@@ -588,7 +652,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            36,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export * as namespace from \"./a.ts\";",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {},
             exports: {

--- a/tests/specs/symbols/ExportStar01.txt
+++ b/tests/specs/symbols/ExportStar01.txt
@@ -36,7 +36,7 @@ export default function Test() {
 }
 
 # output
-file:///a.ts: EsmModuleSymbol {
+file:///a.ts: EsmModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -410,7 +410,7 @@ file:///a.ts: EsmModuleSymbol {
         },
     },
 }
-file:///class.ts: EsmModuleSymbol {
+file:///class.ts: EsmModuleInfo {
     module_id: ModuleId(
         2,
     ),
@@ -465,7 +465,7 @@ file:///class.ts: EsmModuleSymbol {
         },
     },
 }
-file:///function.ts: EsmModuleSymbol {
+file:///function.ts: EsmModuleInfo {
     module_id: ModuleId(
         3,
     ),
@@ -520,7 +520,7 @@ file:///function.ts: EsmModuleSymbol {
         },
     },
 }
-file:///interface.ts: EsmModuleSymbol {
+file:///interface.ts: EsmModuleInfo {
     module_id: ModuleId(
         4,
     ),
@@ -575,7 +575,7 @@ file:///interface.ts: EsmModuleSymbol {
         },
     },
 }
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportedDeclare01.txt
+++ b/tests/specs/symbols/ExportedDeclare01.txt
@@ -51,7 +51,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            246,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "declare function foo(): void;\ndeclare namespace Test {\n  function test(): void;\n  export { test };\n}\nclass Other {}\ndeclare class MyClass {\n  method(): void;\n  prop: Other;\n}\nimport inner = Test.test;\nexport { foo as bar, inner as baz, MyClass };",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/ExportedDeclare01.txt
+++ b/tests/specs/symbols/ExportedDeclare01.txt
@@ -18,43 +18,32 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        0,
-        1,
-        3,
-        4,
-    },
-    exports: {
-        "bar": 0,
-        "baz": 7,
-        "MyClass": 4,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "foo",
             #2,
-        ): 0,
+        ): 1,
         (
             "Test",
             #2,
-        ): 1,
+        ): 2,
         (
             "test",
             #4,
-        ): 2,
+        ): 3,
         (
             "Other",
             #2,
-        ): 3,
+        ): 4,
         (
             "MyClass",
             #2,
-        ): 4,
+        ): 5,
         (
             "inner",
             #2,
-        ): 7,
+        ): 8,
     },
     symbols: {
         0: Symbol {
@@ -62,6 +51,26 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+                2,
+                4,
+                5,
+            },
+            exports: {
+                "bar": 1,
+                "baz": 8,
+                "MyClass": 5,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -95,11 +104,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -119,18 +128,18 @@ file:///mod.ts: EsmModuleSymbol {
             ],
             deps: {},
             child_ids: {
-                2,
+                3,
             },
             exports: {
-                "test": 2,
+                "test": 3,
             },
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -175,11 +184,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -202,11 +211,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        4: Symbol {
+        5: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 4,
+            symbol_id: 5,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -250,15 +259,15 @@ file:///mod.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                5,
                 6,
+                7,
             },
         },
-        5: Symbol {
+        6: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 5,
+            symbol_id: 6,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -281,11 +290,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        6: Symbol {
+        7: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 6,
+            symbol_id: 7,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -315,11 +324,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        7: Symbol {
+        8: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 7,
+            symbol_id: 8,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/ExportedDeclare01.txt
+++ b/tests/specs/symbols/ExportedDeclare01.txt
@@ -13,7 +13,7 @@ import inner = Test.test;
 export { foo as bar, inner as baz, MyClass };
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportedDeclare02.txt
+++ b/tests/specs/symbols/ExportedDeclare02.txt
@@ -3,7 +3,7 @@ declare function foo(): number;
 export function bar() {};
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportedDeclare02.txt
+++ b/tests/specs/symbols/ExportedDeclare02.txt
@@ -8,23 +8,16 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        0,
-        1,
-    },
-    exports: {
-        "bar": 1,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "foo",
             #2,
-        ): 0,
+        ): 1,
         (
             "bar",
             #2,
-        ): 1,
+        ): 2,
     },
     symbols: {
         0: Symbol {
@@ -32,6 +25,22 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+                2,
+            },
+            exports: {
+                "bar": 2,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -54,11 +63,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/ExportedDeclare02.txt
+++ b/tests/specs/symbols/ExportedDeclare02.txt
@@ -25,7 +25,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            57,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "declare function foo(): number;\nexport function bar() {};",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/FunctionOverloads01.txt
+++ b/tests/specs/symbols/FunctionOverloads01.txt
@@ -20,32 +20,24 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        0,
-        1,
-    },
-    exports: {
-        "test": 0,
-        "InnerInner": 3,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "test",
             #2,
-        ): 0,
+        ): 1,
         (
             "Inner",
             #2,
-        ): 1,
+        ): 2,
         (
             "inner",
             #6,
-        ): 2,
+        ): 3,
         (
             "InnerInner",
             #2,
-        ): 3,
+        ): 4,
     },
     symbols: {
         0: Symbol {
@@ -53,6 +45,23 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+                2,
+            },
+            exports: {
+                "test": 1,
+                "InnerInner": 4,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -105,11 +114,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -136,18 +145,18 @@ file:///mod.ts: EsmModuleSymbol {
                 ),
             },
             child_ids: {
-                2,
+                3,
             },
             exports: {
-                "inner": 2,
+                "inner": 3,
             },
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -200,11 +209,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/FunctionOverloads01.txt
+++ b/tests/specs/symbols/FunctionOverloads01.txt
@@ -45,7 +45,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            334,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export function test(value: number);\nexport function test(value: string);\nexport function test(value: string | number) {\n}\n\nnamespace Inner {\n  export function inner(value: number);\n  export function inner(value: string);\n  export function inner(value: string | number) {\n  }\n}\n\nimport InnerInner = Inner.inner;\nexport { InnerInner };",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/FunctionOverloads01.txt
+++ b/tests/specs/symbols/FunctionOverloads01.txt
@@ -15,7 +15,7 @@ import InnerInner = Inner.inner;
 export { InnerInner };
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/Functions01.txt
+++ b/tests/specs/symbols/Functions01.txt
@@ -84,7 +84,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            575,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export function test<T extends TypeParam = Default>(param: Param): Return {\n}\n\nclass TypeParam {}\nclass Param {}\nclass Return {}\nclass Default {}\n\n// the top two overloads should appear in the results\nexport function overloaded<T extends OverloadTypeParam>(param: OverloadParam): OverloadReturn;\nexport function overloaded(): string;\nexport function overloaded<T extends PrivateTypeParam>(param: PrivateParam): PrivateReturn {\n}\n\nclass OverloadTypeParam {}\nclass OverloadParam {}\nclass OverloadReturn {}\n\nclass PrivateTypeParam {}\nclass PrivateParam {}\nclass PrivateReturn {}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/Functions01.txt
+++ b/tests/specs/symbols/Functions01.txt
@@ -22,7 +22,7 @@ class PrivateParam {}
 class PrivateReturn {}
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/Functions01.txt
+++ b/tests/specs/symbols/Functions01.txt
@@ -27,74 +27,56 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-    },
-    exports: {
-        "test": 0,
-        "overloaded": 5,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "test",
             #2,
-        ): 0,
+        ): 1,
         (
             "TypeParam",
             #2,
-        ): 1,
+        ): 2,
         (
             "Param",
             #2,
-        ): 2,
+        ): 3,
         (
             "Return",
             #2,
-        ): 3,
+        ): 4,
         (
             "Default",
             #2,
-        ): 4,
+        ): 5,
         (
             "overloaded",
             #2,
-        ): 5,
+        ): 6,
         (
             "OverloadTypeParam",
             #2,
-        ): 6,
+        ): 7,
         (
             "OverloadParam",
             #2,
-        ): 7,
+        ): 8,
         (
             "OverloadReturn",
             #2,
-        ): 8,
+        ): 9,
         (
             "PrivateTypeParam",
             #2,
-        ): 9,
+        ): 10,
         (
             "PrivateParam",
             #2,
-        ): 10,
+        ): 11,
         (
             "PrivateReturn",
             #2,
-        ): 11,
+        ): 12,
     },
     symbols: {
         0: Symbol {
@@ -102,6 +84,33 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12,
+            },
+            exports: {
+                "test": 1,
+                "overloaded": 6,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -149,11 +158,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -176,11 +185,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -203,11 +212,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -230,11 +239,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        4: Symbol {
+        5: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 4,
+            symbol_id: 5,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -257,11 +266,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        5: Symbol {
+        6: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 5,
+            symbol_id: 6,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -333,11 +342,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        6: Symbol {
+        7: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 6,
+            symbol_id: 7,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -360,11 +369,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        7: Symbol {
+        8: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 7,
+            symbol_id: 8,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -387,11 +396,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        8: Symbol {
+        9: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 8,
+            symbol_id: 9,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -414,11 +423,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        9: Symbol {
+        10: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 9,
+            symbol_id: 10,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -441,11 +450,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        10: Symbol {
+        11: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 10,
+            symbol_id: 11,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -468,11 +477,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        11: Symbol {
+        12: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 11,
+            symbol_id: 12,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/ImportEquals01.txt
+++ b/tests/specs/symbols/ImportEquals01.txt
@@ -33,7 +33,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            83,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export import MyExport = Test.Inner;\n\nnamespace Test {\n  export class Inner {\n  }\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 2,

--- a/tests/specs/symbols/ImportEquals01.txt
+++ b/tests/specs/symbols/ImportEquals01.txt
@@ -7,7 +7,7 @@ namespace Test {
 }
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ImportEquals01.txt
+++ b/tests/specs/symbols/ImportEquals01.txt
@@ -12,26 +12,20 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        1,
-    },
-    exports: {
-        "MyExport": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "MyExport",
             #2,
-        ): 0,
+        ): 1,
         (
             "Test",
             #2,
-        ): 1,
+        ): 2,
         (
             "Inner",
             #3,
-        ): 2,
+        ): 3,
     },
     symbols: {
         0: Symbol {
@@ -39,6 +33,21 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                2,
+            },
+            exports: {
+                "MyExport": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -75,11 +84,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -106,18 +115,18 @@ file:///mod.ts: EsmModuleSymbol {
                 ),
             },
             child_ids: {
-                2,
+                3,
             },
             exports: {
-                "Inner": 2,
+                "Inner": 3,
             },
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/ImportEquals02.txt
+++ b/tests/specs/symbols/ImportEquals02.txt
@@ -55,7 +55,23 @@ file:///a.ts: EsmModuleInfo {
                 1,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            195,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "namespace A.B {\n  export interface Other {\n    prop1: string;\n  }\n  export interface Other {\n    prop2: string;\n  }\n  export namespace Other {\n    export class MyTest {\n    }\n  }\n}\n\nexport { A };",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,
@@ -351,7 +367,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            152,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "import { A } from \"./a.ts\";\n\nexport import MyExport = Test.Inner;\n\nnamespace Test {\n  import OtherInner = A.B.Other;\n  export { OtherInner as Inner };\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 3,

--- a/tests/specs/symbols/ImportEquals02.txt
+++ b/tests/specs/symbols/ImportEquals02.txt
@@ -25,7 +25,7 @@ namespace A.B {
 export { A };
 
 # output
-file:///a.ts: EsmModuleSymbol {
+file:///a.ts: EsmModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -321,7 +321,7 @@ file:///a.ts: EsmModuleSymbol {
         },
     },
 }
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ImportEquals02.txt
+++ b/tests/specs/symbols/ImportEquals02.txt
@@ -30,30 +30,24 @@ file:///a.ts: EsmModuleSymbol {
         1,
     ),
     specifier: "file:///a.ts",
-    child_ids: {
-        0,
-    },
-    exports: {
-        "A": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "A",
             #2,
-        ): 0,
+        ): 1,
         (
             "B",
             #3,
-        ): 1,
+        ): 2,
         (
             "Other",
             #3,
-        ): 2,
+        ): 3,
         (
             "MyTest",
             #4,
-        ): 5,
+        ): 6,
     },
     symbols: {
         0: Symbol {
@@ -61,6 +55,21 @@ file:///a.ts: EsmModuleSymbol {
                 1,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+            },
+            exports: {
+                "A": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                1,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -110,15 +119,15 @@ file:///a.ts: EsmModuleSymbol {
             },
             child_ids: {},
             exports: {
-                "B": 1,
+                "B": 2,
             },
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -151,18 +160,18 @@ file:///a.ts: EsmModuleSymbol {
                 ),
             },
             child_ids: {
-                2,
+                3,
             },
             exports: {
-                "Other": 2,
+                "Other": 3,
             },
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -219,21 +228,21 @@ file:///a.ts: EsmModuleSymbol {
                 ),
             },
             child_ids: {
-                5,
+                6,
             },
             exports: {
-                "MyTest": 5,
+                "MyTest": 6,
             },
             members: {
-                3,
                 4,
+                5,
             },
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -256,11 +265,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        4: Symbol {
+        5: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 4,
+            symbol_id: 5,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -283,11 +292,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        5: Symbol {
+        6: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 5,
+            symbol_id: 6,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -317,30 +326,24 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        2,
-    },
-    exports: {
-        "MyExport": 1,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "A",
             #2,
-        ): 0,
+        ): 1,
         (
             "MyExport",
             #2,
-        ): 1,
+        ): 2,
         (
             "Test",
             #2,
-        ): 2,
+        ): 3,
         (
             "OtherInner",
             #3,
-        ): 3,
+        ): 4,
     },
     symbols: {
         0: Symbol {
@@ -348,6 +351,21 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                3,
+            },
+            exports: {
+                "MyExport": 2,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -373,11 +391,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -414,11 +432,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -439,15 +457,15 @@ file:///mod.ts: EsmModuleSymbol {
             deps: {},
             child_ids: {},
             exports: {
-                "Inner": 3,
+                "Inner": 4,
             },
             members: {},
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/ImportType01.txt
+++ b/tests/specs/symbols/ImportType01.txt
@@ -11,7 +11,7 @@ export namespace A {
 }
 
 # output
-file:///a.ts: EsmModuleSymbol {
+file:///a.ts: EsmModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -139,7 +139,7 @@ file:///a.ts: EsmModuleSymbol {
         },
     },
 }
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ImportType01.txt
+++ b/tests/specs/symbols/ImportType01.txt
@@ -16,22 +16,16 @@ file:///a.ts: EsmModuleSymbol {
         1,
     ),
     specifier: "file:///a.ts",
-    child_ids: {
-        0,
-    },
-    exports: {
-        "A": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "A",
             #2,
-        ): 0,
+        ): 1,
         (
             "B",
             #3,
-        ): 1,
+        ): 2,
     },
     symbols: {
         0: Symbol {
@@ -39,6 +33,21 @@ file:///a.ts: EsmModuleSymbol {
                 1,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+            },
+            exports: {
+                "A": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                1,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -65,18 +74,18 @@ file:///a.ts: EsmModuleSymbol {
                 ),
             },
             child_ids: {
-                1,
+                2,
             },
             exports: {
-                "B": 1,
+                "B": 2,
             },
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -98,14 +107,14 @@ file:///a.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                2,
+                3,
             },
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -135,18 +144,12 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        0,
-    },
-    exports: {
-        "Test": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "Test",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -154,6 +157,21 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+            },
+            exports: {
+                "Test": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -175,14 +193,14 @@ file:///mod.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                1,
+                2,
             },
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/ImportType01.txt
+++ b/tests/specs/symbols/ImportType01.txt
@@ -33,7 +33,23 @@ file:///a.ts: EsmModuleInfo {
                 1,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            67,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export namespace A {\n  export interface B {\n    prop: string,\n  }\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,
@@ -157,7 +173,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            55,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export interface Test {\n  prop: import(\"./a.ts\").A.B,\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/ImportType02.txt
+++ b/tests/specs/symbols/ImportType02.txt
@@ -16,23 +16,16 @@ file:///a.ts: EsmModuleSymbol {
         1,
     ),
     specifier: "file:///a.ts",
-    child_ids: {
-        0,
-    },
-    exports: {
-        "Test": 0,
-        "default": 2,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "Test",
             #2,
-        ): 0,
+        ): 1,
         (
             "test",
             #2,
-        ): 2,
+        ): 3,
     },
     symbols: {
         0: Symbol {
@@ -40,6 +33,22 @@ file:///a.ts: EsmModuleSymbol {
                 1,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+            },
+            exports: {
+                "Test": 1,
+                "default": 3,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                1,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -61,14 +70,14 @@ file:///a.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                1,
+                2,
             },
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -91,11 +100,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -125,18 +134,12 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        0,
-    },
-    exports: {
-        "Test": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "Test",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -144,6 +147,21 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+            },
+            exports: {
+                "Test": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/ImportType02.txt
+++ b/tests/specs/symbols/ImportType02.txt
@@ -11,7 +11,7 @@ export default function test() {
 }
 
 # output
-file:///a.ts: EsmModuleSymbol {
+file:///a.ts: EsmModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -129,7 +129,7 @@ file:///a.ts: EsmModuleSymbol {
         },
     },
 }
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ImportType02.txt
+++ b/tests/specs/symbols/ImportType02.txt
@@ -33,7 +33,23 @@ file:///a.ts: EsmModuleInfo {
                 1,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            151,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export interface Test {\n  prop: string;\n}\n\n// should be public because import types will include the default exports\nexport default function test() {\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,
@@ -147,7 +163,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            43,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export type Test = typeof import(\"./a.ts\");",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/Interfaces01.txt
+++ b/tests/specs/symbols/Interfaces01.txt
@@ -66,7 +66,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            283,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "interface A {\n}\n\nexport interface Main extends Extends {\n  prop: Prop;\n  method(method: Param): Return;\n  [key: string]: SignatureValueType;\n}\n\ninterface Extends {}\ninterface Prop {}\ninterface Param {}\ninterface Return {}\ninterface SignatureValueType {\n  other: B;\n}\n\ninterface B {\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/Interfaces01.txt
+++ b/tests/specs/symbols/Interfaces01.txt
@@ -20,7 +20,7 @@ interface B {
 }
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/Interfaces01.txt
+++ b/tests/specs/symbols/Interfaces01.txt
@@ -25,53 +25,40 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        0,
-        1,
-        5,
-        6,
-        7,
-        8,
-        9,
-        11,
-    },
-    exports: {
-        "Main": 1,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "A",
             #2,
-        ): 0,
+        ): 1,
         (
             "Main",
             #2,
-        ): 1,
+        ): 2,
         (
             "Extends",
             #2,
-        ): 5,
+        ): 6,
         (
             "Prop",
             #2,
-        ): 6,
+        ): 7,
         (
             "Param",
             #2,
-        ): 7,
+        ): 8,
         (
             "Return",
             #2,
-        ): 8,
+        ): 9,
         (
             "SignatureValueType",
             #2,
-        ): 9,
+        ): 10,
         (
             "B",
             #2,
-        ): 11,
+        ): 12,
     },
     symbols: {
         0: Symbol {
@@ -79,6 +66,28 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+                2,
+                6,
+                7,
+                8,
+                9,
+                10,
+                12,
+            },
+            exports: {
+                "Main": 2,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -101,11 +110,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -134,16 +143,16 @@ file:///mod.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                2,
                 3,
                 4,
+                5,
             },
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -173,11 +182,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -219,11 +228,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        4: Symbol {
+        5: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 4,
+            symbol_id: 5,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -259,11 +268,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        5: Symbol {
+        6: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 5,
+            symbol_id: 6,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -286,11 +295,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        6: Symbol {
+        7: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 6,
+            symbol_id: 7,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -313,11 +322,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        7: Symbol {
+        8: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 7,
+            symbol_id: 8,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -340,11 +349,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        8: Symbol {
+        9: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 8,
+            symbol_id: 9,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -367,11 +376,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        9: Symbol {
+        10: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 9,
+            symbol_id: 10,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -393,14 +402,14 @@ file:///mod.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                10,
+                11,
             },
         },
-        10: Symbol {
+        11: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 10,
+            symbol_id: 11,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -430,11 +439,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        11: Symbol {
+        12: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 11,
+            symbol_id: 12,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/Interfaces02.txt
+++ b/tests/specs/symbols/Interfaces02.txt
@@ -27,7 +27,7 @@ interface Prop2 {}
 export { A1 };
 
 # output
-file:///a.ts: EsmModuleSymbol {
+file:///a.ts: EsmModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -217,7 +217,7 @@ file:///a.ts: EsmModuleSymbol {
         },
     },
 }
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/Interfaces02.txt
+++ b/tests/specs/symbols/Interfaces02.txt
@@ -49,7 +49,23 @@ file:///a.ts: EsmModuleInfo {
                 1,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            102,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "interface A1 {\n  prop1: string;\n}\ninterface A1 {\n  prop2: Prop2;\n}\n\ninterface Prop2 {}\n\nexport { A1 };",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,
@@ -245,7 +261,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            23,
+                        ),
+                        end: SourcePos(
+                            174,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "interface Test {\n  prop1: Prop1;\n}\ninterface Test {\n  prop2: Prop2;\n}\n\ninterface Prop1 {}\ninterface Prop2 {}\n\nexport { Test };\n\nexport * from \"./a.ts\";",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/Interfaces02.txt
+++ b/tests/specs/symbols/Interfaces02.txt
@@ -32,23 +32,16 @@ file:///a.ts: EsmModuleSymbol {
         1,
     ),
     specifier: "file:///a.ts",
-    child_ids: {
-        0,
-        3,
-    },
-    exports: {
-        "A1": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "A1",
             #2,
-        ): 0,
+        ): 1,
         (
             "Prop2",
             #2,
-        ): 3,
+        ): 4,
     },
     symbols: {
         0: Symbol {
@@ -56,6 +49,22 @@ file:///a.ts: EsmModuleSymbol {
                 1,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+                4,
+            },
+            exports: {
+                "A1": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                1,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -114,15 +123,15 @@ file:///a.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                1,
                 2,
+                3,
             },
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -145,11 +154,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -179,11 +188,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -213,14 +222,6 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        0,
-        3,
-        4,
-    },
-    exports: {
-        "Test": 0,
-    },
     re_exports: [
         "./a.ts",
     ],
@@ -228,15 +229,15 @@ file:///mod.ts: EsmModuleSymbol {
         (
             "Test",
             #2,
-        ): 0,
+        ): 1,
         (
             "Prop1",
             #2,
-        ): 3,
+        ): 4,
         (
             "Prop2",
             #2,
-        ): 4,
+        ): 5,
     },
     symbols: {
         0: Symbol {
@@ -244,6 +245,23 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+                4,
+                5,
+            },
+            exports: {
+                "Test": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -302,15 +320,15 @@ file:///mod.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                1,
                 2,
+                3,
             },
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -340,11 +358,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -374,11 +392,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -401,11 +419,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        4: Symbol {
+        5: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 4,
+            symbol_id: 5,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/ModuleExportNameStr01.txt
+++ b/tests/specs/symbols/ModuleExportNameStr01.txt
@@ -18,16 +18,12 @@ file:///a.ts: EsmModuleSymbol {
         1,
     ),
     specifier: "file:///a.ts",
-    child_ids: {},
-    exports: {
-        "someName": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "someName",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -35,6 +31,19 @@ file:///a.ts: EsmModuleSymbol {
                 1,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {},
+            exports: {
+                "someName": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                1,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -78,10 +87,6 @@ file:///b.ts: EsmModuleSymbol {
         2,
     ),
     specifier: "file:///b.ts",
-    child_ids: {},
-    exports: {
-        "some-name": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {},
     symbols: {
@@ -90,6 +95,19 @@ file:///b.ts: EsmModuleSymbol {
                 2,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {},
+            exports: {
+                "some-name": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                2,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -122,18 +140,12 @@ file:///c.ts: EsmModuleSymbol {
         3,
     ),
     specifier: "file:///c.ts",
-    child_ids: {
-        0,
-    },
-    exports: {
-        "MyClass": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "MyClass",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -141,6 +153,21 @@ file:///c.ts: EsmModuleSymbol {
                 3,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+            },
+            exports: {
+                "MyClass": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                3,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -170,10 +197,6 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {},
-    exports: {
-        "someOtherName": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {},
     symbols: {
@@ -182,6 +205,19 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {},
+            exports: {
+                "someOtherName": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/ModuleExportNameStr01.txt
+++ b/tests/specs/symbols/ModuleExportNameStr01.txt
@@ -31,7 +31,23 @@ file:///a.ts: EsmModuleInfo {
                 1,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            85,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "import { \"some-name\" as someName } from \"./b.ts\";\n\nexport { someName as \"someName\" };",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {},
             exports: {
@@ -95,7 +111,23 @@ file:///b.ts: EsmModuleInfo {
                 2,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            48,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export { MyClass as \"some-name\" } from \"./c.ts\";",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {},
             exports: {
@@ -153,7 +185,23 @@ file:///c.ts: EsmModuleInfo {
                 3,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            23,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export class MyClass {}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,
@@ -205,7 +253,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            55,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export { \"someName\" as \"someOtherName\" } from \"./a.ts\";",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {},
             exports: {

--- a/tests/specs/symbols/ModuleExportNameStr01.txt
+++ b/tests/specs/symbols/ModuleExportNameStr01.txt
@@ -13,7 +13,7 @@ export { MyClass as "some-name" } from "./c.ts";
 export class MyClass {}
 
 # output
-file:///a.ts: EsmModuleSymbol {
+file:///a.ts: EsmModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -82,7 +82,7 @@ file:///a.ts: EsmModuleSymbol {
         },
     },
 }
-file:///b.ts: EsmModuleSymbol {
+file:///b.ts: EsmModuleInfo {
     module_id: ModuleId(
         2,
     ),
@@ -135,7 +135,7 @@ file:///b.ts: EsmModuleSymbol {
         },
     },
 }
-file:///c.ts: EsmModuleSymbol {
+file:///c.ts: EsmModuleInfo {
     module_id: ModuleId(
         3,
     ),
@@ -192,7 +192,7 @@ file:///c.ts: EsmModuleSymbol {
         },
     },
 }
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/Namespaces01.txt
+++ b/tests/specs/symbols/Namespaces01.txt
@@ -52,7 +52,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            228,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export namespace Namespace1 {\n  export function test() {\n  }\n}\nexport namespace Namespace1.Inner {\n  export function test2() {\n  }\n}\n\nimport test = Namespace1.test;\nimport test2 = Namespace1.Inner.test2;\n\nexport { test, test2 };",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/Namespaces01.txt
+++ b/tests/specs/symbols/Namespaces01.txt
@@ -19,40 +19,32 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        0,
-    },
-    exports: {
-        "Namespace1": 0,
-        "test": 4,
-        "test2": 5,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "Namespace1",
             #2,
-        ): 0,
+        ): 1,
         (
             "test",
             #3,
-        ): 1,
+        ): 2,
         (
             "Inner",
             #5,
-        ): 2,
+        ): 3,
         (
             "test2",
             #5,
-        ): 3,
+        ): 4,
         (
             "test",
             #2,
-        ): 4,
+        ): 5,
         (
             "test2",
             #2,
-        ): 5,
+        ): 6,
     },
     symbols: {
         0: Symbol {
@@ -60,6 +52,23 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+            },
+            exports: {
+                "Namespace1": 1,
+                "test": 5,
+                "test2": 6,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -107,19 +116,19 @@ file:///mod.ts: EsmModuleSymbol {
                 ),
             },
             child_ids: {
-                1,
+                2,
             },
             exports: {
-                "test": 1,
-                "Inner": 2,
+                "test": 2,
+                "Inner": 3,
             },
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -142,11 +151,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -179,18 +188,18 @@ file:///mod.ts: EsmModuleSymbol {
                 ),
             },
             child_ids: {
-                3,
+                4,
             },
             exports: {
-                "test2": 3,
+                "test2": 4,
             },
             members: {},
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -213,11 +222,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        4: Symbol {
+        5: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 4,
+            symbol_id: 5,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -276,11 +285,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        5: Symbol {
+        6: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 5,
+            symbol_id: 6,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/Namespaces01.txt
+++ b/tests/specs/symbols/Namespaces01.txt
@@ -14,7 +14,7 @@ import test2 = Namespace1.Inner.test2;
 export { test, test2 };
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/Namespaces02.txt
+++ b/tests/specs/symbols/Namespaces02.txt
@@ -10,7 +10,7 @@ export namespace RootNs {
 }
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/Namespaces02.txt
+++ b/tests/specs/symbols/Namespaces02.txt
@@ -15,30 +15,24 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        0,
-    },
-    exports: {
-        "RootNs": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "RootNs",
             #2,
-        ): 0,
+        ): 1,
         (
             "NestedNs",
             #3,
-        ): 1,
-        (
-            "Foo",
-            #4,
         ): 2,
         (
             "Foo",
-            #3,
+            #4,
         ): 3,
+        (
+            "Foo",
+            #3,
+        ): 4,
     },
     symbols: {
         0: Symbol {
@@ -46,6 +40,21 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+            },
+            exports: {
+                "RootNs": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -78,20 +87,20 @@ file:///mod.ts: EsmModuleSymbol {
                 ),
             },
             child_ids: {
-                1,
-                3,
+                2,
+                4,
             },
             exports: {
-                "NestedNs": 1,
-                "Foo": 3,
+                "NestedNs": 2,
+                "Foo": 4,
             },
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -118,18 +127,18 @@ file:///mod.ts: EsmModuleSymbol {
                 ),
             },
             child_ids: {
-                2,
+                3,
             },
             exports: {
-                "Foo": 2,
+                "Foo": 3,
             },
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -152,11 +161,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/Namespaces02.txt
+++ b/tests/specs/symbols/Namespaces02.txt
@@ -40,7 +40,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            114,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export namespace RootNs {\n  export namespace NestedNs {\n    export enum Foo {\n    }\n  }\n\n  export enum Foo {\n  }\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/ReExportJson01.txt
+++ b/tests/specs/symbols/ReExportJson01.txt
@@ -66,7 +66,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            157,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "import other from \"./non_public.json\" with { type: 'json' };\nexport { default as configFile } from './bar.json' assert { type: 'json' };\n\nconsole.log(other);",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {},
             exports: {

--- a/tests/specs/symbols/ReExportJson01.txt
+++ b/tests/specs/symbols/ReExportJson01.txt
@@ -21,7 +21,7 @@ file:///bar.json: JsonModuleSymbol {
     exports: {
         "default": 0,
     },
-    default_symbol: Symbol {
+    module_symbol: Symbol {
         module_id: ModuleId(
             1,
         ),
@@ -45,7 +45,9 @@ file:///bar.json: JsonModuleSymbol {
         ],
         deps: {},
         child_ids: {},
-        exports: {},
+        exports: {
+            "default": 0,
+        },
         members: {},
     },
 }
@@ -54,16 +56,12 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {},
-    exports: {
-        "configFile": 1,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "other",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -71,6 +69,19 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {},
+            exports: {
+                "configFile": 2,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -96,11 +107,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -136,7 +147,7 @@ file:///non_public.json: JsonModuleSymbol {
     exports: {
         "default": 0,
     },
-    default_symbol: Symbol {
+    module_symbol: Symbol {
         module_id: ModuleId(
             2,
         ),
@@ -160,7 +171,9 @@ file:///non_public.json: JsonModuleSymbol {
         ],
         deps: {},
         child_ids: {},
-        exports: {},
+        exports: {
+            "default": 0,
+        },
         members: {},
     },
 }

--- a/tests/specs/symbols/ReExportJson01.txt
+++ b/tests/specs/symbols/ReExportJson01.txt
@@ -13,7 +13,7 @@ console.log(other);
 {}
 
 # output
-file:///bar.json: JsonModuleSymbol {
+file:///bar.json: JsonModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -48,7 +48,7 @@ file:///bar.json: JsonModuleSymbol {
         members: {},
     },
 }
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),
@@ -136,7 +136,7 @@ file:///mod.ts: EsmModuleSymbol {
         },
     },
 }
-file:///non_public.json: JsonModuleSymbol {
+file:///non_public.json: JsonModuleInfo {
     module_id: ModuleId(
         2,
     ),

--- a/tests/specs/symbols/ReExportJson01.txt
+++ b/tests/specs/symbols/ReExportJson01.txt
@@ -18,9 +18,6 @@ file:///bar.json: JsonModuleSymbol {
         1,
     ),
     specifier: "file:///bar.json",
-    exports: {
-        "default": 0,
-    },
     module_symbol: Symbol {
         module_id: ModuleId(
             1,
@@ -46,7 +43,7 @@ file:///bar.json: JsonModuleSymbol {
         deps: {},
         child_ids: {},
         exports: {
-            "default": 0,
+            "default": 1,
         },
         members: {},
     },
@@ -144,9 +141,6 @@ file:///non_public.json: JsonModuleSymbol {
         2,
     ),
     specifier: "file:///non_public.json",
-    exports: {
-        "default": 0,
-    },
     module_symbol: Symbol {
         module_id: ModuleId(
             2,
@@ -172,7 +166,7 @@ file:///non_public.json: JsonModuleSymbol {
         deps: {},
         child_ids: {},
         exports: {
-            "default": 0,
+            "default": 1,
         },
         members: {},
     },

--- a/tests/specs/symbols/ReexportExport.txt
+++ b/tests/specs/symbols/ReexportExport.txt
@@ -3,7 +3,7 @@ export function foo(): void {}
 export { foo as bar };
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ReexportExport.txt
+++ b/tests/specs/symbols/ReexportExport.txt
@@ -8,19 +8,12 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        0,
-    },
-    exports: {
-        "foo": 0,
-        "bar": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "foo",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -28,6 +21,22 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+            },
+            exports: {
+                "foo": 1,
+                "bar": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/ReexportExport.txt
+++ b/tests/specs/symbols/ReexportExport.txt
@@ -21,7 +21,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            53,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export function foo(): void {}\nexport { foo as bar };",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/TsExternalModuleRef01.txt
+++ b/tests/specs/symbols/TsExternalModuleRef01.txt
@@ -11,7 +11,7 @@ namespace MyNamespace {
 export = MyNamespace;
 
 # output
-file:///a.ts: EsmModuleSymbol {
+file:///a.ts: EsmModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -161,7 +161,7 @@ file:///a.ts: EsmModuleSymbol {
         },
     },
 }
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/TsExternalModuleRef01.txt
+++ b/tests/specs/symbols/TsExternalModuleRef01.txt
@@ -33,7 +33,23 @@ file:///a.ts: EsmModuleInfo {
                 1,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            73,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "namespace MyNamespace {\n  export function B() {}\n}\n\nexport = MyNamespace;",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,
@@ -183,7 +199,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            61,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "import A = require(\"./a.ts\");\n\nexport type Test = typeof A.B;",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 2,

--- a/tests/specs/symbols/TsExternalModuleRef01.txt
+++ b/tests/specs/symbols/TsExternalModuleRef01.txt
@@ -16,22 +16,16 @@ file:///a.ts: EsmModuleSymbol {
         1,
     ),
     specifier: "file:///a.ts",
-    child_ids: {
-        0,
-    },
-    exports: {
-        "default": 2,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "MyNamespace",
             #2,
-        ): 0,
+        ): 1,
         (
             "B",
             #3,
-        ): 1,
+        ): 2,
     },
     symbols: {
         0: Symbol {
@@ -39,6 +33,21 @@ file:///a.ts: EsmModuleSymbol {
                 1,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+            },
+            exports: {
+                "default": 3,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                1,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -81,18 +90,18 @@ file:///a.ts: EsmModuleSymbol {
                 ),
             },
             child_ids: {
-                1,
+                2,
             },
             exports: {
-                "B": 1,
+                "B": 2,
             },
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -115,11 +124,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -157,22 +166,16 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        1,
-    },
-    exports: {
-        "Test": 1,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "A",
             #2,
-        ): 0,
+        ): 1,
         (
             "Test",
             #2,
-        ): 1,
+        ): 2,
     },
     symbols: {
         0: Symbol {
@@ -180,6 +183,21 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                2,
+            },
+            exports: {
+                "Test": 2,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -205,11 +223,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/TsExternalModuleRef02.txt
+++ b/tests/specs/symbols/TsExternalModuleRef02.txt
@@ -16,22 +16,16 @@ file:///a.ts: EsmModuleSymbol {
         1,
     ),
     specifier: "file:///a.ts",
-    child_ids: {
-        0,
-    },
-    exports: {
-        "default": 2,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "MyNamespace",
             #2,
-        ): 0,
+        ): 1,
         (
             "B",
             #3,
-        ): 1,
+        ): 2,
     },
     symbols: {
         0: Symbol {
@@ -39,6 +33,21 @@ file:///a.ts: EsmModuleSymbol {
                 1,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+            },
+            exports: {
+                "default": 3,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                1,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -81,18 +90,18 @@ file:///a.ts: EsmModuleSymbol {
                 ),
             },
             child_ids: {
-                1,
+                2,
             },
             exports: {
-                "B": 1,
+                "B": 2,
             },
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -115,11 +124,11 @@ file:///a.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -157,16 +166,12 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {},
-    exports: {
-        "default": 1,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "A",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -174,6 +179,19 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {},
+            exports: {
+                "default": 2,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -215,11 +233,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/TsExternalModuleRef02.txt
+++ b/tests/specs/symbols/TsExternalModuleRef02.txt
@@ -33,7 +33,23 @@ file:///a.ts: EsmModuleInfo {
                 1,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            73,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "namespace MyNamespace {\n  export function B() {}\n}\n\nexport = MyNamespace;",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,
@@ -179,7 +195,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            48,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "import A = require(\"./a.ts\");\n\nexport default A;",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {},
             exports: {

--- a/tests/specs/symbols/TsExternalModuleRef02.txt
+++ b/tests/specs/symbols/TsExternalModuleRef02.txt
@@ -11,7 +11,7 @@ namespace MyNamespace {
 export = MyNamespace;
 
 # output
-file:///a.ts: EsmModuleSymbol {
+file:///a.ts: EsmModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -161,7 +161,7 @@ file:///a.ts: EsmModuleSymbol {
         },
     },
 }
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/TsNamespaceExport01.txt
+++ b/tests/specs/symbols/TsNamespaceExport01.txt
@@ -8,7 +8,7 @@ export function isPrime(x: number): boolean {
 export as namespace mathLib;
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/TsNamespaceExport01.txt
+++ b/tests/specs/symbols/TsNamespaceExport01.txt
@@ -26,7 +26,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            187,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export function isPrime(x: number): boolean {\n  // ...\n}\n\n// we just ignore this because this causes typescript to\n// export this module as a \"mathLib\" global\nexport as namespace mathLib;",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/TsNamespaceExport01.txt
+++ b/tests/specs/symbols/TsNamespaceExport01.txt
@@ -13,18 +13,12 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        0,
-    },
-    exports: {
-        "isPrime": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "isPrime",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -32,6 +26,21 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+            },
+            exports: {
+                "isPrime": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/TsQualifiedName01.txt
+++ b/tests/specs/symbols/TsQualifiedName01.txt
@@ -38,7 +38,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            110,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export type Test = typeof Other.Test;\n\nnamespace Other {\n  export const Test = 1;\n\n  export const other = 2;\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/TsQualifiedName01.txt
+++ b/tests/specs/symbols/TsQualifiedName01.txt
@@ -13,31 +13,24 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        0,
-        1,
-    },
-    exports: {
-        "Test": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "Test",
             #2,
-        ): 0,
+        ): 1,
         (
             "Other",
             #2,
-        ): 1,
+        ): 2,
         (
             "Test",
             #3,
-        ): 3,
+        ): 4,
         (
             "other",
             #3,
-        ): 5,
+        ): 6,
     },
     symbols: {
         0: Symbol {
@@ -45,6 +38,22 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+                2,
+            },
+            exports: {
+                "Test": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -77,11 +86,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -114,20 +123,20 @@ file:///mod.ts: EsmModuleSymbol {
                 ),
             },
             child_ids: {
-                2,
-                4,
+                3,
+                5,
             },
             exports: {
-                "Test": 3,
-                "other": 5,
+                "Test": 4,
+                "other": 6,
             },
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -153,11 +162,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -180,11 +189,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        4: Symbol {
+        5: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 4,
+            symbol_id: 5,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -210,11 +219,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        5: Symbol {
+        6: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 5,
+            symbol_id: 6,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/TsQualifiedName01.txt
+++ b/tests/specs/symbols/TsQualifiedName01.txt
@@ -8,7 +8,7 @@ namespace Other {
 }
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/TypeAlias01.txt
+++ b/tests/specs/symbols/TypeAlias01.txt
@@ -31,7 +31,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            83,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export type Test<T extends Other> = Other2;\n\ninterface Other {}\ninterface Other2 {}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/TypeAlias01.txt
+++ b/tests/specs/symbols/TypeAlias01.txt
@@ -10,28 +10,20 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        0,
-        1,
-        2,
-    },
-    exports: {
-        "Test": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "Test",
             #2,
-        ): 0,
+        ): 1,
         (
             "Other",
             #2,
-        ): 1,
+        ): 2,
         (
             "Other2",
             #2,
-        ): 2,
+        ): 3,
     },
     symbols: {
         0: Symbol {
@@ -39,6 +31,23 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+                2,
+                3,
+            },
+            exports: {
+                "Test": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -74,11 +83,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -101,11 +110,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/TypeAlias01.txt
+++ b/tests/specs/symbols/TypeAlias01.txt
@@ -5,7 +5,7 @@ interface Other {}
 interface Other2 {}
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/TypeScriptTypesHeader.txt
+++ b/tests/specs/symbols/TypeScriptTypesHeader.txt
@@ -33,7 +33,7 @@ export interface MyInterface3 {
 }
 
 # output
-file:///mod.ts: EsmModuleSymbol {
+file:///mod.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),
@@ -211,7 +211,7 @@ file:///mod.ts: EsmModuleSymbol {
         },
     },
 }
-file:///other.d.ts: EsmModuleSymbol {
+file:///other.d.ts: EsmModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -297,7 +297,7 @@ file:///other.d.ts: EsmModuleSymbol {
         },
     },
 }
-file:///other.js: EsmModuleSymbol {
+file:///other.js: EsmModuleInfo {
     module_id: ModuleId(
         2,
     ),
@@ -318,7 +318,7 @@ file:///other.js: EsmModuleSymbol {
         },
     },
 }
-file:///typescript.ts: EsmModuleSymbol {
+file:///typescript.ts: EsmModuleInfo {
     module_id: ModuleId(
         3,
     ),
@@ -404,7 +404,7 @@ file:///typescript.ts: EsmModuleSymbol {
         },
     },
 }
-https://localhost/mod.d.ts: EsmModuleSymbol {
+https://localhost/mod.d.ts: EsmModuleInfo {
     module_id: ModuleId(
         4,
     ),
@@ -552,7 +552,7 @@ https://localhost/mod.d.ts: EsmModuleSymbol {
         },
     },
 }
-https://localhost/mod.js: EsmModuleSymbol {
+https://localhost/mod.js: EsmModuleInfo {
     module_id: ModuleId(
         5,
     ),

--- a/tests/specs/symbols/TypeScriptTypesHeader.txt
+++ b/tests/specs/symbols/TypeScriptTypesHeader.txt
@@ -63,7 +63,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            223,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "import { MyInterface } from \"https://localhost/mod.js\";\nimport { MyInterface2 } from \"./other.js\";\nimport { MyInterface3 } from \"./typescript.ts\";\n\nexport class MyClass implements MyInterface, MyInterface2, MyInterface3 {\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 4,
@@ -229,7 +245,23 @@ file:///other.d.ts: EsmModuleInfo {
                 1,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            46,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export interface MyInterface2 {\n  b: string;\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,
@@ -310,7 +342,23 @@ file:///other.js: EsmModuleInfo {
                 2,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            0,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {},
             exports: {},
@@ -336,7 +384,23 @@ file:///typescript.ts: EsmModuleInfo {
                 3,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            46,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export interface MyInterface3 {\n  c: string;\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,
@@ -426,7 +490,23 @@ https://localhost/mod.d.ts: EsmModuleInfo {
                 4,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            102,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export interface MyInterface {\n  a: string;\n}\n\nexport interface MyNonPublicInterface {\n  a1: string;\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,
@@ -570,7 +650,23 @@ https://localhost/mod.js: EsmModuleInfo {
                 5,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            21,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export class Dummy {}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/TypeScriptTypesHeader.txt
+++ b/tests/specs/symbols/TypeScriptTypesHeader.txt
@@ -38,30 +38,24 @@ file:///mod.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.ts",
-    child_ids: {
-        3,
-    },
-    exports: {
-        "MyClass": 3,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "MyInterface",
             #2,
-        ): 0,
+        ): 1,
         (
             "MyInterface2",
             #2,
-        ): 1,
+        ): 2,
         (
             "MyInterface3",
             #2,
-        ): 2,
+        ): 3,
         (
             "MyClass",
             #2,
-        ): 3,
+        ): 4,
     },
     symbols: {
         0: Symbol {
@@ -69,6 +63,21 @@ file:///mod.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                4,
+            },
+            exports: {
+                "MyClass": 4,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -94,11 +103,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -124,11 +133,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -154,11 +163,11 @@ file:///mod.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -207,18 +216,12 @@ file:///other.d.ts: EsmModuleSymbol {
         1,
     ),
     specifier: "file:///other.d.ts",
-    child_ids: {
-        0,
-    },
-    exports: {
-        "MyInterface2": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "MyInterface2",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -226,6 +229,21 @@ file:///other.d.ts: EsmModuleSymbol {
                 1,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+            },
+            exports: {
+                "MyInterface2": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                1,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -247,14 +265,14 @@ file:///other.d.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                1,
+                2,
             },
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 1,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -284,29 +302,33 @@ file:///other.js: EsmModuleSymbol {
         2,
     ),
     specifier: "file:///other.js",
-    child_ids: {},
-    exports: {},
     re_exports: [],
     swc_id_to_symbol_id: {},
-    symbols: {},
+    symbols: {
+        0: Symbol {
+            module_id: ModuleId(
+                2,
+            ),
+            symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {},
+            exports: {},
+            members: {},
+        },
+    },
 }
 file:///typescript.ts: EsmModuleSymbol {
     module_id: ModuleId(
         3,
     ),
     specifier: "file:///typescript.ts",
-    child_ids: {
-        0,
-    },
-    exports: {
-        "MyInterface3": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "MyInterface3",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -314,6 +336,21 @@ file:///typescript.ts: EsmModuleSymbol {
                 3,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+            },
+            exports: {
+                "MyInterface3": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                3,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -335,14 +372,14 @@ file:///typescript.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                1,
+                2,
             },
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 3,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -372,24 +409,16 @@ https://localhost/mod.d.ts: EsmModuleSymbol {
         4,
     ),
     specifier: "https://localhost/mod.d.ts",
-    child_ids: {
-        0,
-        2,
-    },
-    exports: {
-        "MyInterface": 0,
-        "MyNonPublicInterface": 2,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "MyInterface",
             #2,
-        ): 0,
+        ): 1,
         (
             "MyNonPublicInterface",
             #2,
-        ): 2,
+        ): 3,
     },
     symbols: {
         0: Symbol {
@@ -397,6 +426,23 @@ https://localhost/mod.d.ts: EsmModuleSymbol {
                 4,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+                3,
+            },
+            exports: {
+                "MyInterface": 1,
+                "MyNonPublicInterface": 3,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                4,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -418,14 +464,14 @@ https://localhost/mod.d.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                1,
+                2,
             },
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 4,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -448,11 +494,11 @@ https://localhost/mod.d.ts: EsmModuleSymbol {
             exports: {},
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 4,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -474,14 +520,14 @@ https://localhost/mod.d.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                3,
+                4,
             },
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 4,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -511,18 +557,12 @@ https://localhost/mod.js: EsmModuleSymbol {
         5,
     ),
     specifier: "https://localhost/mod.js",
-    child_ids: {
-        0,
-    },
-    exports: {
-        "Dummy": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "Dummy",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -530,6 +570,21 @@ https://localhost/mod.js: EsmModuleSymbol {
                 5,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+            },
+            exports: {
+                "Dummy": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                5,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {

--- a/tests/specs/symbols/TypesEntrypoint.txt
+++ b/tests/specs/symbols/TypesEntrypoint.txt
@@ -29,7 +29,23 @@ file:///mod.d.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            45,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export interface MyInterface {\n  a: string;\n}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,
@@ -115,7 +131,23 @@ file:///mod.js: EsmModuleInfo {
                 1,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            143,
+                        ),
+                        end: SourcePos(
+                            167,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export class JsExport {}",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/TypesEntrypoint.txt
+++ b/tests/specs/symbols/TypesEntrypoint.txt
@@ -11,7 +11,7 @@ export interface MyInterface {
 }
 
 # output
-file:///mod.d.ts: EsmModuleSymbol {
+file:///mod.d.ts: EsmModuleInfo {
     module_id: ModuleId(
         0,
     ),
@@ -97,7 +97,7 @@ file:///mod.d.ts: EsmModuleSymbol {
         },
     },
 }
-file:///mod.js: EsmModuleSymbol {
+file:///mod.js: EsmModuleInfo {
     module_id: ModuleId(
         1,
     ),

--- a/tests/specs/symbols/TypesEntrypoint.txt
+++ b/tests/specs/symbols/TypesEntrypoint.txt
@@ -1,6 +1,9 @@
 # mod.js
 /// <reference types="./mod.d.ts" />
-export class ShouldNotHaveThisInOutput {}
+
+// this won't be included in the exported definitions because the
+// root will resolve to the .d.ts file
+export class JsExport {}
 
 # mod.d.ts
 export interface MyInterface {
@@ -13,18 +16,12 @@ file:///mod.d.ts: EsmModuleSymbol {
         0,
     ),
     specifier: "file:///mod.d.ts",
-    child_ids: {
-        0,
-    },
-    exports: {
-        "MyInterface": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
             "MyInterface",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -32,6 +29,21 @@ file:///mod.d.ts: EsmModuleSymbol {
                 0,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+            },
+            exports: {
+                "MyInterface": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -53,14 +65,14 @@ file:///mod.d.ts: EsmModuleSymbol {
             child_ids: {},
             exports: {},
             members: {
-                1,
+                2,
             },
         },
-        1: Symbol {
+        2: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 1,
+            symbol_id: 2,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
@@ -90,18 +102,12 @@ file:///mod.js: EsmModuleSymbol {
         1,
     ),
     specifier: "file:///mod.js",
-    child_ids: {
-        0,
-    },
-    exports: {
-        "ShouldNotHaveThisInOutput": 0,
-    },
     re_exports: [],
     swc_id_to_symbol_id: {
         (
-            "ShouldNotHaveThisInOutput",
+            "JsExport",
             #2,
-        ): 0,
+        ): 1,
     },
     symbols: {
         0: Symbol {
@@ -109,19 +115,34 @@ file:///mod.js: EsmModuleSymbol {
                 1,
             ),
             symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+            },
+            exports: {
+                "JsExport": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                1,
+            ),
+            symbol_id: 1,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            37,
+                            143,
                         ),
                         end: SourcePos(
-                            78,
+                            167,
                         ),
                     },
                     kind: Definition(
                         SymbolNode(
-                            "export class ShouldNotHaveThisInOutput {}",
+                            "export class JsExport {}",
                         ),
                     ),
                 },

--- a/tests/specs/symbols/UnresolvedParts.txt
+++ b/tests/specs/symbols/UnresolvedParts.txt
@@ -37,7 +37,23 @@ file:///mod.ts: EsmModuleInfo {
                 0,
             ),
             symbol_id: 0,
-            decls: [],
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            125,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "namespace Test {\n  export function test() {}\n}\n\nexport import Resolved = Test.test;\nexport import Unresolved = Test.NotFound;",
+                        ),
+                    ),
+                },
+            ],
             deps: {},
             child_ids: {
                 1,

--- a/tests/specs/symbols/UnresolvedParts.txt
+++ b/tests/specs/symbols/UnresolvedParts.txt
@@ -1,0 +1,204 @@
+# mod.ts
+namespace Test {
+  export function test() {}
+}
+
+export import Resolved = Test.test;
+export import Unresolved = Test.NotFound;
+
+# output
+file:///mod.ts: EsmModuleInfo {
+    module_id: ModuleId(
+        0,
+    ),
+    specifier: "file:///mod.ts",
+    re_exports: [],
+    swc_id_to_symbol_id: {
+        (
+            "Test",
+            #2,
+        ): 1,
+        (
+            "test",
+            #3,
+        ): 2,
+        (
+            "Resolved",
+            #2,
+        ): 3,
+        (
+            "Unresolved",
+            #2,
+        ): 4,
+    },
+    symbols: {
+        0: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 0,
+            decls: [],
+            deps: {},
+            child_ids: {
+                1,
+            },
+            exports: {
+                "Resolved": 3,
+                "Unresolved": 4,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 1,
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            46,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "namespace Test {\n  export function test() {}\n}",
+                        ),
+                    ),
+                },
+            ],
+            deps: {
+                Id(
+                    (
+                        "test",
+                        #3,
+                    ),
+                ),
+            },
+            child_ids: {
+                2,
+            },
+            exports: {
+                "test": 2,
+            },
+            members: {},
+        },
+        2: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 2,
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            19,
+                        ),
+                        end: SourcePos(
+                            44,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export function test() {}",
+                        ),
+                    ),
+                },
+            ],
+            deps: {},
+            child_ids: {},
+            exports: {},
+            members: {},
+        },
+        3: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 3,
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            48,
+                        ),
+                        end: SourcePos(
+                            83,
+                        ),
+                    },
+                    kind: QualifiedTarget(
+                        (
+                            "Test",
+                            #2,
+                        ),
+                        [
+                            "test",
+                        ],
+                    ),
+                },
+            ],
+            deps: {
+                QualifiedId(
+                    (
+                        "Test",
+                        #2,
+                    ),
+                    [
+                        "test",
+                    ],
+                ),
+            },
+            child_ids: {},
+            exports: {},
+            members: {},
+        },
+        4: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 4,
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            84,
+                        ),
+                        end: SourcePos(
+                            125,
+                        ),
+                    },
+                    kind: QualifiedTarget(
+                        (
+                            "Test",
+                            #2,
+                        ),
+                        [
+                            "NotFound",
+                        ],
+                    ),
+                },
+            ],
+            deps: {
+                QualifiedId(
+                    (
+                        "Test",
+                        #2,
+                    ),
+                    [
+                        "NotFound",
+                    ],
+                ),
+            },
+            child_ids: {},
+            exports: {},
+            members: {},
+        },
+    },
+}
+== export definitions ==
+[Resolved]: file:///mod.ts:19..44
+  export function test() {}
+[Unresolved]: file:///mod.ts
+  Unresolved Part("NotFound") (["NotFound"])

--- a/tests/specs/symbols/UnresolvedParts.txt
+++ b/tests/specs/symbols/UnresolvedParts.txt
@@ -1,10 +1,19 @@
 # mod.ts
+import * as other from "./other.ts";
+
 namespace Test {
   export function test() {}
 }
 
 export import Resolved = Test.test;
 export import Unresolved = Test.NotFound;
+
+export { NonExistent } from "./other.ts";
+
+export import NonExistent2 = other.NotFound;
+
+# other.ts
+export class Other {}
 
 # output
 file:///mod.ts: EsmModuleInfo {
@@ -15,21 +24,29 @@ file:///mod.ts: EsmModuleInfo {
     re_exports: [],
     swc_id_to_symbol_id: {
         (
-            "Test",
+            "other",
             #2,
         ): 1,
         (
+            "Test",
+            #2,
+        ): 2,
+        (
             "test",
             #3,
-        ): 2,
+        ): 3,
         (
             "Resolved",
             #2,
-        ): 3,
+        ): 4,
         (
             "Unresolved",
             #2,
-        ): 4,
+        ): 5,
+        (
+            "NonExistent2",
+            #2,
+        ): 7,
     },
     symbols: {
         0: Symbol {
@@ -44,23 +61,25 @@ file:///mod.ts: EsmModuleInfo {
                             0,
                         ),
                         end: SourcePos(
-                            125,
+                            252,
                         ),
                     },
                     kind: Definition(
                         SymbolNode(
-                            "namespace Test {\n  export function test() {}\n}\n\nexport import Resolved = Test.test;\nexport import Unresolved = Test.NotFound;",
+                            "import * as other from \"./other.ts\";\n\nnamespace Test {\n  export function test() {}\n}\n\nexport import Resolved = Test.test;\nexport import Unresolved = Test.NotFound;\n\nexport { NonExistent } from \"./other.ts\";\n\nexport import NonExistent2 = other.NotFound;",
                         ),
                     ),
                 },
             ],
             deps: {},
             child_ids: {
-                1,
+                2,
             },
             exports: {
-                "Resolved": 3,
-                "Unresolved": 4,
+                "Resolved": 4,
+                "Unresolved": 5,
+                "NonExistent": 6,
+                "NonExistent2": 7,
             },
             members: {},
         },
@@ -73,10 +92,38 @@ file:///mod.ts: EsmModuleInfo {
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            0,
+                            7,
                         ),
                         end: SourcePos(
-                            46,
+                            17,
+                        ),
+                    },
+                    kind: FileRef(
+                        FileDep {
+                            name: Star,
+                            specifier: "./other.ts",
+                        },
+                    ),
+                },
+            ],
+            deps: {},
+            child_ids: {},
+            exports: {},
+            members: {},
+        },
+        2: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 2,
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            38,
+                        ),
+                        end: SourcePos(
+                            84,
                         ),
                     },
                     kind: Definition(
@@ -95,26 +142,26 @@ file:///mod.ts: EsmModuleInfo {
                 ),
             },
             child_ids: {
-                2,
+                3,
             },
             exports: {
-                "test": 2,
+                "test": 3,
             },
             members: {},
         },
-        2: Symbol {
+        3: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 2,
+            symbol_id: 3,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            19,
+                            57,
                         ),
                         end: SourcePos(
-                            44,
+                            82,
                         ),
                     },
                     kind: Definition(
@@ -129,19 +176,19 @@ file:///mod.ts: EsmModuleInfo {
             exports: {},
             members: {},
         },
-        3: Symbol {
+        4: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 3,
+            symbol_id: 4,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            48,
+                            86,
                         ),
                         end: SourcePos(
-                            83,
+                            121,
                         ),
                     },
                     kind: QualifiedTarget(
@@ -170,19 +217,19 @@ file:///mod.ts: EsmModuleInfo {
             exports: {},
             members: {},
         },
-        4: Symbol {
+        5: Symbol {
             module_id: ModuleId(
                 0,
             ),
-            symbol_id: 4,
+            symbol_id: 5,
             decls: [
                 SymbolDecl {
                     range: SourceRange {
                         start: SourcePos(
-                            84,
+                            122,
                         ),
                         end: SourcePos(
-                            125,
+                            163,
                         ),
                     },
                     kind: QualifiedTarget(
@@ -211,10 +258,158 @@ file:///mod.ts: EsmModuleInfo {
             exports: {},
             members: {},
         },
+        6: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 6,
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            174,
+                        ),
+                        end: SourcePos(
+                            185,
+                        ),
+                    },
+                    kind: FileRef(
+                        FileDep {
+                            name: Name(
+                                "NonExistent",
+                            ),
+                            specifier: "./other.ts",
+                        },
+                    ),
+                },
+            ],
+            deps: {},
+            child_ids: {},
+            exports: {},
+            members: {},
+        },
+        7: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 7,
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            208,
+                        ),
+                        end: SourcePos(
+                            252,
+                        ),
+                    },
+                    kind: QualifiedTarget(
+                        (
+                            "other",
+                            #2,
+                        ),
+                        [
+                            "NotFound",
+                        ],
+                    ),
+                },
+            ],
+            deps: {
+                QualifiedId(
+                    (
+                        "other",
+                        #2,
+                    ),
+                    [
+                        "NotFound",
+                    ],
+                ),
+            },
+            child_ids: {},
+            exports: {},
+            members: {},
+        },
+    },
+}
+file:///other.ts: EsmModuleInfo {
+    module_id: ModuleId(
+        1,
+    ),
+    specifier: "file:///other.ts",
+    re_exports: [],
+    swc_id_to_symbol_id: {
+        (
+            "Other",
+            #2,
+        ): 1,
+    },
+    symbols: {
+        0: Symbol {
+            module_id: ModuleId(
+                1,
+            ),
+            symbol_id: 0,
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            21,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export class Other {}",
+                        ),
+                    ),
+                },
+            ],
+            deps: {},
+            child_ids: {
+                1,
+            },
+            exports: {
+                "Other": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                1,
+            ),
+            symbol_id: 1,
+            decls: [
+                SymbolDecl {
+                    range: SourceRange {
+                        start: SourcePos(
+                            0,
+                        ),
+                        end: SourcePos(
+                            21,
+                        ),
+                    },
+                    kind: Definition(
+                        SymbolNode(
+                            "export class Other {}",
+                        ),
+                    ),
+                },
+            ],
+            deps: {},
+            child_ids: {},
+            exports: {},
+            members: {},
+        },
     },
 }
 == export definitions ==
-[Resolved]: file:///mod.ts:19..44
+[Resolved]: file:///mod.ts:57..82
   export function test() {}
 [Unresolved]: file:///mod.ts
+  Unresolved Part("NotFound") (["NotFound"])
+[NonExistent]: file:///mod.ts
+  Unresolved Part("NonExistent") ([])
+[NonExistent2]: file:///other.ts
   Unresolved Part("NotFound") (["NotFound"])


### PR DESCRIPTION
This adds a `Symbol` for each module (same as what the typescript compiler does) and renames `ModuleSymbol` to `ModuleInfo` to prevent confusion.

Additionally, it's now possible to see where a "go to defintion" failed.