### PR TITLE
feat(fast_check): infer type literals

### DIFF
--- a/src/fast_check/transform.rs
+++ b/src/fast_check/transform.rs
@@ -1568,7 +1568,7 @@ fn infer_simple_type_from_type(t: &TsType) -> Option<TsType> {
       },
     })),
     TsType::TsTypeQuery(_) => None,
-    TsType::TsTypeLit(_) => None,
+    TsType::TsTypeLit(t) => Some(TsType::TsTypeLit(t.clone())),
     TsType::TsTupleType(t) => {
       let mut elems = Vec::with_capacity(t.elem_types.len());
       for elem_type in &t.elem_types {

--- a/tests/specs/graph/jsr/FastCheck_TypeAssertion.txt
+++ b/tests/specs/graph/jsr/FastCheck_TypeAssertion.txt
@@ -9,6 +9,8 @@ export class Application<S> {
   prop: S;
 }
 
+export const str = "foo" as "foo" & { __brand: "foo" }
+
 export function createMockApp<
   S extends Record<string | number | symbol, any> = Record<string, any>,
 >(
@@ -71,7 +73,7 @@ import 'jsr:@scope/a'
     },
     {
       "kind": "esm",
-      "size": 580,
+      "size": 636,
       "mediaType": "TypeScript",
       "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
     }
@@ -89,6 +91,9 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   export class Application<S> {
     prop!: S;
   }
+  export const str: "foo" & {
+    __brand: "foo";
+  } = {} as any;
   export function createMockApp<S extends Record<string | number | symbol, any> = Record<string, any>>(state?: S): Application<S> {
     return {} as any;
   }
@@ -115,6 +120,9 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   export declare class Application<S> {
     prop: S;
   }
+  export declare const str: "foo" & {
+    __brand: "foo";
+  };
   export function createMockApp<S extends Record<string | number | symbol, any> = Record<string, any>>(state?: S): Application<S>;
   export declare class A {
     prop: Public1;

--- a/tests/specs/graph/jsr/FastCheck_TypeAssertion.txt
+++ b/tests/specs/graph/jsr/FastCheck_TypeAssertion.txt
@@ -38,6 +38,9 @@ interface Public4 {}
 interface Public5 {}
 interface Public6 {}
 
+class Public7 {}
+export const str2 = "foo" as "foo" & { data: Public7 };
+
 # mod.ts
 import 'jsr:@scope/a'
 
@@ -73,7 +76,7 @@ import 'jsr:@scope/a'
     },
     {
       "kind": "esm",
-      "size": 636,
+      "size": 710,
       "mediaType": "TypeScript",
       "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
     }
@@ -116,6 +119,11 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   }
   interface Public6 {
   }
+  class Public7 {
+  }
+  export const str2: "foo" & {
+    data: Public7;
+  } = {} as any;
   --- DTS ---
   export declare class Application<S> {
     prop: S;
@@ -143,3 +151,8 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   }
   interface Public6 {
   }
+  declare class Public7 {
+  }
+  export declare const str2: "foo" & {
+    data: Public7;
+  };


### PR DESCRIPTION
This PR adds support for inferring the type of an expression initializer for an exported var declaration. This is needed to make branded types work with fast-check and our dts transform.

```ts
// input
export const foo = "foo" as "foo" & { __brand: "foo" };

// Fast check output
export const foo: "foo" & { __brand: "foo" } = {} as any;

// DTS
export const foo: "foo" & { __brand: "foo" };
```