### PR TITLE
refactor: rename `EsmModule`-like names to `EsModule`

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -693,7 +693,7 @@ pub struct WorkspaceMember {
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "kind")]
 pub enum Module {
-  Esm(EsmModule),
+  Esm(EsModule),
   // todo(#239): remove this when updating the --json output for 2.0
   #[serde(rename = "asserted")]
   Json(JsonModule),
@@ -721,7 +721,7 @@ impl Module {
     }
   }
 
-  pub fn esm(&self) -> Option<&EsmModule> {
+  pub fn esm(&self) -> Option<&EsModule> {
     if let Module::Esm(module) = &self {
       Some(module)
     } else {
@@ -817,7 +817,7 @@ pub struct FastCheckTypeModule {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct EsmModule {
+pub struct EsModule {
   #[serde(
     skip_serializing_if = "IndexMap::is_empty",
     serialize_with = "serialize_dependencies"
@@ -836,7 +836,7 @@ pub struct EsmModule {
   pub fast_check: Option<FastCheckTypeModuleSlot>,
 }
 
-impl EsmModule {
+impl EsModule {
   fn new(specifier: ModuleSpecifier, source: Arc<str>) -> Self {
     Self {
       dependencies: Default::default(),
@@ -1201,7 +1201,7 @@ impl<'a> ModuleGraphErrorIterator<'a> {
 
   fn check_resolution(
     &self,
-    module: &EsmModule,
+    module: &EsModule,
     mode: ResolutionMode,
     specifier_text: &str,
     resolution: &Resolution,
@@ -1877,7 +1877,7 @@ pub(crate) fn parse_module(
       match module_analyzer.analyze(specifier, content.clone(), media_type) {
         Ok(module_info) => {
           // Return the module as a valid module
-          Ok(Module::Esm(parse_esm_module_from_module_info(
+          Ok(Module::Esm(parse_es_module_from_module_info(
             graph_kind,
             specifier,
             media_type,
@@ -1902,7 +1902,7 @@ pub(crate) fn parse_module(
       ) {
         Ok(module_info) => {
           // Return the module as a valid module
-          Ok(Module::Esm(parse_esm_module_from_module_info(
+          Ok(Module::Esm(parse_es_module_from_module_info(
             graph_kind,
             specifier,
             media_type,
@@ -1928,7 +1928,7 @@ pub(crate) fn parse_module(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn parse_esm_module_from_module_info(
+pub(crate) fn parse_es_module_from_module_info(
   graph_kind: GraphKind,
   specifier: &ModuleSpecifier,
   media_type: MediaType,
@@ -1938,8 +1938,8 @@ pub(crate) fn parse_esm_module_from_module_info(
   file_system: &dyn FileSystem,
   maybe_resolver: Option<&dyn Resolver>,
   maybe_npm_resolver: Option<&dyn NpmResolver>,
-) -> EsmModule {
-  let mut module = EsmModule::new(specifier.clone(), source);
+) -> EsModule {
+  let mut module = EsModule::new(specifier.clone(), source);
   module.media_type = media_type;
 
   // Analyze the TypeScript triple-slash references

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub use graph::BuildDiagnostic;
 pub use graph::BuildOptions;
 pub use graph::Dependency;
 pub use graph::DiagnosticRange;
-pub use graph::EsmModule;
+pub use graph::EsModule;
 pub use graph::ExternalModule;
 pub use graph::FastCheckTypeModule;
 pub use graph::FastCheckTypeModuleSlot;
@@ -136,8 +136,8 @@ pub struct ParseModuleFromAstOptions<'a> {
 }
 
 /// Parse an individual module from an AST, returning the module.
-pub fn parse_module_from_ast(options: ParseModuleFromAstOptions) -> EsmModule {
-  graph::parse_esm_module_from_module_info(
+pub fn parse_module_from_ast(options: ParseModuleFromAstOptions) -> EsModule {
+  graph::parse_es_module_from_module_info(
     options.graph_kind,
     options.specifier,
     options.parsed_source.media_type(),

--- a/src/symbols/analyzer.rs
+++ b/src/symbols/analyzer.rs
@@ -17,7 +17,7 @@ use deno_ast::SourceTextInfo;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
 
-use crate::EsmModule;
+use crate::EsModule;
 use crate::JsonModule;
 use crate::ModuleGraph;
 use crate::ModuleParser;
@@ -83,7 +83,7 @@ impl<'a> RootSymbol<'a> {
     };
 
     match graph_module {
-      crate::Module::Esm(esm_module) => self.analyze_esm_module(esm_module),
+      crate::Module::Esm(es_module) => self.analyze_es_module(es_module),
       crate::Module::Json(json_module) => {
         Some(self.analyze_json_module(json_module))
       }
@@ -151,14 +151,11 @@ impl<'a> RootSymbol<'a> {
     )
   }
 
-  fn analyze_esm_module(
-    &self,
-    esm_module: &EsmModule,
-  ) -> Option<ModuleInfoRef> {
-    let Ok(source) = self.parsed_source(esm_module) else {
+  fn analyze_es_module(&self, es_module: &EsModule) -> Option<ModuleInfoRef> {
+    let Ok(source) = self.parsed_source(es_module) else {
       return None;
     };
-    let specifier = &esm_module.specifier;
+    let specifier = &es_module.specifier;
     let module = source.module();
 
     let module_id = ModuleId(self.ids_to_modules.len() as u32);
@@ -168,7 +165,7 @@ impl<'a> RootSymbol<'a> {
       builder: &builder,
     };
     filler.fill(module);
-    let module_symbol = EsmModuleInfo {
+    let module_symbol = EsModuleInfo {
       specifier: specifier.clone(),
       module_id,
       source: source.clone(),
@@ -243,7 +240,7 @@ impl<'a> RootSymbol<'a> {
 
   fn parsed_source(
     &self,
-    graph_module: &EsmModule,
+    graph_module: &EsModule,
   ) -> Result<ParsedSource, deno_ast::Diagnostic> {
     self.parser.parse_module(ParseOptions {
       specifier: &graph_module.specifier,
@@ -1207,7 +1204,7 @@ impl UniqueSymbolId {
 #[derive(Debug, Clone, Copy)]
 pub enum ModuleInfoRef<'a> {
   Json(&'a JsonModuleInfo),
-  Esm(&'a EsmModuleInfo),
+  Esm(&'a EsModuleInfo),
 }
 
 impl<'a> ModuleInfoRef<'a> {
@@ -1218,7 +1215,7 @@ impl<'a> ModuleInfoRef<'a> {
     }
   }
 
-  pub fn esm(&self) -> Option<&'a EsmModuleInfo> {
+  pub fn esm(&self) -> Option<&'a EsModuleInfo> {
     match self {
       Self::Json(_) => None,
       Self::Esm(esm) => Some(esm),
@@ -1345,7 +1342,7 @@ impl<'a> ModuleInfoRef<'a> {
 #[derive(Debug, Clone)]
 pub enum ModuleInfo {
   Json(Box<JsonModuleInfo>),
-  Esm(EsmModuleInfo),
+  Esm(EsModuleInfo),
 }
 
 impl ModuleInfo {
@@ -1356,7 +1353,7 @@ impl ModuleInfo {
     }
   }
 
-  pub fn esm(&self) -> Option<&EsmModuleInfo> {
+  pub fn esm(&self) -> Option<&EsModuleInfo> {
     match self {
       Self::Json(_) => None,
       Self::Esm(esm) => Some(esm),
@@ -1440,7 +1437,7 @@ impl JsonModuleInfo {
 }
 
 #[derive(Clone)]
-pub struct EsmModuleInfo {
+pub struct EsModuleInfo {
   module_id: ModuleId,
   specifier: ModuleSpecifier,
   source: ParsedSource,
@@ -1451,9 +1448,9 @@ pub struct EsmModuleInfo {
   symbols: IndexMap<SymbolId, Symbol>,
 }
 
-impl std::fmt::Debug for EsmModuleInfo {
+impl std::fmt::Debug for EsModuleInfo {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    f.debug_struct("EsmModuleInfo")
+    f.debug_struct("EsModuleInfo")
       .field("module_id", &self.module_id)
       .field("specifier", &self.specifier.as_str())
       .field(
@@ -1470,7 +1467,7 @@ impl std::fmt::Debug for EsmModuleInfo {
   }
 }
 
-impl EsmModuleInfo {
+impl EsModuleInfo {
   pub fn as_ref(&self) -> ModuleInfoRef {
     ModuleInfoRef::Esm(self)
   }

--- a/src/symbols/mod.rs
+++ b/src/symbols/mod.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-pub use self::analyzer::EsmModuleInfo;
+pub use self::analyzer::EsModuleInfo;
 pub use self::analyzer::ExportDeclRef;
 pub use self::analyzer::FileDep;
 pub use self::analyzer::FileDepName;

--- a/tests/specs/symbols/Basic.txt
+++ b/tests/specs/symbols/Basic.txt
@@ -27,7 +27,7 @@ export default class C {
 export type D = typeof C;
 
 # output
-file:///a.ts: EsmModuleInfo {
+file:///a.ts: EsModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -386,7 +386,7 @@ file:///a.ts: EsmModuleInfo {
 6:102..115 [Id(("AInner", #2))]
 9:173..198 [Id(("C", #2))]
 
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ClassPrivateCtorParamProps.txt
+++ b/tests/specs/symbols/ClassPrivateCtorParamProps.txt
@@ -12,7 +12,7 @@ class PublicClass {}
 class PrivateClass {}
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/Classes01.txt
+++ b/tests/specs/symbols/Classes01.txt
@@ -60,7 +60,7 @@ class ClassWithIndexSignatures {
 }
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/DeclarationMerging01.txt
+++ b/tests/specs/symbols/DeclarationMerging01.txt
@@ -25,7 +25,7 @@ namespace Test {
 export { Album, Color, Test };
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportAssignment01.txt
+++ b/tests/specs/symbols/ExportAssignment01.txt
@@ -6,7 +6,7 @@ function test() {
 export = test;
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportDefault01.txt
+++ b/tests/specs/symbols/ExportDefault01.txt
@@ -41,7 +41,7 @@ export default function Test() {
 }
 
 # output
-file:///a.ts: EsmModuleInfo {
+file:///a.ts: EsModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -460,7 +460,7 @@ file:///a.ts: EsmModuleInfo {
 5:172..180 [Id(("A", #2))]
 8:213..218 [Id(("B", #2))]
 
-file:///class.ts: EsmModuleInfo {
+file:///class.ts: EsModuleInfo {
     module_id: ModuleId(
         2,
     ),
@@ -537,7 +537,7 @@ file:///class.ts: EsmModuleInfo {
         },
     },
 }
-file:///function.ts: EsmModuleInfo {
+file:///function.ts: EsModuleInfo {
     module_id: ModuleId(
         3,
     ),
@@ -614,7 +614,7 @@ file:///function.ts: EsmModuleInfo {
         },
     },
 }
-file:///interface.ts: EsmModuleInfo {
+file:///interface.ts: EsModuleInfo {
     module_id: ModuleId(
         4,
     ),
@@ -691,7 +691,7 @@ file:///interface.ts: EsmModuleInfo {
         },
     },
 }
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportDefault02.txt
+++ b/tests/specs/symbols/ExportDefault02.txt
@@ -2,7 +2,7 @@
 export default Test; class Test {}
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportDefault03.txt
+++ b/tests/specs/symbols/ExportDefault03.txt
@@ -13,7 +13,7 @@ export class B {}
 export class B1 {}
 
 # output
-file:///a.ts: EsmModuleInfo {
+file:///a.ts: EsModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -122,7 +122,7 @@ file:///a.ts: EsmModuleInfo {
         },
     },
 }
-file:///b.ts: EsmModuleInfo {
+file:///b.ts: EsModuleInfo {
     module_id: ModuleId(
         2,
     ),
@@ -235,7 +235,7 @@ file:///b.ts: EsmModuleInfo {
         },
     },
 }
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportDefault04.txt
+++ b/tests/specs/symbols/ExportDefault04.txt
@@ -2,7 +2,7 @@
 export default 1 + 1;
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportDefaultLiteral01.txt
+++ b/tests/specs/symbols/ExportDefaultLiteral01.txt
@@ -2,7 +2,7 @@
 export default 1;
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportDefaultLiteral02.txt
+++ b/tests/specs/symbols/ExportDefaultLiteral02.txt
@@ -2,7 +2,7 @@
 export default "test";
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportDestructured.txt
+++ b/tests/specs/symbols/ExportDestructured.txt
@@ -15,7 +15,7 @@ export const {
 } = c;
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportStar01.txt
+++ b/tests/specs/symbols/ExportStar01.txt
@@ -36,7 +36,7 @@ export default function Test() {
 }
 
 # output
-file:///a.ts: EsmModuleInfo {
+file:///a.ts: EsModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -455,7 +455,7 @@ file:///a.ts: EsmModuleInfo {
 5:172..180 [Id(("A", #2))]
 8:213..218 [Id(("B", #2))]
 
-file:///class.ts: EsmModuleInfo {
+file:///class.ts: EsModuleInfo {
     module_id: ModuleId(
         2,
     ),
@@ -532,7 +532,7 @@ file:///class.ts: EsmModuleInfo {
         },
     },
 }
-file:///function.ts: EsmModuleInfo {
+file:///function.ts: EsModuleInfo {
     module_id: ModuleId(
         3,
     ),
@@ -609,7 +609,7 @@ file:///function.ts: EsmModuleInfo {
         },
     },
 }
-file:///interface.ts: EsmModuleInfo {
+file:///interface.ts: EsModuleInfo {
     module_id: ModuleId(
         4,
     ),
@@ -686,7 +686,7 @@ file:///interface.ts: EsmModuleInfo {
         },
     },
 }
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportedDeclare01.txt
+++ b/tests/specs/symbols/ExportedDeclare01.txt
@@ -13,7 +13,7 @@ import inner = Test.test;
 export { foo as bar, inner as baz, MyClass };
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ExportedDeclare02.txt
+++ b/tests/specs/symbols/ExportedDeclare02.txt
@@ -3,7 +3,7 @@ declare function foo(): number;
 export function bar() {};
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/FunctionOverloads01.txt
+++ b/tests/specs/symbols/FunctionOverloads01.txt
@@ -15,7 +15,7 @@ import InnerInner = Inner.inner;
 export { InnerInner };
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/Functions01.txt
+++ b/tests/specs/symbols/Functions01.txt
@@ -22,7 +22,7 @@ class PrivateParam {}
 class PrivateReturn {}
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ImportEquals01.txt
+++ b/tests/specs/symbols/ImportEquals01.txt
@@ -7,7 +7,7 @@ namespace Test {
 }
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ImportEquals02.txt
+++ b/tests/specs/symbols/ImportEquals02.txt
@@ -25,7 +25,7 @@ namespace A.B {
 export { A };
 
 # output
-file:///a.ts: EsmModuleInfo {
+file:///a.ts: EsModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -342,7 +342,7 @@ file:///a.ts: EsmModuleInfo {
         },
     },
 }
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ImportType01.txt
+++ b/tests/specs/symbols/ImportType01.txt
@@ -11,7 +11,7 @@ export namespace A {
 }
 
 # output
-file:///a.ts: EsmModuleInfo {
+file:///a.ts: EsModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -158,7 +158,7 @@ file:///a.ts: EsmModuleInfo {
         },
     },
 }
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ImportType02.txt
+++ b/tests/specs/symbols/ImportType02.txt
@@ -11,7 +11,7 @@ export default function test() {
 }
 
 # output
-file:///a.ts: EsmModuleInfo {
+file:///a.ts: EsModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -156,7 +156,7 @@ file:///a.ts: EsmModuleInfo {
         },
     },
 }
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/Interfaces01.txt
+++ b/tests/specs/symbols/Interfaces01.txt
@@ -20,7 +20,7 @@ interface B {
 }
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/Interfaces02.txt
+++ b/tests/specs/symbols/Interfaces02.txt
@@ -27,7 +27,7 @@ interface Prop2 {}
 export { A1 };
 
 # output
-file:///a.ts: EsmModuleInfo {
+file:///a.ts: EsModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -255,7 +255,7 @@ file:///a.ts: EsmModuleInfo {
 == symbol deps (types only) ==
 3:51..64 [Id(("Prop2", #2))]
 
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/MemberExpr.txt
+++ b/tests/specs/symbols/MemberExpr.txt
@@ -10,7 +10,7 @@ export class Test {
 }
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ModuleExportNameStr01.txt
+++ b/tests/specs/symbols/ModuleExportNameStr01.txt
@@ -13,7 +13,7 @@ export { MyClass as "some-name" } from "./c.ts";
 export class MyClass {}
 
 # output
-file:///a.ts: EsmModuleInfo {
+file:///a.ts: EsModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -122,7 +122,7 @@ file:///a.ts: EsmModuleInfo {
         },
     },
 }
-file:///b.ts: EsmModuleInfo {
+file:///b.ts: EsModuleInfo {
     module_id: ModuleId(
         2,
     ),
@@ -195,7 +195,7 @@ file:///b.ts: EsmModuleInfo {
         },
     },
 }
-file:///c.ts: EsmModuleInfo {
+file:///c.ts: EsModuleInfo {
     module_id: ModuleId(
         3,
     ),
@@ -272,7 +272,7 @@ file:///c.ts: EsmModuleInfo {
         },
     },
 }
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/Namespaces01.txt
+++ b/tests/specs/symbols/Namespaces01.txt
@@ -14,7 +14,7 @@ import test2 = Namespace1.Inner.test2;
 export { test, test2 };
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/Namespaces02.txt
+++ b/tests/specs/symbols/Namespaces02.txt
@@ -10,7 +10,7 @@ export namespace RootNs {
 }
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/NamespacesAmbient.txt
+++ b/tests/specs/symbols/NamespacesAmbient.txt
@@ -47,7 +47,7 @@ namespace Inner {
 }
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),
@@ -805,7 +805,7 @@ file:///mod.ts: EsmModuleInfo {
         },
     },
 }
-file:///other.d.ts: EsmModuleInfo {
+file:///other.d.ts: EsModuleInfo {
     module_id: ModuleId(
         1,
     ),

--- a/tests/specs/symbols/ReExportJson01.txt
+++ b/tests/specs/symbols/ReExportJson01.txt
@@ -51,7 +51,7 @@ file:///bar.json: JsonModuleInfo {
         members: {},
     },
 }
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ReexportAll.txt
+++ b/tests/specs/symbols/ReexportAll.txt
@@ -18,7 +18,7 @@ export { Test } from "./b.ts";
 export { Test, test1 } from "./c.ts";
 
 # output
-file:///a.ts: EsmModuleInfo {
+file:///a.ts: EsModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -394,7 +394,7 @@ file:///a.ts: EsmModuleInfo {
         },
     },
 }
-file:///b.ts: EsmModuleInfo {
+file:///b.ts: EsModuleInfo {
     module_id: ModuleId(
         2,
     ),
@@ -471,7 +471,7 @@ file:///b.ts: EsmModuleInfo {
         },
     },
 }
-file:///c.ts: EsmModuleInfo {
+file:///c.ts: EsModuleInfo {
     module_id: ModuleId(
         3,
     ),
@@ -546,7 +546,7 @@ file:///c.ts: EsmModuleInfo {
         },
     },
 }
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ReexportDeep.txt
+++ b/tests/specs/symbols/ReexportDeep.txt
@@ -16,7 +16,7 @@ export declare namespace MessageEntity {
 }
 
 # output
-file:///a.ts: EsmModuleInfo {
+file:///a.ts: EsModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -56,7 +56,7 @@ file:///a.ts: EsmModuleInfo {
         },
     },
 }
-file:///b.ts: EsmModuleInfo {
+file:///b.ts: EsModuleInfo {
     module_id: ModuleId(
         2,
     ),
@@ -96,7 +96,7 @@ file:///b.ts: EsmModuleInfo {
         },
     },
 }
-file:///c.ts: EsmModuleInfo {
+file:///c.ts: EsModuleInfo {
     module_id: ModuleId(
         3,
     ),
@@ -243,7 +243,7 @@ file:///c.ts: EsmModuleInfo {
         },
     },
 }
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/ReexportExport.txt
+++ b/tests/specs/symbols/ReexportExport.txt
@@ -3,7 +3,7 @@ export function foo(): void {}
 export { foo as bar };
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/TsExternalModuleRef01.txt
+++ b/tests/specs/symbols/TsExternalModuleRef01.txt
@@ -11,7 +11,7 @@ namespace MyNamespace {
 export = MyNamespace;
 
 # output
-file:///a.ts: EsmModuleInfo {
+file:///a.ts: EsModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -157,7 +157,7 @@ file:///a.ts: EsmModuleInfo {
         },
     },
 }
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/TsExternalModuleRef02.txt
+++ b/tests/specs/symbols/TsExternalModuleRef02.txt
@@ -11,7 +11,7 @@ namespace MyNamespace {
 export = MyNamespace;
 
 # output
-file:///a.ts: EsmModuleInfo {
+file:///a.ts: EsModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -157,7 +157,7 @@ file:///a.ts: EsmModuleInfo {
         },
     },
 }
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/TsNamespaceExport01.txt
+++ b/tests/specs/symbols/TsNamespaceExport01.txt
@@ -8,7 +8,7 @@ export function isPrime(x: number): boolean {
 export as namespace mathLib;
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/TsQualifiedName01.txt
+++ b/tests/specs/symbols/TsQualifiedName01.txt
@@ -8,7 +8,7 @@ namespace Other {
 }
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/TypeAlias01.txt
+++ b/tests/specs/symbols/TypeAlias01.txt
@@ -8,7 +8,7 @@ interface Other2 {}
 export type Tuple = [lat: number, long: number];
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),

--- a/tests/specs/symbols/TypeScriptTypesHeader.txt
+++ b/tests/specs/symbols/TypeScriptTypesHeader.txt
@@ -33,7 +33,7 @@ export interface MyInterface3 {
 }
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),
@@ -227,7 +227,7 @@ file:///mod.ts: EsmModuleInfo {
 == symbol deps (types only) ==
 4:148..223 [Id(("MyInterface", #2)), Id(("MyInterface2", #2)), Id(("MyInterface3", #2))]
 
-file:///other.d.ts: EsmModuleInfo {
+file:///other.d.ts: EsModuleInfo {
     module_id: ModuleId(
         1,
     ),
@@ -336,7 +336,7 @@ file:///other.d.ts: EsmModuleInfo {
         },
     },
 }
-file:///other.js: EsmModuleInfo {
+file:///other.js: EsModuleInfo {
     module_id: ModuleId(
         2,
     ),
@@ -374,7 +374,7 @@ file:///other.js: EsmModuleInfo {
         },
     },
 }
-file:///typescript.ts: EsmModuleInfo {
+file:///typescript.ts: EsModuleInfo {
     module_id: ModuleId(
         3,
     ),
@@ -483,7 +483,7 @@ file:///typescript.ts: EsmModuleInfo {
         },
     },
 }
-https://localhost/mod.d.ts: EsmModuleInfo {
+https://localhost/mod.d.ts: EsModuleInfo {
     module_id: ModuleId(
         4,
     ),
@@ -660,7 +660,7 @@ https://localhost/mod.d.ts: EsmModuleInfo {
         },
     },
 }
-https://localhost/mod.js: EsmModuleInfo {
+https://localhost/mod.js: EsModuleInfo {
     module_id: ModuleId(
         5,
     ),

--- a/tests/specs/symbols/TypesEntrypoint.txt
+++ b/tests/specs/symbols/TypesEntrypoint.txt
@@ -11,7 +11,7 @@ export interface MyInterface {
 }
 
 # output
-file:///mod.d.ts: EsmModuleInfo {
+file:///mod.d.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),
@@ -120,7 +120,7 @@ file:///mod.d.ts: EsmModuleInfo {
         },
     },
 }
-file:///mod.js: EsmModuleInfo {
+file:///mod.js: EsModuleInfo {
     module_id: ModuleId(
         1,
     ),

--- a/tests/specs/symbols/UnresolvedParts.txt
+++ b/tests/specs/symbols/UnresolvedParts.txt
@@ -16,7 +16,7 @@ export import NonExistent2 = other.NotFound;
 export class Other {}
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),
@@ -316,7 +316,7 @@ file:///mod.ts: EsmModuleInfo {
         },
     },
 }
-file:///other.ts: EsmModuleInfo {
+file:///other.ts: EsModuleInfo {
     module_id: ModuleId(
         1,
     ),

--- a/tests/specs/symbols/UsingDecl.txt
+++ b/tests/specs/symbols/UsingDecl.txt
@@ -5,7 +5,7 @@ using test = 5;
 export { test };
 
 # output
-file:///mod.ts: EsmModuleInfo {
+file:///mod.ts: EsModuleInfo {
     module_id: ModuleId(
         0,
     ),


### PR DESCRIPTION
Extracted out of https://github.com/denoland/deno_graph/pull/357