### PR TITLE
fix: relative dynamic imports in jsr packages

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2805,7 +2805,7 @@ struct PendingJsrState {
 
 struct PendingDynamicBranch {
   range: Range,
-  maybe_assert_type: Option<AttributeTypeWithRange>,
+  maybe_attribute_type: Option<AttributeTypeWithRange>,
   maybe_version_info: Option<JsrPackageVersionInfoExt>,
 }
 
@@ -3007,13 +3007,13 @@ impl<'a, 'graph> Builder<'a, 'graph> {
                 ))),
               );
             } else {
-              let assert_types =
+              let attribute_types =
                 self.state.pending_specifiers.remove(&specifier).unwrap();
-              for maybe_assert_type in assert_types {
+              for maybe_attribute_type in attribute_types {
                 self.visit(
                   &specifier,
                   &response,
-                  maybe_assert_type,
+                  maybe_attribute_type,
                   maybe_range.clone(),
                   maybe_version_info.as_ref(),
                 )
@@ -3279,7 +3279,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
             &specifier,
             Some(&dynamic_branch.range),
             true,
-            dynamic_branch.maybe_assert_type,
+            dynamic_branch.maybe_attribute_type,
             dynamic_branch.maybe_version_info.as_ref(),
           );
         }
@@ -3524,7 +3524,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
     specifier: &ModuleSpecifier,
     maybe_range: Option<&Range>,
     is_dynamic: bool,
-    maybe_assert_type: Option<AttributeTypeWithRange>,
+    maybe_attribute_type: Option<AttributeTypeWithRange>,
     maybe_version_info: Option<&JsrPackageVersionInfoExt>,
   ) {
     let specifier = self.graph.redirects.get(specifier).unwrap_or(specifier);
@@ -3533,7 +3533,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
       .pending_specifiers
       .entry(specifier.clone())
       .or_default()
-      .insert(maybe_assert_type);
+      .insert(maybe_attribute_type);
     if self.graph.module_slots.contains_key(specifier) {
       return;
     }
@@ -4024,7 +4024,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
     &mut self,
     requested_specifier: &ModuleSpecifier,
     response: &PendingInfoResponse,
-    maybe_assert_type: Option<AttributeTypeWithRange>,
+    maybe_attribute_type: Option<AttributeTypeWithRange>,
     maybe_referrer: Option<Range>,
     maybe_version_info: Option<&JsrPackageVersionInfoExt>,
   ) {
@@ -4049,7 +4049,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
             specifier,
             maybe_headers.as_ref(),
             content_or_module_info.clone(),
-            maybe_assert_type,
+            maybe_attribute_type,
             maybe_referrer,
             maybe_version_info,
           ),
@@ -4068,7 +4068,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
     specifier: &ModuleSpecifier,
     maybe_headers: Option<&HashMap<String, String>>,
     content_or_module_info: ContentOrModuleInfo,
