### PR TITLE
chore: fix publishing for jsr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,4 +84,4 @@ jobs:
         if: contains(matrix.os, 'ubuntu') && startsWith(github.ref, 'refs/tags/')
         run: |
           deno run -A ./scripts/update_deno_json_version.ts ${{steps.get_tag_version.outputs.TAG_VERSION}}
-          cd js && deno publish
+          cd js && deno publish --allow-dirty

--- a/deno.json
+++ b/deno.json
@@ -6,8 +6,7 @@
   },
   "exclude": [
     "npm",
-    "target",
-    "temp"
+    "target"
   ],
   "workspaces": [
     "./js"

--- a/js/deno.json
+++ b/js/deno.json
@@ -5,5 +5,10 @@
     ".": "./mod.ts",
     "./loader": "./loader.ts",
     "./types": "./types.ts"
+  },
+  "publish": {
+    "exclude": [
+      "!**"
+    ]
   }
 }


### PR DESCRIPTION
The gitignore will now be correctly taken into account so we need to un-ignore the files in the js directory.