### PR TITLE
fix: always create a package entry for jsr packages

### DIFF
--- a/src/packages.rs
+++ b/src/packages.rs
@@ -110,7 +110,10 @@ impl PackageSpecifiers {
     if !nvs.contains(&nv) {
       nvs.push(nv.clone());
     }
-    self.package_reqs.insert(package_req, nv);
+    self.package_reqs.insert(package_req, nv.clone());
+    // always create an entry because this is used in the lockfile
+    // todo(dsherret): add integrity for the package here
+    self.packages.entry(nv.clone()).or_default();
   }
 
   /// Gets the dependencies (package constraints) of JSR packages found in the graph.


### PR DESCRIPTION
For https://github.com/denoland/deno/pull/22359 and tests will go in there (I'll add tests here once adding the integrity check)

The lockfile always expects these to exist now because we're going to add integrity there.