-    maybe_assert_type: Option<AttributeTypeWithRange>,
+    maybe_attribute_type: Option<AttributeTypeWithRange>,
     maybe_referrer: Option<Range>,
     maybe_version_info: Option<&JsrPackageVersionInfoExt>,
   ) -> ModuleSlot {
@@ -4126,7 +4126,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
       specifier,
       maybe_headers,
       content,
-      maybe_assert_type,
+      maybe_attribute_type,
       maybe_referrer,
       self.file_system,
       self.resolver,
@@ -4155,7 +4155,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
             if let Resolution::Ok(resolved) = &dep.maybe_code {
               let specifier = &resolved.specifier;
               let range = &resolved.range;
-              let maybe_assert_type =
+              let maybe_attribute_type =
                 dep.maybe_attribute_type.as_ref().map(|assert_type| {
                   AttributeTypeWithRange {
                     range: range.clone(),
@@ -4167,7 +4167,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
                   specifier.clone(),
                   PendingDynamicBranch {
                     range: range.clone(),
-                    maybe_assert_type,
+                    maybe_attribute_type,
                     maybe_version_info: maybe_version_info
                       .map(ToOwned::to_owned),
                   },
@@ -4177,7 +4177,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
                   specifier,
                   Some(range),
                   self.in_dynamic_branch,
-                  maybe_assert_type,
+                  maybe_attribute_type,
                   maybe_version_info,
                 );
               }
@@ -4190,7 +4190,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
             if let Resolution::Ok(resolved) = &dep.maybe_type {
               let specifier = &resolved.specifier;
               let range = &resolved.range;
-              let maybe_assert_type =
+              let maybe_attribute_type =
                 dep.maybe_attribute_type.as_ref().map(|assert_type| {
                   AttributeTypeWithRange {
                     range: range.clone(),
@@ -4202,7 +4202,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
                   specifier.clone(),
                   PendingDynamicBranch {
                     range: range.clone(),
-                    maybe_assert_type,
+                    maybe_attribute_type,
                     maybe_version_info: maybe_version_info
                       .map(ToOwned::to_owned),
                   },
@@ -4212,7 +4212,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
                   specifier,
                   Some(range),
                   self.in_dynamic_branch,
-                  maybe_assert_type,
+                  maybe_attribute_type,
                   maybe_version_info,
                 );
               }

--- a/tests/helpers/test_builder.rs
+++ b/tests/helpers/test_builder.rs
@@ -249,21 +249,23 @@ impl TestBuilder {
     } else {
       None
     };
-    graph.build_fast_check_type_graph(
-      deno_graph::BuildFastCheckTypeGraphOptions {
-        fast_check_cache: fast_check_cache.as_ref().map(|c| c as _),
-        fast_check_dts: !self.fast_check_cache,
-        jsr_url_provider: None,
-        module_parser: Some(&capturing_analyzer),
-        resolver: None,
-        npm_resolver: None,
-        workspace_fast_check: if self.workspace_fast_check {
-          WorkspaceFastCheckOption::Enabled(&self.workspace_members)
-        } else {
-          WorkspaceFastCheckOption::Disabled
+    if graph.module_errors().next().is_none() {
+      graph.build_fast_check_type_graph(
+        deno_graph::BuildFastCheckTypeGraphOptions {
+          fast_check_cache: fast_check_cache.as_ref().map(|c| c as _),
+          fast_check_dts: !self.fast_check_cache,
+          jsr_url_provider: None,
+          module_parser: Some(&capturing_analyzer),
+          resolver: None,
+          npm_resolver: None,
+          workspace_fast_check: if self.workspace_fast_check {
+            WorkspaceFastCheckOption::Enabled(&self.workspace_members)
+          } else {
+            WorkspaceFastCheckOption::Disabled
+          },
         },
-      },
-    );
+      );
+    }
     BuildResult {
       graph,
       diagnostics,

--- a/tests/specs/graph/jsr/DynamicImport.txt
+++ b/tests/specs/graph/jsr/DynamicImport.txt
@@ -1,0 +1,133 @@
+# https://jsr.io/@scope/a/meta.json
+{"versions": { "1.0.0": {} } }
+
+# https://jsr.io/@scope/a/1.0.0_meta.json
+{
+  "exports": {
+    ".": "./mod.ts"
+  }
+}
+# https://jsr.io/@scope/a/1.0.0/mod.ts
+const test: typeof import('./a.ts') = await import("./a.ts");
+export { test };
+
+# https://jsr.io/@scope/a/1.0.0/a.ts
+export class Test {}
+
+# mod.ts
+import "jsr:@scope/a";
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "jsr:@scope/a",
+          "code": {
+            "specifier": "jsr:@scope/a",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 7
+              },
+              "end": {
+                "line": 0,
+                "character": 21
+              }
+            }
+          }
+        }
+      ],
+      "size": 23,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 21,
+      "mediaType": "TypeScript",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts"
+    },
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "./a.ts",
+          "code": {
+            "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 51
+              },
+              "end": {
+                "line": 0,
+                "character": 59
+              }
+            }
+          },
+          "type": {
+            "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 26
+              },
+              "end": {
+                "line": 0,
+                "character": 34
+              }
+            }
+          },
+          "isDynamic": true
+        }
+      ],
+      "size": 79,
+      "mediaType": "TypeScript",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+    }
+  ],
+  "redirects": {
+    "jsr:@scope/a": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+  },
+  "packages": {
+    "@scope/a": "@scope/a@1.0.0"
+  }
+}
+
+Fast check https://jsr.io/@scope/a/1.0.0/a.ts:
+  {}
+  export class Test {
+  }
+  --- DTS ---
+  export declare class Test {
+  }
+
+Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
+  {
+    "./a.ts": {
+      "type": {
+        "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+        "span": {
+          "start": {
+            "line": 0,
+            "character": 26
+          },
+          "end": {
+            "line": 0,
+            "character": 34
+          }
+        }
+      }
+    }
+  }
+  const test: typeof import('./a.ts') = {} as any;
+  export { test };
+  --- DTS ---
+  declare const test: typeof import('./a.ts');
+  export { test };

