### PR TITLE
feat: move text encoding functionality into `deno_graph::source` from CLI

### DIFF
--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -344,6 +344,9 @@ impl RawDataUrl {
       return MediaType::Unknown;
     };
     MediaType::from_content_type(
+      // this data url will be ignored when resolving the MediaType
+      // as in this rare case the MediaType is determined solely based
+      // on the provided content type
       &ModuleSpecifier::parse("data:image/png;base64,").unwrap(),
       content_type,
     )

--- a/src/text_encoding.rs
+++ b/src/text_encoding.rs
@@ -48,6 +48,8 @@ pub fn strip_bom_mut(text: &mut String) {
 
 #[cfg(test)]
 mod test {
+  use std::io::ErrorKind;
+
   use super::*;
 
   fn test_detection(test_data: &[u8], expected_charset: &str) {
@@ -90,5 +92,23 @@ mod test {
     let mut text = "text".to_string();
     strip_bom_mut(&mut text);
     assert_eq!(text, "text");
+  }
+
+  #[test]
+  fn test_decoding_unsupported_charset() {
+    let test_data = Vec::new();
+    let result = convert_to_utf8(&test_data, "utf-32le");
+    assert!(result.is_err());
+    let err = result.expect_err("Err expected");
+    assert!(err.kind() == ErrorKind::InvalidInput);
+  }
+
+  #[test]
+  fn test_decoding_invalid_utf8() {
+    let test_data = b"\xFE\xFE\xFF\xFF".to_vec();
+    let result = convert_to_utf8(&test_data, "utf-8");
+    assert!(result.is_err());
+    let err = result.expect_err("Err expected");
+    assert!(err.kind() == ErrorKind::InvalidData);
   }
 }


### PR DESCRIPTION
Moving this into the CLI allows me to delete some CLI code and re-use the functionality that's already in this crate.