### PR TITLE
perf: remove range on dep descriptor

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -193,13 +193,6 @@ impl DependencyDescriptor {
       DependencyDescriptor::Dynamic(d) => &d.import_attributes,
     }
   }
-
-  pub fn range(&self) -> &PositionRange {
-    match self {
-      DependencyDescriptor::Static(d) => &d.range,
-      DependencyDescriptor::Dynamic(d) => &d.range,
-    }
-  }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -210,8 +203,6 @@ pub struct StaticDependencyDescriptor {
   /// further processing of supported pragma that impact the dependency.
   #[serde(skip_serializing_if = "Vec::is_empty", default)]
   pub leading_comments: Vec<Comment>,
-  /// The range of the import/export statement.
-  pub range: PositionRange,
   /// The text specifier associated with the import/export statement.
   pub specifier: String,
   /// The range of the specifier.
@@ -260,8 +251,6 @@ pub struct DynamicDependencyDescriptor {
   /// further processing of supported pragma that impact the dependency.
   #[serde(skip_serializing_if = "Vec::is_empty", default)]
   pub leading_comments: Vec<Comment>,
-  /// The range of the dynamic import.
-  pub range: PositionRange,
   /// The argument associated with the dynamic import.
   #[serde(skip_serializing_if = "DynamicArgument::is_expr", default)]
   pub argument: DynamicArgument,
@@ -368,16 +357,6 @@ mod test {
               },
             },
           }],
-          range: PositionRange {
-            start: Position {
-              line: 4,
-              character: 3,
-            },
-            end: Position {
-              line: 2,
-              character: 1,
-            },
-          },
           specifier: "./test".to_string(),
           specifier_range: PositionRange {
             start: Position {
@@ -394,10 +373,6 @@ mod test {
         .into(),
         DynamicDependencyDescriptor {
           leading_comments: vec![],
-          range: PositionRange {
-            start: Position::zeroed(),
-            end: Position::zeroed(),
-          },
           argument: DynamicArgument::String("./test2".to_string()),
           argument_range: PositionRange {
             start: Position::zeroed(),
@@ -428,12 +403,10 @@ mod test {
             "text": "a",
             "range": [[9, 7], [5, 3]],
           }],
-          "range": [[4, 3], [2, 1]],
           "specifier": "./test",
           "specifierRange": [[1, 2], [3, 4]],
         }, {
           "type": "dynamic",
-          "range": [[0, 0], [0, 0]],
           "argument": "./test2",
           "argumentRange": [[0, 0], [0, 0]],
           "importAttributes": {
@@ -549,10 +522,6 @@ mod test {
           end: Position::zeroed(),
         },
       }]),
-      range: PositionRange {
-        start: Position::zeroed(),
-        end: Position::zeroed(),
-      },
       specifier: "./test".to_string(),
       specifier_range: PositionRange {
         start: Position::zeroed(),
@@ -569,7 +538,6 @@ mod test {
           "text": "a",
           "range": [[0, 0], [0, 0]],
         }],
-        "range": [[0, 0], [0, 0]],
         "specifier": "./test",
         "specifierRange": [[0, 0], [0, 0]],
         "importAttributes": "unknown",
@@ -588,10 +556,6 @@ mod test {
             end: Position::zeroed(),
           },
         }]),
-        range: PositionRange {
-          start: Position::zeroed(),
-          end: Position::zeroed(),
-        },
         argument: DynamicArgument::Expr,
         argument_range: PositionRange {
           start: Position::zeroed(),
@@ -605,7 +569,6 @@ mod test {
           "text": "a",
           "range": [[0, 0], [0, 0]],
         }],
-        "range": [[0, 0], [0, 0]],
         "argumentRange": [[0, 0], [0, 0]],
         "importAttributes": "unknown",
       }),
@@ -620,10 +583,6 @@ mod test {
             end: Position::zeroed(),
           },
         }]),
-        range: PositionRange {
-          start: Position::zeroed(),
-          end: Position::zeroed(),
-        },
         argument: DynamicArgument::String("test".to_string()),
         argument_range: PositionRange {
           start: Position::zeroed(),
@@ -637,7 +596,6 @@ mod test {
           "text": "a",
           "range": [[0, 0], [0, 0]],
         }],
