### PR TITLE
fix(fast_check): better property output

### DIFF
--- a/tests/specs/graph/jsr/FastCheck.txt
+++ b/tests/specs/graph/jsr/FastCheck.txt
@@ -265,7 +265,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     hasReturnType(): A1 & RenamedA3 | A4 | A6 {
       return {} as any;
     }
-    private inner!: unknown;
+    declare private inner: unknown;
   }
   --- DTS ---
   import { A1, A3 as RenamedA3, A4, A6 } from "./a.ts";

--- a/tests/specs/graph/jsr/FastCheckCache_Basic.txt
+++ b/tests/specs/graph/jsr/FastCheckCache_Basic.txt
@@ -282,7 +282,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     hasReturnType(): A1 & RenamedA3 | A4 | A6 {
       return {} as any;
     }
-    private inner!: unknown;
+    declare private inner: unknown;
   }
 
 == fast check cache ==

--- a/tests/specs/graph/jsr/FastCheck_ClassCtors.txt
+++ b/tests/specs/graph/jsr/FastCheck_ClassCtors.txt
@@ -143,22 +143,22 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     constructor(param0?: any){}
   }
   export class ClassPrivateCtorPublicParamProp {
-    param1!: Public2;
-    private param2!: unknown;
+    declare param1: Public2;
+    declare private param2: unknown;
     private constructor(){}
   }
   export class ClassCtorPublicParamProp {
-    param1!: Public3;
-    private param2!: unknown;
-    private param3!: unknown;
+    declare param1: Public3;
+    declare private param2: unknown;
+    declare private param3: unknown;
     constructor(param1: Public3, param2: Public4, param3?: Public5){}
   }
   export class ClassCtorPublicParamPropInit {
-    param1!: Public3;
+    declare param1: Public3;
     constructor(param1?: Public3){}
   }
   export class ClassCtorPublicParamPropOptional {
-    param1?: string;
+    declare param1?: string;
     constructor(param1?: string){}
   }
   export declare class AmbientClassCtor {

--- a/tests/specs/graph/jsr/FastCheck_ClassCtors.txt
+++ b/tests/specs/graph/jsr/FastCheck_ClassCtors.txt
@@ -57,6 +57,10 @@ export class ClassCtorPublicParamPropOptional {
   constructor(public param1?: string) {
   }
 }
+export declare class AmbientClassCtor {
+  constructor(public param: string, private value: number);
+  constructor(public param: string);
+}
 
 class Public1 {}
 class Public2 {}
@@ -100,7 +104,7 @@ import 'jsr:@scope/a'
     },
     {
       "kind": "esm",
-      "size": 1382,
+      "size": 1521,
       "mediaType": "TypeScript",
       "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
     }
@@ -125,7 +129,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     private constructor();
   }
   export declare class ClassDeclarePrivateCtor {
-    private constructor();
+    private constructor(prop: string, other: Private1);
   }
   export class ClassProtectedCtor {
     protected constructor(prop: string, other?: number){}
@@ -157,6 +161,10 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     param1?: string;
     constructor(param1?: string){}
   }
