### PR TITLE
fix(js): correct passing of load options from Rust

### DIFF
--- a/js/test.ts
+++ b/js/test.ts
@@ -77,7 +77,11 @@ Deno.test({
   name: "createGraph() - root module missing",
   async fn() {
     const graph = await createGraph("file:///a/test.ts", {
-      load() {
+      load(specifier, isDynamic, cacheSetting, checksum) {
+        assert(specifier != null);
+        assert(isDynamic != null);
+        assert(cacheSetting != null);
+        assert(checksum === undefined); // in this case
         return Promise.resolve(undefined);
       },
     });

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -68,10 +68,11 @@ impl Loader for JsLoader {
     options: LoadOptions,
   ) -> LoadFuture {
     #[derive(Serialize)]
+    #[serde(rename_all = "camelCase")]
     struct JsLoadOptions {
       is_dynamic: bool,
       cache_setting: &'static str,
-      maybe_checksum: Option<String>,
+      checksum: Option<String>,
     }
 
     if specifier.scheme() == "data" {
@@ -83,7 +84,7 @@ impl Loader for JsLoader {
       let arg2 = serde_wasm_bindgen::to_value(&JsLoadOptions {
         is_dynamic: options.is_dynamic,
         cache_setting: options.cache_setting.as_js_str(),
-        maybe_checksum: options.maybe_checksum.map(|c| c.into_string()),
+        checksum: options.maybe_checksum.map(|c| c.into_string()),
       })
       .unwrap();
       let result = self.load.call2(&context, &arg1, &arg2);


### PR DESCRIPTION
Remembered about this while writing something similar in eszip. Seems like we had no tests.