### PR TITLE
feat: expose referrer's `Range` in `Resolver`

### DIFF
--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -141,13 +141,13 @@ impl Resolver for JsResolver {
   fn resolve(
     &self,
     specifier: &str,
-    referrer: &ModuleSpecifier,
+    referrer_range: &Range,
     _mode: ResolutionMode,
   ) -> Result<ModuleSpecifier, ResolveError> {
     if let Some(resolve) = &self.maybe_resolve {
       let this = JsValue::null();
       let arg1 = JsValue::from(specifier);
-      let arg2 = JsValue::from(referrer.to_string());
+      let arg2 = JsValue::from(referrer_range.specifier.to_string());
       let value = match resolve.call2(&this, &arg1, &arg2) {
         Ok(value) => value,
         Err(_) => return Err(anyhow!("JavaScript resolve threw.").into()),
@@ -159,7 +159,8 @@ impl Resolver for JsResolver {
       ModuleSpecifier::parse(&value)
         .map_err(|err| ResolveError::Specifier(SpecifierError::InvalidUrl(err)))
     } else {
-      resolve_import(specifier, referrer).map_err(|err| err.into())
+      resolve_import(specifier, &referrer_range.specifier)
+        .map_err(|err| err.into())
     }
   }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1667,7 +1667,7 @@ fn resolve(
   maybe_npm_resolver: Option<&dyn NpmResolver>,
 ) -> Resolution {
   let response = if let Some(resolver) = maybe_resolver {
-    resolver.resolve(specifier_text, &referrer_range.specifier, mode)
+    resolver.resolve(specifier_text, &referrer_range, mode)
   } else {
     resolve_import(specifier_text, &referrer_range.specifier)
       .map_err(|err| err.into())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1191,14 +1191,14 @@ console.log(a);
     fn resolve(
       &self,
       specifier_text: &str,
-      referrer: &deno_ast::ModuleSpecifier,
+      referrer_range: &Range,
       _mode: ResolutionMode,
     ) -> Result<deno_ast::ModuleSpecifier, source::ResolveError> {
       use import_map::ImportMapError;
       Err(source::ResolveError::Other(
         ImportMapError::UnmappedBareSpecifier(
           specifier_text.to_string(),
-          Some(referrer.to_string()),
+          Some(referrer_range.specifier.to_string()),
         )
         .into(),
       ))
@@ -3761,14 +3761,14 @@ export function a(a: A): B {
       fn resolve(
         &self,
         specifier_text: &str,
-        referrer: &ModuleSpecifier,
+        referrer_range: &Range,
         mode: ResolutionMode,
       ) -> Result<ModuleSpecifier, crate::source::ResolveError> {
         let specifier_text = match mode {
           ResolutionMode::Types => format!("{}.d.ts", specifier_text),
           ResolutionMode::Execution => format!("{}.js", specifier_text),
         };
-        Ok(resolve_import(&specifier_text, referrer)?)
+        Ok(resolve_import(&specifier_text, &referrer_range.specifier)?)
       }
     }
 
@@ -3948,12 +3948,12 @@ export function a(a: A): B {
       fn resolve(
         &self,
         specifier_text: &str,
-        referrer: &ModuleSpecifier,
+        referrer_range: &Range,
         mode: ResolutionMode,
       ) -> Result<ModuleSpecifier, crate::source::ResolveError> {
         match mode {
           ResolutionMode::Execution => {
-            Ok(resolve_import(specifier_text, referrer)?)
+            Ok(resolve_import(specifier_text, &referrer_range.specifier)?)
           }
           ResolutionMode::Types => Err(crate::source::ResolveError::Other(
             anyhow::anyhow!("Failed."),

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -180,10 +180,10 @@ pub trait Resolver: fmt::Debug {
   fn resolve(
     &self,
     specifier_text: &str,
-    referrer: &ModuleSpecifier,
+    referrer_range: &Range,
     _mode: ResolutionMode,
   ) -> Result<ModuleSpecifier, ResolveError> {
-    Ok(resolve_import(specifier_text, referrer)?)
+    Ok(resolve_import(specifier_text, &referrer_range.specifier)?)
   }
 
   /// Given a module specifier, return an optional tuple which provides a module
@@ -491,15 +491,15 @@ pub mod tests {
     fn resolve(
       &self,
       specifier: &str,
-      referrer: &ModuleSpecifier,
+      referrer_range: &Range,
       _mode: ResolutionMode,
     ) -> Result<ModuleSpecifier, ResolveError> {
-      if let Some(map) = self.map.get(referrer) {
+      if let Some(map) = self.map.get(&referrer_range.specifier) {
         if let Some(resolved_specifier) = map.get(specifier) {
           return Ok(resolved_specifier.clone());
         }
       }
-      Ok(resolve_import(specifier, referrer)?)
+      Ok(resolve_import(specifier, &referrer_range.specifier)?)
     }
 
     fn resolve_types(


### PR DESCRIPTION
This allows me to display a warning when resolving an `--unstable-loose-import`.