### PR TITLE
fix: jsr specifier does not support tags

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -39,6 +39,8 @@ use deno_semver::npm::NpmPackageReqReference;
 use deno_semver::package::PackageNv;
 use deno_semver::package::PackageNvReference;
 use deno_semver::package::PackageReq;
+use deno_semver::package::PackageReqReferenceParseError;
+use deno_semver::RangeSetOrTag;
 use deno_semver::Version;
 use futures::future::LocalBoxFuture;
 use futures::future::Shared;
@@ -62,6 +64,7 @@ use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::fmt;
 use std::sync::Arc;
+use thiserror::Error;
 use url::Url;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
@@ -3508,7 +3511,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
     maybe_range: Option<Range>,
     is_dynamic: bool,
   ) {
-    match JsrPackageReqReference::from_specifier(&specifier) {
+    match validate_jsr_specifier(&specifier) {
       Ok(package_ref) => {
         if let Some(range) = &maybe_range {
           if let Some(nv) =
@@ -4120,6 +4123,25 @@ impl<'a, 'graph> Builder<'a, 'graph> {
   }
 }
 
+#[derive(Error, Debug, Clone)]
+pub enum JsrPackageFormatError {
+  #[error(transparent)]
+  JsrPackageParseError(PackageReqReferenceParseError),
+  #[error("Version tag not supported in jsr specifiers.")]
+  VersionTagNotSupported,
+}
+
+fn validate_jsr_specifier(
+  specifier: &Url,
+) -> Result<JsrPackageReqReference, JsrPackageFormatError> {
+  let package_ref = JsrPackageReqReference::from_specifier(specifier)
+    .map_err(JsrPackageFormatError::JsrPackageParseError)?;
+  match package_ref.req().version_req.inner() {
+    RangeSetOrTag::Tag(_) => Err(JsrPackageFormatError::VersionTagNotSupported),
+    RangeSetOrTag::RangeSet(_) => Ok(package_ref),
+  }
+}
+
 fn normalize_export_name(sub_path: Option<&str>) -> Cow<str> {
   let Some(sub_path) = sub_path else {
     return Cow::Borrowed(".");
@@ -4481,6 +4503,28 @@ mod tests {
       line: 2,
       character: 25
     }));
+  }
+
+  #[test]
+  fn test_jsr_import_format() {
+    assert!(
+      validate_jsr_specifier(&Url::parse("jsr:@scope/mod@tag").unwrap())
+        .is_err(),
+      "jsr import specifier with tag should be an error"
+    );
+
+    assert!(
+      validate_jsr_specifier(&Url::parse("jsr:@scope/mod@").unwrap()).is_err()
+    );
+
+    assert!(validate_jsr_specifier(
+      &Url::parse("jsr:@scope/mod@1.2.3").unwrap()
+    )
+    .is_ok());
+
+    assert!(
+      validate_jsr_specifier(&Url::parse("jsr:@scope/mod").unwrap()).is_ok()
+    );
   }
 
   #[test]

--- a/tests/specs/graph/JsrSpecifiers_VersionTagNotSupported.txt
+++ b/tests/specs/graph/JsrSpecifiers_VersionTagNotSupported.txt
@@ -1,0 +1,47 @@
+# https://jsr.io/@scope/a/meta.json
+{
+  "versions": {
+    "1.0.0": {}
+  }
+}
+
+# mod.ts
+import 'jsr:@scope/a@tag';
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "jsr:@scope/a@tag",
+          "code": {
+            "specifier": "jsr:@scope/a@tag",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 7
+              },
+              "end": {
+                "line": 0,
+                "character": 25
+              }
+            }
+          }
+        }
+      ],
+      "size": 27,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    },
+    {
+      "specifier": "jsr:@scope/a@tag",
+      "error": "Version tag not supported in jsr specifiers."
+    }
+  ],
+  "redirects": {}
+}


### PR DESCRIPTION
When a jsr specifier is used, an error is returned if the version segment contains a tag.

Fixes: https://github.com/denoland/deno/issues/22420