### PR TITLE
fix(fast-check): do not add warning diagnostic for js entrypoint with types

### DIFF
--- a/src/fast_check/range_finder.rs
+++ b/src/fast_check/range_finder.rs
@@ -1029,7 +1029,9 @@ impl<'a> PublicRangeFinder<'a> {
       return true; // just analyze it
     };
     match module {
-      crate::Module::Js(m) => is_typed_media_type(m.media_type),
+      crate::Module::Js(m) => {
+        is_typed_media_type(m.media_type) || m.maybe_types_dependency.is_some()
+      }
       crate::Module::Json(_) => true,
       crate::Module::Npm(_)
       | crate::Module::Node(_)

--- a/tests/specs/graph/JsrSpecifiers_FastCheck_EntrypointJsWithTsDecl.txt
+++ b/tests/specs/graph/JsrSpecifiers_FastCheck_EntrypointJsWithTsDecl.txt
@@ -1,0 +1,88 @@
+# https://jsr.io/@scope/a/meta.json
+{"versions": { "1.0.0": {} } }
+
+# https://jsr.io/@scope/a/1.0.0_meta.json
+{ "exports": { ".": "./mod.js" } }
+
+# https://jsr.io/@scope/a/1.0.0/mod.d.ts
+export function getRandom(): number;
+
+# https://jsr.io/@scope/a/1.0.0/mod.js
+/// <reference types="./mod.d.ts" />
+export function getRandom() {
+  return Math.random();
+}
+
+# mod.ts
+import 'jsr:@scope/a'
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "jsr:@scope/a",
+          "code": {
+            "specifier": "jsr:@scope/a",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 7
+              },
+              "end": {
+                "line": 0,
+                "character": 21
+              }
+            }
+          }
+        }
+      ],
+      "size": 22,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 37,
+      "mediaType": "Dts",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/mod.d.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 93,
+      "typesDependency": {
+        "specifier": "./mod.d.ts",
+        "dependency": {
+          "specifier": "https://jsr.io/@scope/a/1.0.0/mod.d.ts",
+          "span": {
+            "start": {
+              "line": 0,
+              "character": 21
+            },
+            "end": {
+              "line": 0,
+              "character": 33
+            }
+          }
+        }
+      },
+      "mediaType": "JavaScript",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/mod.js"
+    }
+  ],
+  "redirects": {
+    "jsr:@scope/a": "https://jsr.io/@scope/a/1.0.0/mod.js"
+  },
+  "packages": {
+    "@scope/a": "@scope/a@1.0.0"
+  }
+}
+
+Fast check https://jsr.io/@scope/a/1.0.0/mod.d.ts:
+  {}
+  export function getRandom(): number;

--- a/tests/specs/graph/JsrSpecifiers_FastCheck_JsWithTsDecl.txt
+++ b/tests/specs/graph/JsrSpecifiers_FastCheck_JsWithTsDecl.txt
@@ -1,0 +1,135 @@
+# https://jsr.io/@scope/a/meta.json
+{"versions": { "1.0.0": {} } }
+
+# https://jsr.io/@scope/a/1.0.0_meta.json
+{ "exports": { ".": "./mod.ts" } }
+
+# https://jsr.io/@scope/a/1.0.0/random.d.ts
+export function getRandom(): number;
+
+# https://jsr.io/@scope/a/1.0.0/random.js
+/// <reference types="./random.d.ts" />
+export function getRandom() {
+  return Math.random();
+}
+
+# https://jsr.io/@scope/a/1.0.0/mod.ts
+export * from "./random.js";
+
+# mod.ts
+import 'jsr:@scope/a'
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "jsr:@scope/a",
+          "code": {
+            "specifier": "jsr:@scope/a",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 7
+              },
+              "end": {
+                "line": 0,
+                "character": 21
+              }
+            }
+          }
+        }
+      ],
+      "size": 22,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    },
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "./random.js",
+          "code": {
+            "specifier": "https://jsr.io/@scope/a/1.0.0/random.js",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 14
+              },
+              "end": {
+                "line": 0,
+                "character": 27
+              }
+            }
+          }
+        }
+      ],
+      "size": 29,
+      "mediaType": "TypeScript",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 37,
+      "mediaType": "Dts",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/random.d.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 96,
+      "typesDependency": {
+        "specifier": "./random.d.ts",
+        "dependency": {
+          "specifier": "https://jsr.io/@scope/a/1.0.0/random.d.ts",
+          "span": {
+            "start": {
+              "line": 0,
+              "character": 21
+            },
+            "end": {
+              "line": 0,
+              "character": 36
+            }
+          }
+        }
+      },
+      "mediaType": "JavaScript",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/random.js"
+    }
+  ],
+  "redirects": {
+    "jsr:@scope/a": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+  },
+  "packages": {
+    "@scope/a": "@scope/a@1.0.0"
+  }
+}
+
+Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
+  {
+    "./random.d.ts": {
+      "code": {
+        "specifier": "https://jsr.io/@scope/a/1.0.0/random.d.ts",
+        "span": {
+          "start": {
+            "line": 0,
+            "character": 14
+          },
+          "end": {
+            "line": 0,
+            "character": 27
+          }
+        }
+      }
+    }
+  }
+  export * from "./random.d.ts";
+
+Fast check https://jsr.io/@scope/a/1.0.0/random.d.ts:
+  {}
+  export function getRandom(): number;

