### PR TITLE
perf: spawn jsr futures on executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
  "data-url",
  "deno_ast",
  "deno_semver",
+ "deno_unsync",
  "encoding_rs",
  "futures",
  "import_map",
@@ -348,6 +349,15 @@ checksum = "7e6337d4e7f375f8b986409a76fbeecfa4bd8a1343e63355729ae4befa058eaf"
 dependencies = [
  "once_cell",
  "termcolor",
+]
+
+[[package]]
+name = "deno_unsync"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30dff7e03584dbae188dae96a0f1876740054809b2ad0cf7c9fc5d361f20e739"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ default = ["fast_check", "tokio_executor"]
 fast_check = ["symbols", "deno_ast/transpiling", "twox-hash"]
 symbols = ["deno_ast/transforms", "deno_ast/visit", "deno_ast/utils"]
 tokio_executor = ["deno_unsync"]
+wasm_executor = []
 
 [dependencies]
 anyhow = "1.0.43"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,10 @@ name = "deno_graph"
 all-features = true
 
 [features]
-default = ["fast_check"]
+default = ["fast_check", "tokio_executor"]
 fast_check = ["symbols", "deno_ast/transpiling", "twox-hash"]
 symbols = ["deno_ast/transforms", "deno_ast/visit", "deno_ast/utils"]
+tokio_executor = ["deno_unsync"]
 
 [dependencies]
 anyhow = "1.0.43"
@@ -29,6 +30,7 @@ async-trait = "0.1.68"
 data-url = "0.3.0"
 deno_ast = { version = "0.33.1", features = ["dep_analysis"] }
 deno_semver = "0.5.4"
+deno_unsync = { version = "0.3.2", optional = true }
 encoding_rs = "0.8.33"
 futures = "0.3.26"
 import_map = "0.18.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = "1.0.43"
 console_error_panic_hook = "0.1.7"
-deno_graph = { path = "../" }
+deno_graph = { path = "../", default-features = false, features = ["fast_check"] }
 getrandom = { version = "*", features = ["js"] }
 futures = "0.3.17"
 js-sys = "0.3.63"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = "1.0.43"
 console_error_panic_hook = "0.1.7"
-deno_graph = { path = "../", default-features = false, features = ["fast_check", "wasm_executor"] }
+deno_graph = { path = "../", default-features = false, features = ["wasm_executor"] }
 getrandom = { version = "*", features = ["js"] }
 futures = "0.3.17"
 js-sys = "0.3.63"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = "1.0.43"
 console_error_panic_hook = "0.1.7"
-deno_graph = { path = "../", default-features = false, features = ["fast_check"] }
+deno_graph = { path = "../", default-features = false, features = ["fast_check", "wasm_executor"] }
 getrandom = { version = "*", features = ["js"] }
 futures = "0.3.17"
 js-sys = "0.3.63"

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -195,6 +195,22 @@ impl Resolver for JsResolver {
   }
 }
 
+struct WasmExecutor;
+
+impl deno_graph::Executor for WasmExecutor {
+  fn execute(
+    &self,
+    future: futures::future::LocalBoxFuture<'static, ()>,
+  ) -> futures::future::LocalBoxFuture<'static, ()> {
+    // TODO(littledivy): bug in wasm_bindgen where Shared futures panic on spawn.
+    // https://github.com/rustwasm/wasm-bindgen/issues/2562
+    //
+    // Box::pin(async move { wasm_bindgen_futures::spawn_local(future) })
+
+    future
+  }
+}
+
 #[wasm_bindgen(js_name = createGraph)]
 #[allow(clippy::too_many_arguments)]
 pub async fn js_create_graph(
@@ -271,6 +287,7 @@ pub async fn js_create_graph(
         imports,
         reporter: None,
         workspace_members: &[],
+        executor: &WasmExecutor,
       },
     )
     .await;

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -195,22 +195,6 @@ impl Resolver for JsResolver {
   }
 }
 