-        "range": [[0, 0], [0, 0]],
         "argument": "test",
         "argumentRange": [[0, 0], [0, 0]],
         "importAttributes": "unknown",

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -372,7 +372,6 @@ fn analyze_dependencies(
             .into_iter()
             .map(|c| Comment::from_dep_comment(c, text_info))
             .collect(),
-          range: PositionRange::from_source_range(d.range, text_info),
           specifier: d.specifier.to_string(),
           specifier_range: PositionRange::from_source_range(
             d.specifier_range,
@@ -388,7 +387,6 @@ fn analyze_dependencies(
             .into_iter()
             .map(|c| Comment::from_dep_comment(c, text_info))
             .collect(),
-          range: PositionRange::from_source_range(d.range, text_info),
           argument: match d.argument {
             deno_ast::dep::DynamicArgument::String(text) => {
               DynamicArgument::String(text.to_string())

--- a/tests/specs/graph/JsrSpecifiers_ModuleGraphInfo.txt
+++ b/tests/specs/graph/JsrSpecifiers_ModuleGraphInfo.txt
@@ -15,7 +15,6 @@
       "dependencies": [{
           "type": "static",
           "kind": "import",
-          "range": [[1, 2], [3, 4]],
           "specifier": "./a.ts",
           "specifierRange": [[5, 6], [7, 8]]
       }]
@@ -24,13 +23,11 @@
       "dependencies": [{
           "type": "static",
           "kind": "import",
-          "range": [[9, 10], [11, 12]],
           "specifier": "./b.ts",
           "specifierRange": [[13, 14], [15, 16]]
       }, {
           "type": "static",
           "kind": "import",
-          "range": [[1, 2], [3, 4]],
           "specifier": "jsr:@scope/b/export",
           "specifierRange": [[5, 6], [7, 8]]
       }]
@@ -55,7 +52,6 @@
       "dependencies": [{
         "type": "static",
         "kind": "import",
-        "range": [[1, 2], [3, 4]],
         "specifier": "./inner.ts",
         "specifierRange": [[5, 6], [7, 8]]
       }]

--- a/tests/specs/graph/JsrSpecifiers_ModuleGraphInfo_ModifiedCachedFiles.txt
+++ b/tests/specs/graph/JsrSpecifiers_ModuleGraphInfo_ModifiedCachedFiles.txt
@@ -15,7 +15,6 @@
       "dependencies": [{
           "type": "static",
           "kind": "import",
-          "range": [[1, 2], [3, 4]],
           "specifier": "./a.ts",
           "specifierRange": [[5, 6], [7, 8]]
       }]
@@ -24,13 +23,11 @@
       "dependencies": [{
           "type": "static",
           "kind": "import",
-          "range": [[9, 10], [11, 12]],
           "specifier": "./b.ts",
           "specifierRange": [[13, 14], [15, 16]]
       }, {
           "type": "static",
           "kind": "import",
-          "range": [[1, 2], [3, 4]],
           "specifier": "jsr:@scope/b",
           "specifierRange": [[5, 6], [7, 8]]
       }]
@@ -39,7 +36,6 @@
       "dependencies": [{
           "type": "static",
           "kind": "import",
-          "range": [[9, 10], [11, 12]],
           "specifier": "./c.ts",
           "specifierRange": [[13, 14], [15, 16]]
       }]
@@ -65,7 +61,6 @@
       "dependencies": [{
         "type": "static",
         "kind": "import",
-        "range": [[1, 2], [3, 4]],
         "specifier": "./inner.ts",
         "specifierRange": [[5, 6], [7, 8]]
       }]

--- a/tests/specs/graph/JsrSpecifiers_SamePackageMultipleTimes.txt
+++ b/tests/specs/graph/JsrSpecifiers_SamePackageMultipleTimes.txt
@@ -15,7 +15,6 @@
       "dependencies": [{
           "type": "static",
           "kind": "import",
-          "range": [[1, 2], [3, 4]],
           "specifier": "jsr:@scope/b@1",
           "specifierRange": [[5, 6], [7, 8]]
       }]


### PR DESCRIPTION
It is not used. The specifier and argument range seems good enough.