### PR TITLE
fix: dynamic arg search should not find self

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2347,6 +2347,9 @@ fn analyze_dynamic_arg_template_parts(
         DirEntryKind::File => {
           let url = &entry.url;
           if matching_media_types.contains(&MediaType::from_specifier(url)) {
+            if url == referrer {
+              continue; // found itself, so skip
+            }
             if let Some(specifier) = referrer.make_relative(url) {
               let specifier = if !specifier.starts_with("../") {
                 format!("./{}", specifier)

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -618,4 +618,16 @@ await import(`./a/${test}`);
     ],
   )
   .await;
+
+  // finding itself
+  run_test(
+    "await import(`./${expr}`);",
+    vec![
+      ("file:///main.ts", ""), // self
+      ("file:///other.ts", ""),
+    ],
+    // should not have "file:///" here
+    vec!["file:///other.ts"],
+  )
+  .await;
 }


### PR DESCRIPTION
Handles not finding itself when the folder is the same:

```ts
const file = await import(`./${expr}`);
```