### PR TITLE
feat: @deno-types map in build options

### DIFF
--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -269,6 +269,7 @@ pub async fn js_create_graph(
         module_analyzer: None,
         module_parser: None,
         imports,
+        import_types: None,
         reporter: None,
         workspace_members: &[],
         executor: Default::default(),

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1308,7 +1308,7 @@ pub struct ModuleGraphErrorIterator<'a> {
 
 impl<'a> ModuleGraphErrorIterator<'a> {
   pub fn new(iterator: ModuleEntryIterator<'a>) -> Self {
-    let next_errors = if iterator.follow_type_only {
+    let mut next_errors = if iterator.follow_type_only {
       iterator
         .graph
         .import_types
@@ -1323,6 +1323,7 @@ impl<'a> ModuleGraphErrorIterator<'a> {
     } else {
       vec![]
     };
+    next_errors.reverse();
     Self {
       iterator,
       next_errors,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4104,10 +4104,11 @@ export function a(a: A): B {
         !matches!(e, ModuleGraphError::ModuleError(ModuleError::Missing(..)))
       })
       .collect::<Vec<_>>();
-    assert_eq!(errors.len(), 3);
-    assert_eq!(errors[0].to_string_with_range(), "Relative import path \"bad_key\" not prefixed with / or ./ or ../\n    at file:///a/deno.json:1:1");
-    assert_eq!(errors[1].to_string_with_range(), "Relative import path \"bad_value\" not prefixed with / or ./ or ../\n    at file:///a/deno.json:1:1");
-    assert_eq!(errors[2].to_string_with_range(), "Relative import path \"bad_value2\" not prefixed with / or ./ or ../\n    at file:///a/deno.json:1:1");
+    assert_eq!(errors.len(), 4);
+    assert_eq!(errors[0].to_string_with_range(), "Relative import path \"bad_value\" not prefixed with / or ./ or ../\n    at file:///a/deno.json:1:1");
+    assert_eq!(errors[1].to_string_with_range(), "Relative import path \"bad_value2\" not prefixed with / or ./ or ../\n    at file:///a/deno.json:1:1");
+    assert_eq!(errors[2].to_string_with_range(), "Relative import path \"bad_key\" not prefixed with / or ./ or ../\n    at file:///a/deno.json:1:1");
+    assert_eq!(errors[3].to_string_with_range(), "Relative import path \"bad_value3\" not prefixed with / or ./ or ../\n    at file:///a/deno.json:1:1");
     let errors_non_type_only = graph
       .walk(
         &graph.roots,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4016,8 +4016,8 @@ export function a(a: A): B {
               ("npm:express".to_string(), "npm:@types/express".to_string()),
               ("./test02.js".to_string(), "./test02.d.ts".to_string()),
               ("./test03.js".to_string(), "bad_value".to_string()),
-              ("./test04.js".to_string(), "bad_value2".to_string()),
-              ("bad_key".to_string(), "bad_value3".to_string()),
+              ("./test04.js".to_string(), "./ignored.d.ts".to_string()),
+              ("bad_key".to_string(), "bad_value2".to_string()),
             ]
             .into_iter()
             .collect(),
@@ -4104,11 +4104,10 @@ export function a(a: A): B {
         !matches!(e, ModuleGraphError::ModuleError(ModuleError::Missing(..)))
       })
       .collect::<Vec<_>>();
-    assert_eq!(errors.len(), 4);
+    assert_eq!(errors.len(), 3);
     assert_eq!(errors[0].to_string_with_range(), "Relative import path \"bad_value\" not prefixed with / or ./ or ../\n    at file:///a/deno.json:1:1");
-    assert_eq!(errors[1].to_string_with_range(), "Relative import path \"bad_value2\" not prefixed with / or ./ or ../\n    at file:///a/deno.json:1:1");
-    assert_eq!(errors[2].to_string_with_range(), "Relative import path \"bad_key\" not prefixed with / or ./ or ../\n    at file:///a/deno.json:1:1");
-    assert_eq!(errors[3].to_string_with_range(), "Relative import path \"bad_value3\" not prefixed with / or ./ or ../\n    at file:///a/deno.json:1:1");
+    assert_eq!(errors[1].to_string_with_range(), "Relative import path \"bad_key\" not prefixed with / or ./ or ../\n    at file:///a/deno.json:1:1");
+    assert_eq!(errors[2].to_string_with_range(), "Relative import path \"bad_value2\" not prefixed with / or ./ or ../\n    at file:///a/deno.json:1:1");
     let errors_non_type_only = graph
       .walk(
         &graph.roots,


### PR DESCRIPTION
Adds support for a `deno.json` field like:
```json
{
  "types": {
    "npm:express": "npm:@types/express",
    "./file.js": "./file.d.ts"
  }
}
```
All specifiers written there are resolved through provided resolver with the `deno.json` as the referrer. So an import-mapped key (or value) will just work:
```json
{
  "imports": {
    "express": "npm:express@^4.18.3"
  },
  "types": {
    "express": "npm:@types/express@^4.17.21"
  }
}
```
We can make it so that `deno add npm:@types/<package>` adds the entry to `"types"` instead of `"imports"`. So `deno add npm:@types/express` will be the equivalent of `npm i --save @types/express`.

These mappings will only apply to referrers within the passed 'scope' associated with the `deno.json`. In CLI we would presumably pass the parent directory of the `deno.json` file.

JSR will inline these mappings to pragmas on publish. This has parity with the above behaviour.

---

This is essentially `// @deno-types` pragmas in config file form. Reasons we want to do this:
- Deduplicate `// @deno-types` pragmas for dependencies.
- Pragmas can't be used for things like `compilerOptions.jsxImportSource`.
- NPM `@types` packages can be referenced and version-pinned in the config file next to their runtime counterparts.