### PR TITLE
fix(fast_check): regression in cache with diagnostics

### DIFF
--- a/src/fast_check/mod.rs
+++ b/src/fast_check/mod.rs
@@ -530,7 +530,7 @@ pub fn build_fast_check_type_graph<'a>(
         final_result.extend(fast_check_modules);
       }
     } else {
-      // these were sources in the cache, so use those
+      // use the items from the cache
       final_result.extend(package.cache_items);
     }
 

--- a/src/fast_check/mod.rs
+++ b/src/fast_check/mod.rs
@@ -557,7 +557,9 @@ fn transform_package(
   )>,
 ) {
   for (specifier, mut ranges) in package_module_ranges {
-    let module_info = root_symbol.module_from_specifier(&specifier).unwrap();
+    let module_info = root_symbol
+      .module_from_specifier(&specifier)
+      .unwrap_or_else(|| panic!("module not found: {}", specifier));
     if let Some(module_info) = module_info.esm() {
       let diagnostics = ranges.take_diagnostics();
       let transform_result = if diagnostics.is_empty() {

--- a/src/fast_check/mod.rs
+++ b/src/fast_check/mod.rs
@@ -461,7 +461,7 @@ pub fn build_fast_check_type_graph<'a>(
 
     let mut fast_check_modules =
       Vec::with_capacity(package.module_ranges.len());
-    if package.sources.is_empty() {
+    if package.cache_items.is_empty() {
       transform_package(
         package.module_ranges,
         root_symbol,
@@ -531,12 +531,7 @@ pub fn build_fast_check_type_graph<'a>(
       }
     } else {
       // these were sources in the cache, so use those
-      final_result.extend(
-        package
-          .sources
-          .into_iter()
-          .map(|(url, module_item)| (url, Ok(module_item))),
-      );
+      final_result.extend(package.cache_items);
     }
 
     if !errors.is_empty() {

--- a/src/fast_check/range_finder.rs
+++ b/src/fast_check/range_finder.rs
@@ -341,7 +341,7 @@ pub struct PackagePublicRanges {
   // uses an IndexMap to maintain order so that when transforming
   // it goes over the modules in the exact same deterministic order
   pub module_ranges: IndexMap<ModuleSpecifier, ModulePublicRanges>,
-  /// Sources that were loaded from the cache.
+  /// Items loaded from the cache. If set, these should be used over module_ranges.
   pub cache_items: Vec<(
     ModuleSpecifier,
     Result<FastCheckModule, Vec<FastCheckDiagnostic>>,


### PR DESCRIPTION
Fixes a bug I introduced in #401 where modules that are not exports of a pkg that contained a fast check diagnostic would not be invalidated when they changed in all scenarios. This is very tedious to test in deno_graph and much easier to test in integration in the CLI, where this was caught.

I had run the jsr tests in the CLI when I made that change, but maybe I didn't have it hooked up properly and ended up not actually running them on that change.