### PR TITLE
fix(workspace): use IndexMap instead of HashMap for exports

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -666,7 +666,7 @@ fn is_media_type_unknown(media_type: &MediaType) -> bool {
 pub struct WorkspaceMember {
   pub base: Url,
   pub nv: PackageNv,
-  pub exports: HashMap<String, String>,
+  pub exports: IndexMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
This helps add some stability in error messages and in the future order might matter.