-struct WasmExecutor;
-
-impl deno_graph::Executor for WasmExecutor {
-  fn execute(
-    &self,
-    future: futures::future::LocalBoxFuture<'static, ()>,
-  ) -> futures::future::LocalBoxFuture<'static, ()> {
-    // TODO(littledivy): bug in wasm_bindgen where Shared futures panic on spawn.
-    // https://github.com/rustwasm/wasm-bindgen/issues/2562
-    //
-    // Box::pin(async move { wasm_bindgen_futures::spawn_local(future) })
-
-    future
-  }
-}
-
 #[wasm_bindgen(js_name = createGraph)]
 #[allow(clippy::too_many_arguments)]
 pub async fn js_create_graph(
@@ -287,7 +271,7 @@ pub async fn js_create_graph(
         imports,
         reporter: None,
         workspace_members: &[],
-        executor: &WasmExecutor,
+        executor: Default::default(),
       },
     )
     .await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod analyzer;
 mod ast;
 mod graph;
 mod module_specifier;
+mod rt;
 
 #[cfg(feature = "symbols")]
 pub mod symbols;
@@ -85,6 +86,7 @@ pub use graph::WorkspaceMember;
 pub use module_specifier::resolve_import;
 pub use module_specifier::ModuleSpecifier;
 pub use module_specifier::SpecifierError;
+pub use rt::Executor;
 pub use source::NpmPackageReqResolution;
 
 pub use deno_ast::dep::DependencyKind;

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -1,0 +1,52 @@
+use futures::channel::oneshot;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
+
+pub type BoxedFuture = Pin<Box<dyn Future<Output = ()> + 'static>>;
+
+/// An executor for futures.
+///
+/// This trait allows deno_graph to run background tasks on
+/// the async executor.
+pub trait Executor {
+  /// Spawns a future to run on this executor.
+  fn execute(&self, fut: BoxedFuture) -> BoxedFuture;
+}
+
+pub(crate) struct JoinHandle<T> {
+  rx: oneshot::Receiver<T>,
+  fut: BoxedFuture,
+}
+
+impl<T> Future for JoinHandle<T> {
+  type Output = T;
+
+  fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    if let Poll::Ready(()) = Pin::new(&mut self.fut).poll(cx) {
+      if let Poll::Ready(Ok(res)) = Pin::new(&mut self.rx).poll(cx) {
+        Poll::Ready(res)
+      } else {
+        panic!("task panic");
+      }
+    } else {
+      Poll::Pending
+    }
+  }
+}
+
+pub(crate) fn spawn<F, T: 'static>(
+  executor: &dyn Executor,
+  f: F,
+) -> JoinHandle<T>
+where
+  F: Future<Output = T> + 'static,
+{
+  let (tx, rx) = oneshot::channel();
+  let fut = executor.execute(Box::pin(async move {
+    tx.send(f.await).ok();
+  }));
+
+  JoinHandle { rx, fut }
+}

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -19,20 +19,20 @@ pub trait Executor {
 
 impl<'a> Default for &'a dyn Executor {
   fn default() -> &'a dyn Executor {
-    #[cfg(not(feature = "tokio_executor"))]
-    unimplemented!("deno_graph Builder requires an executor to be provided");
-
-    #[cfg(feature = "tokio_executor")]
     {
-      struct SpawnExecutor;
+      struct DefaultExecutor;
 
-      impl Executor for SpawnExecutor {
+      impl Executor for DefaultExecutor {
         fn execute(&self, future: BoxedFuture) -> BoxedFuture {
+          #[cfg(not(feature = "tokio_executor"))]
+          return future;
+
+          #[cfg(feature = "tokio_executor")]
           Box::pin(async { deno_unsync::spawn(future).await.unwrap() })
         }
       }
 
-      &SpawnExecutor
+      &DefaultExecutor
     }
   }
 }


### PR DESCRIPTION
Adds an abstract trait for executing futures onto an async runtime. 

A default Tokio spawn executor is included behing the `tokio_executor` feature flag.

Closes https://github.com/denoland/deno_graph/issues/394