--- a/tests/specs/symbols/TypeScriptTypesHeader.txt
+++ b/tests/specs/symbols/TypeScriptTypesHeader.txt
@@ -338,15 +338,20 @@ file:///other.d.ts: EsModuleInfo {
 }
 file:///other.js: EsModuleInfo {
     module_id: ModuleId(
-        2,
+        1,
     ),
-    specifier: "file:///other.js",
+    specifier: "file:///other.d.ts",
     re_exports: [],
-    swc_id_to_symbol_id: {},
+    swc_id_to_symbol_id: {
+        (
+            "MyInterface2",
+            #2,
+        ): 1,
+    },
     symbols: {
         0: Symbol {
             module_id: ModuleId(
-                2,
+                1,
             ),
             symbol_id: 0,
             parent_id: None,
@@ -354,7 +359,7 @@ file:///other.js: EsModuleInfo {
                 SymbolDecl {
                     kind: Definition(
                         SymbolNode(
-                            "",
+                            "export interface MyInterface2 {\n  b: string;\n}",
                         ),
                     ),
                     range: SourceRange {
@@ -362,7 +367,73 @@ file:///other.js: EsModuleInfo {
                             0,
                         ),
                         end: SourcePos(
+                            46,
+                        ),
+                    },
+                    flags: 0,
+                },
+            ],
+            child_ids: {
+                1,
+            },
+            exports: {
+                "MyInterface2": 1,
+            },
+            members: {},
+        },
+        1: Symbol {
+            module_id: ModuleId(
+                1,
+            ),
+            symbol_id: 1,
+            parent_id: Some(
+                0,
+            ),
+            decls: [
+                SymbolDecl {
+                    kind: Definition(
+                        SymbolNode(
+                            "export interface MyInterface2 {\n  b: string;\n}",
+                        ),
+                    ),
+                    range: SourceRange {
+                        start: SourcePos(
                             0,
+                        ),
+                        end: SourcePos(
+                            46,
+                        ),
+                    },
+                    flags: 0,
+                },
+            ],
+            child_ids: {},
+            exports: {},
+            members: {
+                2,
+            },
+        },
+        2: Symbol {
+            module_id: ModuleId(
+                1,
+            ),
+            symbol_id: 2,
+            parent_id: Some(
+                1,
+            ),
+            decls: [
+                SymbolDecl {
+                    kind: Definition(
+                        SymbolNode(
+                            "b: string;",
+                        ),
+                    ),
+                    range: SourceRange {
+                        start: SourcePos(
+                            34,
+                        ),
+                        end: SourcePos(
+                            44,
                         ),
                     },
                     flags: 0,
@@ -376,7 +447,7 @@ file:///other.js: EsModuleInfo {
 }
 file:///typescript.ts: EsModuleInfo {
     module_id: ModuleId(
-        3,
+        2,
     ),
     specifier: "file:///typescript.ts",
     re_exports: [],
@@ -389,7 +460,7 @@ file:///typescript.ts: EsModuleInfo {
     symbols: {
         0: Symbol {
             module_id: ModuleId(
-                3,
+                2,
             ),
             symbol_id: 0,
             parent_id: None,
@@ -421,7 +492,7 @@ file:///typescript.ts: EsModuleInfo {
         },
         1: Symbol {
             module_id: ModuleId(
-                3,
+                2,
             ),
             symbol_id: 1,
             parent_id: Some(
@@ -453,7 +524,7 @@ file:///typescript.ts: EsModuleInfo {
         },
         2: Symbol {
             module_id: ModuleId(
-                3,
+                2,
             ),
             symbol_id: 2,
             parent_id: Some(
@@ -485,7 +556,7 @@ file:///typescript.ts: EsModuleInfo {
 }
 https://localhost/mod.d.ts: EsModuleInfo {
     module_id: ModuleId(
-        4,
+        3,
     ),
     specifier: "https://localhost/mod.d.ts",
     re_exports: [],
@@ -502,7 +573,7 @@ https://localhost/mod.d.ts: EsModuleInfo {
     symbols: {
         0: Symbol {
             module_id: ModuleId(
-                4,
+                3,
             ),
             symbol_id: 0,
             parent_id: None,
@@ -536,7 +607,7 @@ https://localhost/mod.d.ts: EsModuleInfo {
         },
         1: Symbol {
             module_id: ModuleId(
-                4,
+                3,
             ),
             symbol_id: 1,
             parent_id: Some(
@@ -568,7 +639,7 @@ https://localhost/mod.d.ts: EsModuleInfo {
         },
         2: Symbol {
             module_id: ModuleId(
-                4,
+                3,
             ),
             symbol_id: 2,
             parent_id: Some(
@@ -598,7 +669,7 @@ https://localhost/mod.d.ts: EsModuleInfo {
         },
         3: Symbol {
             module_id: ModuleId(
-                4,
+                3,
             ),
             symbol_id: 3,
             parent_id: Some(
@@ -630,7 +701,7 @@ https://localhost/mod.d.ts: EsModuleInfo {
         },
         4: Symbol {
             module_id: ModuleId(
-                4,
+                3,
             ),
             symbol_id: 4,
             parent_id: Some(
@@ -662,20 +733,24 @@ https://localhost/mod.d.ts: EsModuleInfo {
 }
 https://localhost/mod.js: EsModuleInfo {
     module_id: ModuleId(
-        5,
+        3,
     ),
-    specifier: "https://localhost/mod.js",
+    specifier: "https://localhost/mod.d.ts",
     re_exports: [],
     swc_id_to_symbol_id: {
         (
-            "Dummy",
+            "MyInterface",
             #2,
         ): 1,
+        (
+            "MyNonPublicInterface",
+            #2,
+        ): 3,
     },
     symbols: {
         0: Symbol {
             module_id: ModuleId(
-                5,
+                3,
             ),
             symbol_id: 0,
             parent_id: None,
@@ -683,7 +758,7 @@ https://localhost/mod.js: EsModuleInfo {
                 SymbolDecl {
                     kind: Definition(
                         SymbolNode(
-                            "export class Dummy {}",
+                            "export interface MyInterface {\n  a: string;\n}\n\nexport interface MyNonPublicInterface {\n  a1: string;\n}",
                         ),
                     ),
                     range: SourceRange {
@@ -691,7 +766,7 @@ https://localhost/mod.js: EsModuleInfo {
                             0,
                         ),
                         end: SourcePos(
-                            21,
+                            102,
                         ),
                     },
                     flags: 0,
@@ -699,15 +774,17 @@ https://localhost/mod.js: EsModuleInfo {
             ],
             child_ids: {
                 1,
+                3,
             },
             exports: {
-                "Dummy": 1,
+                "MyInterface": 1,
+                "MyNonPublicInterface": 3,
             },
             members: {},
         },
         1: Symbol {
             module_id: ModuleId(
-                5,
+                3,
             ),
             symbol_id: 1,
             parent_id: Some(
@@ -717,7 +794,7 @@ https://localhost/mod.js: EsModuleInfo {
                 SymbolDecl {
                     kind: Definition(
                         SymbolNode(
-                            "export class Dummy {}",
+                            "export interface MyInterface {\n  a: string;\n}",
                         ),
                     ),
                     range: SourceRange {
@@ -725,7 +802,101 @@ https://localhost/mod.js: EsModuleInfo {
                             0,
                         ),
                         end: SourcePos(
-                            21,
+                            45,
+                        ),
+                    },
+                    flags: 0,
+                },
+            ],
+            child_ids: {},
+            exports: {},
+            members: {
+                2,
+            },
+        },
+        2: Symbol {
+            module_id: ModuleId(
+                3,
+            ),
+            symbol_id: 2,
+            parent_id: Some(
+                1,
+            ),
+            decls: [
+                SymbolDecl {
+                    kind: Definition(
+                        SymbolNode(
+                            "a: string;",
+                        ),
+                    ),
+                    range: SourceRange {
+                        start: SourcePos(
+                            33,
+                        ),
+                        end: SourcePos(
+                            43,
+                        ),
+                    },
+                    flags: 0,
+                },
+            ],
+            child_ids: {},
+            exports: {},
+            members: {},
+        },
+        3: Symbol {
+            module_id: ModuleId(
+                3,
+            ),
+            symbol_id: 3,
+            parent_id: Some(
+                0,
+            ),
+            decls: [
+                SymbolDecl {
+                    kind: Definition(
+                        SymbolNode(
+                            "export interface MyNonPublicInterface {\n  a1: string;\n}",
+                        ),
+                    ),
+                    range: SourceRange {
+                        start: SourcePos(
+                            47,
+                        ),
+                        end: SourcePos(
+                            102,
+                        ),
+                    },
+                    flags: 0,
+                },
+            ],
+            child_ids: {},
+            exports: {},
+            members: {
+                4,
+            },
+        },
+        4: Symbol {
+            module_id: ModuleId(
+                3,
+            ),
+            symbol_id: 4,
+            parent_id: Some(
+                3,
+            ),
+            decls: [
+                SymbolDecl {
+                    kind: Definition(
+                        SymbolNode(
+                            "a1: string;",
+                        ),
+                    ),
+                    range: SourceRange {
+                        start: SourcePos(
+                            89,
+                        ),
+                        end: SourcePos(
+                            100,
                         ),
                     },
                     flags: 0,

--- a/tests/specs/symbols/TypesEntrypoint.txt
+++ b/tests/specs/symbols/TypesEntrypoint.txt
@@ -122,20 +122,20 @@ file:///mod.d.ts: EsModuleInfo {
 }
 file:///mod.js: EsModuleInfo {
     module_id: ModuleId(
-        1,
+        0,
     ),
-    specifier: "file:///mod.js",
+    specifier: "file:///mod.d.ts",
     re_exports: [],
     swc_id_to_symbol_id: {
         (
-            "JsExport",
+            "MyInterface",
             #2,
         ): 1,
     },
     symbols: {
         0: Symbol {
             module_id: ModuleId(
-                1,
+                0,
             ),
             symbol_id: 0,
             parent_id: None,
@@ -143,15 +143,15 @@ file:///mod.js: EsModuleInfo {
                 SymbolDecl {
                     kind: Definition(
                         SymbolNode(
-                            "export class JsExport {}",
+                            "export interface MyInterface {\n  a: string;\n}",
                         ),
                     ),
                     range: SourceRange {
                         start: SourcePos(
-                            143,
+                            0,
                         ),
                         end: SourcePos(
-                            167,
+                            45,
                         ),
                     },
                     flags: 0,
@@ -161,13 +161,13 @@ file:///mod.js: EsModuleInfo {
                 1,
             },
             exports: {
-                "JsExport": 1,
+                "MyInterface": 1,
             },
             members: {},
         },
         1: Symbol {
             module_id: ModuleId(
-                1,
+                0,
             ),
             symbol_id: 1,
             parent_id: Some(
@@ -177,15 +177,47 @@ file:///mod.js: EsModuleInfo {
                 SymbolDecl {
                     kind: Definition(
                         SymbolNode(
-                            "export class JsExport {}",
+                            "export interface MyInterface {\n  a: string;\n}",
                         ),
                     ),
                     range: SourceRange {
                         start: SourcePos(
-                            143,
+                            0,
                         ),
                         end: SourcePos(
-                            167,
+                            45,
+                        ),
+                    },
+                    flags: 0,
+                },
+            ],
+            child_ids: {},
+            exports: {},
+            members: {
+                2,
+            },
+        },
+        2: Symbol {
+            module_id: ModuleId(
+                0,
+            ),
+            symbol_id: 2,
+            parent_id: Some(
+                1,
+            ),
+            decls: [
+                SymbolDecl {
+                    kind: Definition(
+                        SymbolNode(
+                            "a: string;",
+                        ),
+                    ),
+                    range: SourceRange {
+                        start: SourcePos(
+                            33,
+                        ),
+                        end: SourcePos(
+                            43,
                         ),
                     },
                     flags: 0,


### PR DESCRIPTION
It was actually improperly doing this. I discovered while doing some refactors in the CLI.