### PR TITLE
fix: dynamic arg module search should ignore specific folder names

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2392,7 +2392,19 @@ fn analyze_dynamic_arg_template_parts(
           }
         }
         DirEntryKind::Dir => {
-          pending_dirs.push_back(entry.url);
+          // ignore hidden directories and any node_modules/vendor folders
+          let is_allowed_dir = entry
+            .url
+            .path()
+            .rsplit('/')
+            .find(|c| !c.is_empty())
+            .map(|c| {
+              !c.starts_with('.') && c != "node_modules" && c != "vendor"
+            })
+            .unwrap_or(true);
+          if is_allowed_dir {
+            pending_dirs.push_back(entry.url);
+          }
         }
         DirEntryKind::Symlink => {
           // ignore

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -643,4 +643,21 @@ await import(`./a/${test}`);
     vec![],
   )
   .await;
+
+  // won't search node_modules, vendor, or hidden folders
+  run_test(
+    "await import(`./${test}/mod.ts`);",
+    vec![
+      ("file:///dev/other/.git/mod.ts", ""),
+      ("file:///dev/other/node_modules/mod.ts", ""),
+      ("file:///dev/other/sub_dir/mod.ts", ""),
+      ("file:///dev/other/vendor/mod.ts", ""),
+      ("file:///dev/other/mod.ts", ""),
+    ],
+    vec![
+      "file:///dev/other/mod.ts",
+      "file:///dev/other/sub_dir/mod.ts",
+    ],
+  )
+  .await;
 }


### PR DESCRIPTION
I think the dynamic argument module search should ignore certain folder names as they are almost guaranteed to not be wanted. This excludes hidden folders and folders named `node_modules` or `vendor`.