### PR TITLE
fix: export new analyzer types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,9 @@ use std::sync::Arc;
 
 pub use analyzer::analyze_deno_types;
 pub use analyzer::Comment;
+pub use analyzer::DependencyDescriptor;
+pub use analyzer::DynamicArgument;
+pub use analyzer::DynamicDependencyDescriptor;
 pub use analyzer::ModuleAnalyzer;
 pub use analyzer::ModuleInfo;
 pub use analyzer::PositionRange;


### PR DESCRIPTION
Forgot to export these.