+  export declare class AmbientClassCtor {
+    constructor(public param: string, private value: number);
+    constructor(public param: string);
+  }
   class Public1 {
   }
   class Public2 {
@@ -178,7 +186,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     private constructor();
   }
   export declare class ClassDeclarePrivateCtor {
-    private constructor();
+    private constructor(prop: string, other: Private1);
   }
   export declare class ClassProtectedCtor {
     protected constructor(prop: string, other?: number);
@@ -207,6 +215,10 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   export declare class ClassCtorPublicParamPropOptional {
     param1?: string;
     constructor(param1?: string);
+  }
+  export declare class AmbientClassCtor {
+    constructor(public param: string, private value: number);
+    constructor(public param: string);
   }
   declare class Public1 {
   }

--- a/tests/specs/graph/jsr/FastCheck_ClassMemberRefFound.txt
+++ b/tests/specs/graph/jsr/FastCheck_ClassMemberRefFound.txt
@@ -63,10 +63,10 @@ import 'jsr:@scope/a'
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   {}
   export class Export {
-    prop!: typeof Public1.prototype.prop;
+    declare prop: typeof Public1.prototype.prop;
   }
   class Public1 {
-    prop!: string;
+    declare prop: string;
   }
   --- DTS ---
   export declare class Export {

--- a/tests/specs/graph/jsr/FastCheck_ClassMethods.txt
+++ b/tests/specs/graph/jsr/FastCheck_ClassMethods.txt
@@ -46,12 +46,13 @@ export class PrivateMethodOverloadable {
 
 class Private {}
 
-export class AmbientPrivateMethodOverloadable {
+const symbol1 = Symbol();
+export declare class AmbientPrivateMethodOverloadable {
   private constructor(value: string);
   private constructor(private: Private);
 
-  private [getEntity](value: string): Promise<string>;
-  private async [getEntity]();
+  private [symbol1](value: string): Promise<string>;
+  private async [symbol1]();
 
   private method(value: string): string;
 
@@ -69,6 +70,16 @@ export class AmbientPrivateMethodOverloadable {
 
   private "stringOnly"(value: string): string;
   private "stringOnly"(): string;
+}
+
+export declare module Test {
+  export class AmbientClassInModule {
+    private constructor(value: string);
+    private constructor(private: Private);
+
+    private [symbol1](value: string): Promise<string>;
+    private async [symbol1]();
+  }
 }
 
 # mod.ts
@@ -106,7 +117,7 @@ import 'jsr:@scope/a'
     },
     {
       "kind": "esm",
-      "size": 1289,
+      "size": 1563,
       "mediaType": "TypeScript",
       "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
     }
@@ -128,12 +139,22 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     private "stringAndIdent"!: unknown;
     private "stringOnly"!: unknown;
   }
-  export class AmbientPrivateMethodOverloadable {
-    private constructor();
-    private method!: unknown;
-    private methodWithOverload!: unknown;
-    private "stringAndIdent"!: unknown;
-    private "stringOnly"!: unknown;
+  export declare class AmbientPrivateMethodOverloadable {
+    private constructor(value: string);
+    private constructor(private: Private);
+    private method(value: string): string;
+    private methodWithOverload(value: string): string;
+    private methodWithOverload(): string;
+    private "stringAndIdent"(value: string): string;
+    private stringAndIdent(): string;
+    private "stringOnly"(value: string): string;
+    private "stringOnly"(): string;
+  }
+  export declare module Test {
+    export class AmbientClassInModule {
+      private constructor(value: string);
+      private constructor(private: Private);
+    }
   }
   --- DTS ---
   export declare class PrivateMethodOverloadable {
@@ -144,9 +165,19 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     private "stringOnly": unknown;
   }
   export declare class AmbientPrivateMethodOverloadable {
-    private constructor();
-    private method: unknown;
-    private methodWithOverload: unknown;
-    private "stringAndIdent": unknown;
-    private "stringOnly": unknown;
+    private constructor(value: string);
+    private constructor(private: Private);
+    private method(value: string): string;
+    private methodWithOverload(value: string): string;
+    private methodWithOverload(): string;
+    private "stringAndIdent"(value: string): string;
+    private stringAndIdent(): string;
+    private "stringOnly"(value: string): string;
+    private "stringOnly"(): string;
+  }
+  export declare module Test {
+    export class AmbientClassInModule {
+      private constructor(value: string);
+      private constructor(private: Private);
+    }
   }

--- a/tests/specs/graph/jsr/FastCheck_ClassMethods.txt
+++ b/tests/specs/graph/jsr/FastCheck_ClassMethods.txt
@@ -134,10 +134,10 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   {}
   export class PrivateMethodOverloadable {
     private constructor();
-    private method!: unknown;
-    private methodWithOverload!: unknown;
-    private "stringAndIdent"!: unknown;
-    private "stringOnly"!: unknown;
+    declare private method: unknown;
+    declare private methodWithOverload: unknown;
+    declare private "stringAndIdent": unknown;
+    declare private "stringOnly": unknown;
   }
   export declare class AmbientPrivateMethodOverloadable {
     private constructor(value: string);

--- a/tests/specs/graph/jsr/FastCheck_ClassProperties.txt
+++ b/tests/specs/graph/jsr/FastCheck_ClassProperties.txt
@@ -94,7 +94,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     declare parent: RedBlackNode<T> | null;
     declare left: RedBlackNode<T> | null;
     declare right: RedBlackNode<T> | null;
-    red!: boolean;
+    declare red: boolean;
     constructor(parent: RedBlackNode<T> | null, value: T){
       super({} as any, {} as any);
     }
@@ -105,14 +105,14 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   const isSecure: Symbol = {} as any;
   const public2: Symbol = {} as any;
   export class CookieMapBase {
-    [isSecure]!: boolean;
+    declare [isSecure]: boolean;
     [public2](): number {
       return {} as any;
     }
   }
   export class Bar {
-    abstract foo: string;
-    bar!: number;
+    declare abstract foo: string;
+    declare bar: number;
   }
   --- DTS ---
   export declare class RedBlackNode<T> extends BinarySearchNode<T> {

--- a/tests/specs/graph/jsr/FastCheck_ClassStaticMemberRefFound.txt
+++ b/tests/specs/graph/jsr/FastCheck_ClassStaticMemberRefFound.txt
@@ -63,10 +63,10 @@ import 'jsr:@scope/a'
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   {}
   export class Export {
-    prop!: typeof Public1.prop;
+    declare prop: typeof Public1.prop;
   }
   class Public1 {
-    static prop: string;
+    declare static prop: string;
   }
   --- DTS ---
   export declare class Export {

--- a/tests/specs/graph/jsr/FastCheck_CrossFileRefAliased.txt
+++ b/tests/specs/graph/jsr/FastCheck_CrossFileRefAliased.txt
@@ -138,7 +138,7 @@ import 'jsr:@scope/a'
 Fast check https://jsr.io/@scope/a/1.0.0/a.ts:
   {}
   export class A {
-    member!: string;
+    declare member: string;
   }
   --- DTS ---
   export declare class A {
@@ -187,7 +187,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   }
   import { B } from "./b.ts";
   export class Export {
-    prop!: typeof B.prototype.member;
+    declare prop: typeof B.prototype.member;
   }
   --- DTS ---
   import { B } from "./b.ts";

--- a/tests/specs/graph/jsr/FastCheck_CrossFileRefModule.txt
+++ b/tests/specs/graph/jsr/FastCheck_CrossFileRefModule.txt
@@ -140,8 +140,8 @@ import 'jsr:@scope/a'
 Fast check https://jsr.io/@scope/a/1.0.0/a.ts:
   {}
   export class A {
-    member!: string;
-    member2!: string;
+    declare member: string;
+    declare member2: string;
   }
   --- DTS ---
   export declare class A {
@@ -191,8 +191,8 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   }
   import * as mod from "./b.ts";
   export class Export {
-    prop!: typeof mod.B.prototype.member;
-    prop2!: typeof mod.B.prototype.member2;
+    declare prop: typeof mod.B.prototype.member;
+    declare prop2: typeof mod.B.prototype.member2;
   }
   --- DTS ---
   import * as mod from "./b.ts";

--- a/tests/specs/graph/jsr/FastCheck_Functions.txt
+++ b/tests/specs/graph/jsr/FastCheck_Functions.txt
@@ -71,6 +71,11 @@ class PublicOther2 {
 
 class PrivateOther {}
 
+class PublicDeclareFunc {}
+export declare function declareFunc(param: number): number;
+export declare function declareFunc(param: string): string;
+export declare function declareFunc(param: PublicDeclareFunc): string;
+
 # mod.ts
 import 'jsr:@scope/a'
 
@@ -106,7 +111,7 @@ import 'jsr:@scope/a'
     },
     {
       "kind": "esm",
-      "size": 1516,
+      "size": 1735,
       "mediaType": "TypeScript",
       "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
     }
@@ -173,6 +178,11 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   }
   class PublicOther2 {
   }
+  class PublicDeclareFunc {
+  }
+  export declare function declareFunc(param: number): number;
+  export declare function declareFunc(param: string): string;
+  export declare function declareFunc(param: PublicDeclareFunc): string;
   --- DTS ---
   export function test1(): void;
   export function test2(): number;
@@ -202,3 +212,8 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   }
   declare class PublicOther2 {
   }
+  declare class PublicDeclareFunc {
+  }
+  export declare function declareFunc(param: number): number;
+  export declare function declareFunc(param: string): string;
+  export declare function declareFunc(param: PublicDeclareFunc): string;

--- a/tests/specs/graph/jsr/FastCheck_InferredUniqueSymbols.txt
+++ b/tests/specs/graph/jsr/FastCheck_InferredUniqueSymbols.txt
@@ -66,8 +66,8 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   const key: unique symbol = {} as any;
   const key2: unique symbol = {} as any;
   export class MyClass {
-    [key]!: number;
-    [key2]!: string;
+    declare [key]: number;
+    declare [key2]: string;
   }
   --- DTS ---
   declare const key: unique symbol;

--- a/tests/specs/graph/jsr/FastCheck_InitIdentsAndMembers.txt
+++ b/tests/specs/graph/jsr/FastCheck_InitIdentsAndMembers.txt
@@ -141,7 +141,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   declare class Public {
   }
   declare module Test {
-    export declare class A {
+    export class A {
     }
   }
   export declare const handlers: {
@@ -164,7 +164,7 @@ Fast check https://jsr.io/@scope/b/1.0.0/mod.ts:
   declare class BaseHandler {
   }
   declare module Test {
-    export declare class A {
+    export class A {
     }
   }
   export function test(a?: any, C?: any): void;

--- a/tests/specs/graph/jsr/FastCheck_Issue22829.txt
+++ b/tests/specs/graph/jsr/FastCheck_Issue22829.txt
@@ -103,7 +103,7 @@ import 'jsr:@scope/a'
 Fast check https://jsr.io/@scope/a/1.0.0/functions.ts:
   {}
   abstract class Internal<T> {
-    prop!: T;
+    declare prop: T;
   }
   function func(): void {}
   export function other_func(): void {}

--- a/tests/specs/graph/jsr/FastCheck_Methods.txt
+++ b/tests/specs/graph/jsr/FastCheck_Methods.txt
@@ -134,7 +134,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     #private!: unknown;
     public method1(): void {}
     protected method2(): void {}
-    private tsPrivateMethod!: unknown;
+    declare private tsPrivateMethod: unknown;
   }
   class PublicOther {
   }

--- a/tests/specs/graph/jsr/FastCheck_Properties.txt
+++ b/tests/specs/graph/jsr/FastCheck_Properties.txt
@@ -75,11 +75,11 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   {}
   export class Test {
     #private!: unknown;
-    prop1!: PublicOther;
-    protected prop2?: PublicOther2;
-    private prop3!: unknown;
-    prop4!: number;
-    static myMember: string;
+    declare prop1: PublicOther;
+    declare protected prop2?: PublicOther2;
+    declare private prop3: unknown;
+    declare prop4: number;
+    declare static myMember: string;
   }
   class PublicOther {
   }

--- a/tests/specs/graph/jsr/FastCheck_TsModule.txt
+++ b/tests/specs/graph/jsr/FastCheck_TsModule.txt
@@ -11,6 +11,11 @@ export namespace Test.Test {
   }
 }
 
+export namespace Test.Test {
+  export class MyClass2 extends Public1 {
+  }
+}
+
 class Public1 {
 }
 
@@ -49,7 +54,7 @@ import 'jsr:@scope/a'
     },
     {
       "kind": "esm",
-      "size": 113,
+      "size": 191,
       "mediaType": "TypeScript",
       "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
     }
@@ -65,16 +70,18 @@ import 'jsr:@scope/a'
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   {}
   export module Test.Test {
-    export class MyClass extends Public1 {
-      prop!: string;
+  }
+  export module Test.Test {
+    export class MyClass2 extends Public1 {
     }
   }
   class Public1 {
   }
   --- DTS ---
   export declare module Test {
-    export declare class MyClass extends Public1 {
-      prop: string;
+  }
+  export declare module Test {
+    export class MyClass2 extends Public1 {
     }
   }
   declare class Public1 {

--- a/tests/specs/graph/jsr/FastCheck_TypeAssertion.txt
+++ b/tests/specs/graph/jsr/FastCheck_TypeAssertion.txt
@@ -92,7 +92,7 @@ import 'jsr:@scope/a'
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   {}
   export class Application<S> {
-    prop!: S;
+    declare prop: S;
   }
   export const str: "foo" & {
     __brand: "foo";
@@ -101,10 +101,10 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     return {} as any;
   }
   export class A {
-    prop!: Public1;
+    declare prop: Public1;
     constructor(prop?: Public1){}
-    handler!: Public2<Public3>;
-    secondProp!: Public4;
+    declare handler: Public2<Public3>;
+    declare secondProp: Public4;
   }
   export const var1: Public5<Public6> = {} as any;
   interface Public1<T> {

--- a/tests/specs/graph/jsr/FastCheck_WorkspaceFastCheck.txt
+++ b/tests/specs/graph/jsr/FastCheck_WorkspaceFastCheck.txt
@@ -125,8 +125,8 @@ Fast check file:///mod.ts:
   }
   import { C } from "jsr:@scope/c";
   export class MyClass {
-    prop!: Public1;
-    c!: C;
+    declare prop: Public1;
+    declare c: C;
   }
   class Public1 {
   }


### PR DESCRIPTION
Uses the `declare` keyword more when able because it supresses type checking errors like:

```
Property 'stateChangeHandler' will overwrite the base property in 'ClientAbstract'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.
```

Waiting on https://github.com/denoland/deno_graph/pull/415