--- a/tests/specs/graph/jsr/DynamicImportInvalidChecksum.txt
+++ b/tests/specs/graph/jsr/DynamicImportInvalidChecksum.txt
@@ -2,17 +2,25 @@
 {"versions": { "1.0.0": {} } }
 
 # https://jsr.io/@scope/a/1.0.0_meta.json
-{ "exports": { ".": "./mod.ts" } }
-
+{
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "manifest": {
+    "/a.ts": {
+      "checksum": "sha256-invalid"
+    }
+  }
+}
 # https://jsr.io/@scope/a/1.0.0/mod.ts
-import test = require("./other.ts");
+const test = await import("./a.ts");
+export { test };
 
-console.log(test);
-
-# https://jsr.io/@scope/a/1.0.0/other.ts
+# https://jsr.io/@scope/a/1.0.0/a.ts
+export class Test {}
 
 # mod.ts
-import 'jsr:@scope/a'
+import "jsr:@scope/a";
 
 # output
 {
@@ -40,39 +48,38 @@ import 'jsr:@scope/a'
           }
         }
       ],
-      "size": 22,
+      "size": 23,
       "mediaType": "TypeScript",
       "specifier": "file:///mod.ts"
+    },
+    {
+      "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+      "error": "Integrity check failed.\n\nActual: 151a3a3f4587a29c7b3449a3635fed35c4e88a3a773b3bf296804f1a4e1ab86d\nExpected: invalid"
     },
     {
       "kind": "esm",
       "dependencies": [
         {
-          "specifier": "./other.ts",
+          "specifier": "./a.ts",
           "code": {
-            "specifier": "https://jsr.io/@scope/a/1.0.0/other.ts",
+            "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
             "span": {
               "start": {
                 "line": 0,
-                "character": 22
+                "character": 26
               },
               "end": {
                 "line": 0,
                 "character": 34
               }
             }
-          }
+          },
+          "isDynamic": true
         }
       ],
-      "size": 57,
+      "size": 54,
       "mediaType": "TypeScript",
       "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
-    },
-    {
-      "kind": "esm",
-      "size": 0,
-      "mediaType": "TypeScript",
-      "specifier": "https://jsr.io/@scope/a/1.0.0/other.ts"
     }
   ],
   "redirects": {
@@ -82,7 +89,3 @@ import 'jsr:@scope/a'
     "@scope/a": "@scope/a@1.0.0"
   }
 }
-
-Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  require statements are a CommonJS feature, which are not supported in ES modules
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@0

--- a/tests/specs/graph/jsr/ImportViaHttps.txt
+++ b/tests/specs/graph/jsr/ImportViaHttps.txt
@@ -3,12 +3,6 @@
 
 # https://jsr.io/@scope/a/1.0.0_meta.json
 {
-  "checksums": {
-    "mod.ts": {
-      "size": 21,
-      "checksum": "151a3a3f4587a29c7b3449a3635fed35c4e88a3a773b3bf296804f1a4e1ab86d"
-    }
-  },
   "exports": {
     ".": "./mod.ts"
   },


### PR DESCRIPTION
We accidentally weren't passing around the version's manifest for dyanmic imports, so it was thinking it was doing an https import from a non-JSR package.