### PR TITLE
feat: load JSR URLs using checksum found in package's manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
  "parking_lot",
  "pretty_assertions",
  "regex",
+ "ring",
  "serde",
  "serde_json",
  "tempfile",
@@ -398,7 +399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -945,6 +946,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "ring"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,7 +990,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1118,6 +1133,12 @@ dependencies = [
  "unicode-id",
  "url",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stacker"
@@ -1521,7 +1542,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "rustix",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1677,6 +1698,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1812,6 +1839,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,9 +278,9 @@ dependencies = [
  "parking_lot",
  "pretty_assertions",
  "regex",
- "ring",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror",
  "tokio",
@@ -399,7 +399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -946,20 +946,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
-name = "ring"
-version = "0.17.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
-dependencies = [
- "cc",
- "getrandom",
- "libc",
- "spin",
- "untrusted",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,7 +976,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1087,6 +1073,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,12 +1130,6 @@ dependencies = [
  "unicode-id",
  "url",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stacker"
@@ -1542,7 +1533,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1698,12 +1689,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
 name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,15 +1824,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ monch = "0.5.0"
 once_cell = "1.16.0"
 parking_lot = "0.12.0"
 regex = "1.10.2"
+ring = "^0.17.0"
 serde = { version = "1.0.130", features = ["derive", "rc"] }
 serde_json = { version = "1.0.67", features = ["preserve_order"] }
 thiserror = "1.0.24"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,9 @@ monch = "0.5.0"
 once_cell = "1.16.0"
 parking_lot = "0.12.0"
 regex = "1.10.2"
-ring = "^0.17.0"
 serde = { version = "1.0.130", features = ["derive", "rc"] }
 serde_json = { version = "1.0.67", features = ["preserve_order"] }
+sha2 = "^0.10.0"
 thiserror = "1.0.24"
 url = { version = "2.2.2", features = ["serde"] }
 

--- a/js/mod.ts
+++ b/js/mod.ts
@@ -61,6 +61,7 @@ export interface CreateGraphOptions {
     specifier: string,
     isDynamic: boolean,
     cacheSetting: CacheSetting,
+    checksum: string | undefined,
   ): Promise<LoadResponse | undefined>;
   /** The type of graph to build. `"all"` includes all dependencies of the
    * roots. `"typesOnly"` skips any code only dependencies that do not impact
@@ -143,10 +144,13 @@ export async function createGraph(
     rootSpecifiers,
     async (
       specifier: string,
-      isDynamic: boolean,
-      cacheSetting: CacheSetting,
+      options: {
+        isDynamic: boolean,
+        cacheSetting: CacheSetting,
+        checksum: string | undefined
+      }
     ) => {
-      const result = await load(specifier, isDynamic, cacheSetting);
+      const result = await load(specifier, options.isDynamic, options.cacheSetting, options.checksum);
       if (result?.kind === "module") {
         if (typeof result.content === "string") {
           result.content = encoder.encode(result.content);

--- a/js/mod.ts
+++ b/js/mod.ts
@@ -145,12 +145,17 @@ export async function createGraph(
     async (
       specifier: string,
       options: {
-        isDynamic: boolean,
-        cacheSetting: CacheSetting,
-        checksum: string | undefined
-      }
+        isDynamic: boolean;
+        cacheSetting: CacheSetting;
+        checksum: string | undefined;
+      },
     ) => {
-      const result = await load(specifier, options.isDynamic, options.cacheSetting, options.checksum);
+      const result = await load(
+        specifier,
+        options.isDynamic,
+        options.cacheSetting,
+        options.checksum,
+      );
       if (result?.kind === "module") {
         if (typeof result.content === "string") {
           result.content = encoder.encode(result.content);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -3372,8 +3372,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
                     specifier.clone(),
                     maybe_range.cloned(),
                     Arc::new(anyhow!(
-                      "Unsupported checksum in manifest for {}. Maybe try upgrading deno?",
-                      specifier
+                      "Unsupported checksum in manifest. Maybe try upgrading deno?",
                     )),
                   )),
                 );

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2848,36 +2848,37 @@ impl<'a, 'graph> Builder<'a, 'graph> {
           maybe_version_info,
         }) => match result {
           Ok(Some(response)) => {
-            if maybe_version_info.is_none()
-              && self
-                .loader
-                .registry_package_url_to_nv(&response.specifier())
-                .is_some()
-            {
-              self.graph.module_slots.insert(
-                specifier.clone(),
-                ModuleSlot::Err(ModuleError::LoadingErr(
-                  specifier.clone(),
-                  maybe_range,
-                  Arc::new(anyhow!(concat!(
-                    "Importing a JSR package via an HTTPS URL is not implemented. ",
-                    "Use a `jsr:` specifier instead for the time being."
-                  )),
-                ))),
-              );
-            } else {
-              let assert_types =
-                self.state.pending_specifiers.remove(&specifier).unwrap();
-              for maybe_assert_type in assert_types {
-                self.visit(
-                  &specifier,
-                  &response,
-                  maybe_assert_type,
-                  maybe_range.clone(),
-                  maybe_version_info.as_ref(),
-                )
-              }
+            // if maybe_version_info.is_none()
+            //   && specifier.scheme() != "jsr"
+            //   && self
+            //     .loader
+            //     .registry_package_url_to_nv(&response.specifier())
+            //     .is_some()
+            // {
+            //   self.graph.module_slots.insert(
+            //     specifier.clone(),
+            //     ModuleSlot::Err(ModuleError::LoadingErr(
+            //       specifier.clone(),
+            //       maybe_range,
+            //       Arc::new(anyhow!(concat!(
+            //         "Importing a JSR package via an HTTPS URL is not implemented. ",
+            //         "Use a `jsr:` specifier instead for the time being."
+            //       )),
+            //     ))),
+            //   );
+            // } else {
+            let assert_types =
+              self.state.pending_specifiers.remove(&specifier).unwrap();
+            for maybe_assert_type in assert_types {
+              self.visit(
+                &specifier,
+                &response,
+                maybe_assert_type,
+                maybe_range.clone(),
+                maybe_version_info.as_ref(),
+              )
             }
+            //}
             Some(specifier)
           }
           Ok(None) => {

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -26,12 +26,18 @@ pub struct JsrPackageInfoVersion {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct JsrPackageVersionManifestEntry {
+  pub checksum: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct JsrPackageVersionInfo {
   // ensure the fields on here are resilient to change
   #[serde(default)]
   pub exports: serde_json::Value,
   #[serde(rename = "moduleGraph1")]
   pub module_graph: Option<serde_json::Value>,
+  pub manifest: HashMap<String, JsrPackageVersionManifestEntry>,
 }
 
 impl JsrPackageVersionInfo {

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -150,15 +150,15 @@ impl PackageSpecifiers {
     &mut self,
     nv: PackageNv,
     checksum: String,
-  ) -> Result<(), PackageManifestIntegrityError> {
+  ) -> Result<(), Box<PackageManifestIntegrityError>> {
     let package = self.packages.get(&nv);
     if let Some(package) = package {
       if package.manifest_checksum != checksum {
-        Err(PackageManifestIntegrityError {
+        Err(Box::new(PackageManifestIntegrityError {
           nv,
           actual: checksum,
           expected: package.manifest_checksum.clone(),
-        })
+        }))
       } else {
         Ok(())
       }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -123,6 +123,10 @@ impl LoaderChecksum {
     self.0
   }
 
+  pub fn as_str(&self) -> &str {
+    &self.0
+  }
+
   pub fn check_source(&self, source: &[u8]) -> Result<(), anyhow::Error> {
     let actual_checksum = Self::gen(source);
     if self.0 == actual_checksum {

--- a/tests/helpers/test_builder.rs
+++ b/tests/helpers/test_builder.rs
@@ -4,6 +4,7 @@ use deno_ast::ModuleSpecifier;
 use deno_graph::source::CacheInfo;
 use deno_graph::source::CacheSetting;
 use deno_graph::source::LoadFuture;
+use deno_graph::source::LoadOptions;
 use deno_graph::source::Loader;
 use deno_graph::source::MemoryLoader;
 use deno_graph::BuildDiagnostic;
@@ -25,21 +26,14 @@ impl Loader for TestLoader {
   fn load(
     &mut self,
     specifier: &ModuleSpecifier,
-    is_dynamic: bool,
-    cache_setting: CacheSetting,
+    options: LoadOptions,
   ) -> LoadFuture {
-    match cache_setting {
+    match options.cache_setting {
       // todo(dsherret): in the future, actually make this use the cache
-      CacheSetting::Use => {
-        self.remote.load(specifier, is_dynamic, cache_setting)
-      }
+      CacheSetting::Use => self.remote.load(specifier, options),
       // todo(dsherret): in the future, make this update the cache
-      CacheSetting::Reload => {
-        self.remote.load(specifier, is_dynamic, cache_setting)
-      }
-      CacheSetting::Only => {
-        self.cache.load(specifier, is_dynamic, cache_setting)
-      }
+      CacheSetting::Reload => self.remote.load(specifier, options),
+      CacheSetting::Only => self.cache.load(specifier, options),
     }
   }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -13,6 +13,7 @@ use anyhow::anyhow;
 use deno_ast::ModuleSpecifier;
 use deno_graph::source::CacheSetting;
 use deno_graph::source::LoadFuture;
+use deno_graph::source::LoadOptions;
 use deno_graph::source::LoadResponse;
 use deno_graph::source::MemoryFileSystem;
 use deno_graph::source::MemoryLoader;
@@ -451,11 +452,12 @@ async fn test_jsr_version_not_found_then_found() {
     fn load(
       &mut self,
       specifier: &ModuleSpecifier,
-      is_dynamic: bool,
-      cache_setting: CacheSetting,
+      options: LoadOptions,
     ) -> LoadFuture {
-      assert!(!is_dynamic);
-      self.requests.push((specifier.to_string(), cache_setting));
+      assert!(!options.is_dynamic);
+      self
+        .requests
+        .push((specifier.to_string(), options.cache_setting));
       let specifier = specifier.clone();
       match specifier.as_str() {
         "file:///main.ts" => Box::pin(async move {
@@ -470,7 +472,7 @@ async fn test_jsr_version_not_found_then_found() {
             Ok(Some(LoadResponse::Module {
               specifier: specifier.clone(),
               maybe_headers: None,
-              content: match cache_setting {
+              content: match options.cache_setting {
                 CacheSetting::Only | CacheSetting::Use => {
                   // first time it won't have the version
                   br#"{ "versions": { "1.0.0": {} } }"#.to_vec().into()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -38,7 +38,7 @@ mod helpers;
 
 #[tokio::test]
 async fn test_graph_specs() {
-  for (test_file_path, mut spec) in
+  for (test_file_path, spec) in
     get_specs_in_dir(&PathBuf::from("./tests/specs/graph"))
   {
     if !cfg!(feature = "fast_check")
@@ -47,11 +47,6 @@ async fn test_graph_specs() {
       continue;
     }
     eprintln!("Running {}", test_file_path.display());
-    let update =
-      std::env::var("UPDATE").as_ref().map(|v| v.as_str()) == Ok("1");
-    if update {
-      spec.fill_jsr_meta_files_with_checksums();
-    }
     let mut builder = TestBuilder::new();
     builder.with_loader(|loader| {
       for file in &spec.files {
@@ -142,6 +137,8 @@ async fn test_graph_specs() {
       .iter()
       .map(|d| serde_json::to_value(d.to_string()).unwrap())
       .collect::<Vec<_>>();
+    let update =
+      std::env::var("UPDATE").as_ref().map(|v| v.as_str()) == Ok("1");
     let spec = if update {
       let mut spec = spec;
       spec.output_file.text = output_text.clone();
@@ -177,7 +174,7 @@ fn indent(text: &str) -> String {
 #[cfg(feature = "symbols")]
 #[tokio::test]
 async fn test_symbols_specs() {
-  for (test_file_path, spec) in
+  for (test_file_path, mut spec) in
     get_specs_in_dir(&PathBuf::from("./tests/specs/symbols"))
   {
     eprintln!("Running {}", test_file_path.display());

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -76,7 +76,7 @@ async fn test_graph_specs() {
     let jsr_deps = result
       .graph
       .packages
-      .package_deps()
+      .packages()
       .map(|(k, v)| {
         (k.to_string(), v.map(|v| v.to_string()).collect::<Vec<_>>())
       })

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -174,7 +174,7 @@ fn indent(text: &str) -> String {
 #[cfg(feature = "symbols")]
 #[tokio::test]
 async fn test_symbols_specs() {
-  for (test_file_path, mut spec) in
+  for (test_file_path, spec) in
     get_specs_in_dir(&PathBuf::from("./tests/specs/symbols"))
   {
     eprintln!("Running {}", test_file_path.display());
@@ -487,7 +487,17 @@ async fn test_jsr_version_not_found_then_found() {
           Ok(Some(LoadResponse::Module {
             specifier: specifier.clone(),
             maybe_headers: None,
-            content: br#"{ "exports": { ".": "./mod.ts" } }"#.to_vec().into(),
+            content: br#"{
+                "exports": { ".": "./mod.ts" },
+                "manifest": {
+                  "/mod.ts": {
+                    "size": 123,
+                    "checksum": "sha256-b8059cfb1ea623e79efbf432db31595df213c99c6534c58bec9d5f5e069344df"
+                  }
+                }
+              }"#
+              .to_vec()
+              .into(),
           }))
         }),
         "https://jsr.io/@scope/a/1.2.0/mod.ts" => Box::pin(async move {

--- a/tests/specs/graph/JsrSpecifiers_Checksum_Mismatch.txt
+++ b/tests/specs/graph/JsrSpecifiers_Checksum_Mismatch.txt
@@ -1,0 +1,68 @@
+# https://jsr.io/@scope/a/meta.json
+{
+  "versions": {
+    "1.0.0": {}
+  }
+}
+
+# https://jsr.io/@scope/a/1.0.0_meta.json
+{
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "manifest": {
+    "/mod.ts": {
+      "size": 1,
+      "checksum": "sha256-somechecksum"
+    }
+  }
+}
+
+# mod.ts
+import 'jsr:@scope/a'
+
+# https://jsr.io/@scope/a/1.0.0/mod.ts
+console.log('HI');
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "jsr:@scope/a",
+          "code": {
+            "specifier": "jsr:@scope/a",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 7
+              },
+              "end": {
+                "line": 0,
+                "character": 21
+              }
+            }
+          }
+        }
+      ],
+      "size": 22,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    },
+    {
+      "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts",
+      "error": "Integrity check failed.\n\nActual: 6584ea1318267e53901c6b7b83d0d3c1d3e386faa7b93c8e1f7ca1a1ffc76a71\nExpected: somechecksum"
+    }
+  ],
+  "redirects": {
+    "jsr:@scope/a": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+  },
+  "packages": {
+    "@scope/a": "@scope/a@1.0.0"
+  }
+}

--- a/tests/specs/graph/JsrSpecifiers_Checksum_Unsupported.txt
+++ b/tests/specs/graph/JsrSpecifiers_Checksum_Unsupported.txt
@@ -1,0 +1,68 @@
+# https://jsr.io/@scope/a/meta.json
+{
+  "versions": {
+    "1.0.0": {}
+  }
+}
+
+# https://jsr.io/@scope/a/1.0.0_meta.json
+{
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "manifest": {
+    "/mod.ts": {
+      "size": 1,
+      "checksum": "sha1-somechecksum"
+    }
+  }
+}
+
+# mod.ts
+import 'jsr:@scope/a'
+
+# https://jsr.io/@scope/a/1.0.0/mod.ts
+console.log('HI');
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "jsr:@scope/a",
+          "code": {
+            "specifier": "jsr:@scope/a",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 7
+              },
+              "end": {
+                "line": 0,
+                "character": 21
+              }
+            }
+          }
+        }
+      ],
+      "size": 22,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    },
+    {
+      "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts",
+      "error": "Unsupported checksum in manifest. Maybe try upgrading deno?"
+    }
+  ],
+  "redirects": {
+    "jsr:@scope/a": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+  },
+  "packages": {
+    "@scope/a": "@scope/a@1.0.0"
+  }
+}

--- a/tests/specs/graph/JsrSpecifiers_InvalidExport.txt
+++ b/tests/specs/graph/JsrSpecifiers_InvalidExport.txt
@@ -7,6 +7,7 @@
 
 # https://jsr.io/@scope/a/1.0.0_meta.json
 {
+  "manifest": {},
   "exports": {
     ".": "./mod.ts",
     "./sub": "./sub_dir/sub.ts",

--- a/tests/specs/graph/JsrSpecifiers_WorkspaceNotMatched.txt
+++ b/tests/specs/graph/JsrSpecifiers_WorkspaceNotMatched.txt
@@ -25,6 +25,7 @@
 
 # https://jsr.io/@scope/b/2.0.3_meta.json
 {
+  "manifest": {},
   "exports": {
     ".": "./mod.ts"
   }

--- a/tests/specs/graph/Jsr_ImportViaHttps.txt
+++ b/tests/specs/graph/Jsr_ImportViaHttps.txt
@@ -1,0 +1,65 @@
+# https://jsr.io/@scope/a/meta.json
+{"versions": { "1.0.0": {} } }
+
+# https://jsr.io/@scope/a/1.0.0_meta.json
+{
+  "checksums": {
+    "mod.ts": {
+      "size": 21,
+      "checksum": "151a3a3f4587a29c7b3449a3635fed35c4e88a3a773b3bf296804f1a4e1ab86d"
+    }
+  },
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "manifest": {
+    "/mod.ts": {
+      "size": 21,
+      "checksum": "sha256-151a3a3f4587a29c7b3449a3635fed35c4e88a3a773b3bf296804f1a4e1ab86d"
+    }
+  }
+}
+# https://jsr.io/@scope/a/1.0.0/mod.ts
+export class Test {}
+
+# mod.ts
+import { Test } from "https://jsr.io/@scope/a/1.0.0/mod.ts";
+console.log(Test);
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts",
+          "code": {
+            "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 21
+              },
+              "end": {
+                "line": 0,
+                "character": 59
+              }
+            }
+          }
+        }
+      ],
+      "size": 80,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    },
+    {
+      "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts",
+      "error": "Importing a JSR package via an HTTPS URL is not implemented. Use a jsr: specifier instead for the time being."
+    }
+  ],
+  "redirects": {}
+}


### PR DESCRIPTION
This loads individual files in the package using the checksum found in the package's manifest. This allows us to reduce the amount of information we need to store in the lockfile.