### PR TITLE
fix: emit jsdocs in dts emit

### DIFF
--- a/src/fast_check/mod.rs
+++ b/src/fast_check/mod.rs
@@ -557,7 +557,9 @@ fn transform_package(
   )>,
 ) {
   for (specifier, mut ranges) in package_module_ranges {
-    let module_info = root_symbol.module_from_specifier(&specifier).unwrap();
+    let module_info = root_symbol
+      .module_from_specifier(&specifier)
+      .unwrap_or_else(|| panic!("module not found: {}", specifier));
     if let Some(module_info) = module_info.esm() {
       let diagnostics = ranges.take_diagnostics();
       let transform_result = if diagnostics.is_empty() {

--- a/src/fast_check/transform.rs
+++ b/src/fast_check/transform.rs
@@ -122,33 +122,45 @@ pub fn transform(
     &comments,
   );
 
-  let comments = comments.into_single_threaded();
+  // swc will modify the comment collection internally when emitting,
+  // so if we're emitting with dts, make a copy of the comments for
+  // each emit
+  let (fast_check_comments, dts_comments) = if options.dts {
+    (
+      comments.as_single_threaded(),
+      Some(comments.into_single_threaded()),
+    )
+  } else {
+    (comments.into_single_threaded(), None)
+  };
 
   // now emit
-  let (text, source_map) =
-    emit(specifier, &comments, parsed_source.text_info(), &module).map_err(
-      |e| {
-        vec![FastCheckDiagnostic::Emit {
-          specifier: specifier.clone(),
-          inner: Arc::new(e),
-        }]
-      },
-    )?;
+  let (text, source_map) = emit(
+    specifier,
+    &fast_check_comments,
+    parsed_source.text_info(),
+    &module,
+  )
+  .map_err(|e| {
+    vec![FastCheckDiagnostic::Emit {
+      specifier: specifier.clone(),
+      inner: Arc::new(e),
+    }]
+  })?;
 
-  let dts = if options.dts {
+  let dts = if let Some(dts_comments) = dts_comments {
     let mut dts_transformer =
-      FastCheckDtsTransformer::new(parsed_source, specifier);
+      FastCheckDtsTransformer::new(parsed_source.text_info(), specifier);
 
     let module = dts_transformer.transform(module)?;
     let (text, _source_map) =
-      emit(specifier, &comments, parsed_source.text_info(), &module).map_err(
-        |e| {
+      emit(specifier, &dts_comments, parsed_source.text_info(), &module)
+        .map_err(|e| {
           vec![FastCheckDiagnostic::Emit {
             specifier: specifier.clone(),
             inner: Arc::new(e),
           }]
-        },
-      )?;
+        })?;
 
     Some(FastCheckDtsModule {
       text,

--- a/src/fast_check/transform_dts.rs
+++ b/src/fast_check/transform_dts.rs
@@ -1,9 +1,9 @@
 use deno_ast::swc::ast::*;
 use deno_ast::swc::common::DUMMY_SP;
 use deno_ast::ModuleSpecifier;
-use deno_ast::ParsedSource;
 use deno_ast::SourceRange;
 use deno_ast::SourceRangedForSpanned;
+use deno_ast::SourceTextInfo;
 
 use crate::FastCheckDiagnostic;
 use crate::FastCheckDiagnosticRange;
@@ -65,19 +65,19 @@ impl FastCheckDtsDiagnostic {
 
 pub struct FastCheckDtsTransformer<'a> {
   id_counter: usize,
-  parsed_source: &'a ParsedSource,
+  text_info: &'a SourceTextInfo,
   pub diagnostics: Vec<FastCheckDtsDiagnostic>,
   specifier: &'a ModuleSpecifier,
 }
 
 impl<'a> FastCheckDtsTransformer<'a> {
   pub fn new(
-    parsed_source: &'a ParsedSource,
+    text_info: &'a SourceTextInfo,
     specifier: &'a ModuleSpecifier,
   ) -> Self {
     Self {
       id_counter: 0,
-      parsed_source,
+      text_info,
       specifier,
       diagnostics: vec![],
     }
@@ -98,7 +98,7 @@ impl<'a> FastCheckDtsTransformer<'a> {
   ) -> FastCheckDiagnosticRange {
     FastCheckDiagnosticRange {
       specifier: self.specifier.clone(),
-      text_info: self.parsed_source.text_info().clone(),
+      text_info: self.text_info.clone(),
       range,
     }
   }
@@ -971,7 +971,7 @@ mod tests {
     let module = parsed_source.module().to_owned();
 
     let mut transformer =
-      FastCheckDtsTransformer::new(parsed_source, &specifier);
+      FastCheckDtsTransformer::new(parsed_source.text_info(), &specifier);
     let module = transformer.transform(module).unwrap();
 
     let comments = parsed_source.comments().as_single_threaded();

--- a/tests/specs/graph/JsrSpecifiers_FastCheck.txt
+++ b/tests/specs/graph/JsrSpecifiers_FastCheck.txt
@@ -270,7 +270,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   --- DTS ---
   import { A1, A3 as RenamedA3, A4, A6 } from "./a.ts";
   export declare class Test {
-    noReturnTypeVoid(param?: number, param2?: string): void;
+    /** Testing */ noReturnTypeVoid(param?: number, param2?: string): void;
     noReturnTypeAsync(): Promise<void>;
     returnTypeGenerator(): Generator<unknown, any, any>;
     hasReturnType(): A1 & RenamedA3 | A4 | A6;

--- a/tests/specs/graph/JsrSpecifiers_FastCheck_ClassCtors.txt
+++ b/tests/specs/graph/JsrSpecifiers_FastCheck_ClassCtors.txt
@@ -5,7 +5,9 @@
 { "exports": { ".": "./mod.ts" } }
 
 # https://jsr.io/@scope/a/1.0.0/mod.ts
+/** A */
 export class ClassBasic {
+  /** B */
   constructor(prop: string, other = 5) {
   }
 }
@@ -95,7 +97,7 @@ import 'jsr:@scope/a'
     },
     {
       "kind": "esm",
-      "size": 1259,
+      "size": 1279,
       "mediaType": "TypeScript",
       "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
     }
@@ -110,8 +112,8 @@ import 'jsr:@scope/a'
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   {}
-  export class ClassBasic {
-    constructor(prop: string, other?: number){}
+  /** A */ export class ClassBasic {
+    /** B */ constructor(prop: string, other?: number){}
   }
   export class ClassPrivateCtor {
     private constructor(){}
@@ -160,8 +162,8 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   class Public5 {
   }
   --- DTS ---
-  export declare class ClassBasic {
-    constructor(prop: string, other?: number);
+  /** A */ export declare class ClassBasic {
+    /** B */ constructor(prop: string, other?: number);
   }
   export declare class ClassPrivateCtor {
     private constructor();

--- a/tests/specs/graph/JsrSpecifiers_FastCheck_Comments.txt
+++ b/tests/specs/graph/JsrSpecifiers_FastCheck_Comments.txt
@@ -63,4 +63,5 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   // @ts-ignore broken line
   export const value1: number = {} as any;
   --- DTS ---
+  // @ts-ignore broken line
   export declare const value1: number;

--- a/tests/specs/graph/JsrSpecifiers_FastCheck_Functions.txt
+++ b/tests/specs/graph/JsrSpecifiers_FastCheck_Functions.txt
@@ -9,6 +9,7 @@ export function test1() {}
 export function test2(): number {
   return 2;
 }
+/** Some Doc **/
 export function test3(param: number): number {
 }
 export function test4(param = 2): number {
@@ -105,7 +106,7 @@ import 'jsr:@scope/a'
     },
     {
       "kind": "esm",
-      "size": 1499,
+      "size": 1516,
       "mediaType": "TypeScript",
       "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
     }
@@ -124,7 +125,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   export function test2(): number {
     return {} as any;
   }
-  export function test3(param: number): number {
+  /** Some Doc **/ export function test3(param: number): number {
     return {} as any;
   }
   export function test4(param?: number): number {
@@ -175,7 +176,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   --- DTS ---
   export function test1(): void;
   export function test2(): number;
-  export function test3(param: number): number;
+  /** Some Doc **/ export function test3(param: number): number;
   export function test4(param?: number): number;
   export function test5<T extends PublicOther>(param?: number): T;
   export function test6<T = PublicOther>(param?: number): T;

--- a/tests/specs/graph/JsrSpecifiers_FastCheck_RefObjType.txt
+++ b/tests/specs/graph/JsrSpecifiers_FastCheck_RefObjType.txt
@@ -77,9 +77,9 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   export type Status = typeof STATUS_CODE.Continue;
   --- DTS ---
   export declare const STATUS_CODE: {
-    readonly Continue: number;
-    readonly SwitchingProtocols: number;
-    readonly Processing: number;
-    readonly EarlyHints: number;
+    readonly /** RFC 7231, 6.2.1 */ Continue: number;
+    readonly /** RFC 7231, 6.2.2 */ SwitchingProtocols: number;
+    readonly /** RFC 2518, 10.1 */ Processing: number;
+    readonly /** RFC 8297 **/ EarlyHints: number;
   };
   export type Status = typeof STATUS_CODE.Continue;


### PR DESCRIPTION
This was tricky. swc was modifying an Rc<RefCell<T>> in the comments collection during emit as a way of saying "I already emitted this comment", so we need to deep clone it.