### PR TITLE
feat: infer new Map/Set expression type

### DIFF
--- a/src/fast_check/transform.rs
+++ b/src/fast_check/transform.rs
@@ -1485,6 +1485,22 @@ impl<'a> FastCheckTransformer<'a> {
         }
       }
       Expr::Paren(n) => self.maybe_infer_type_from_expr(&n.expr),
+      Expr::New(new_expr) => match &*new_expr.callee {
+        Expr::Ident(ident) => {
+          if ident.sym == "Map" || ident.sym == "Set" {
+            if let Some(type_args) = &new_expr.type_args {
+              return Some(TsType::TsTypeRef(TsTypeRef {
+                span: DUMMY_SP,
+                type_name: TsEntityName::Ident(ident.clone()),
+                type_params: Some(Box::new(*type_args.clone())),
+              }));
+            }
+          }
+
+          None
+        }
+        _ => None,
+      },
       Expr::This(_)
       | Expr::Array(_)
       | Expr::Object(_)
@@ -1496,7 +1512,6 @@ impl<'a> FastCheckTransformer<'a> {
       | Expr::Member(_)
       | Expr::SuperProp(_)
       | Expr::Cond(_)
-      | Expr::New(_)
       | Expr::Seq(_)
       | Expr::Ident(_)
       | Expr::Tpl(_)

--- a/tests/specs/graph/jsr/FastCheck_Infer_Map_Set.txt
+++ b/tests/specs/graph/jsr/FastCheck_Infer_Map_Set.txt
@@ -1,0 +1,78 @@
+# https://jsr.io/@scope/a/meta.json
+{"versions": { "1.0.0": {} } }
+
+# https://jsr.io/@scope/a/1.0.0_meta.json
+{ "exports": { ".": "./mod.ts" } }
+
+# https://jsr.io/@scope/a/1.0.0/mod.ts
+type Foo = { foo: number }
+export const foo = new Map<string, Foo>();
+export const bar = new Set<Foo>();
+
+export function something(arg = new Map<string, string>(), arg2 = new Set<string>()): void {
+
+}
+
+# mod.ts
+import 'jsr:@scope/a'
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "jsr:@scope/a",
+          "code": {
+            "specifier": "jsr:@scope/a",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 7
+              },
+              "end": {
+                "line": 0,
+                "character": 21
+              }
+            }
+          }
+        }
+      ],
+      "size": 22,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 202,
+      "mediaType": "TypeScript",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+    }
+  ],
+  "redirects": {
+    "jsr:@scope/a": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+  },
+  "packages": {
+    "@scope/a": "@scope/a@1.0.0"
+  }
+}
+
+Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
+  {}
+  type Foo = {
+    foo: number;
+  };
+  export const foo: Map<string, Foo> = {} as any;
+  export const bar: Set<Foo> = {} as any;
+  export function something(arg?: Map<string, string>, arg2?: Set<string>): void {}
+  --- DTS ---
+  type Foo = {
+    foo: number;
+  };
+  export declare const foo: Map<string, Foo>;
+  export declare const bar: Set<Foo>;
+  export function something(arg?: Map<string, string>, arg2?: Set<string>): void;


### PR DESCRIPTION
This PR adds support for inferring the type of `new Map/Set` expressions if the relevant type arguments are specified:

```ts
export const foo = new Map<string, string>();
export const bar = new Set<string>();
export function something(arg = new Map<string, string>(), arg2 = new Set<string>()): void {}
```

Inferred result:

```ts
export declare const foo: Map<string, string>;
export declare const bar: Set<string>;
export declare function something(arg?: Map<string, string>, arg2?: Set<string>): void;
```

Fixes https://github.com/denoland/deno/issues/23068