### PR TITLE
fix(fast_check): use `as never` instead of `as any`

### DIFF
--- a/src/fast_check/swc_helpers.rs
+++ b/src/fast_check/swc_helpers.rs
@@ -92,10 +92,6 @@ pub fn is_void_type(return_type: &TsType) -> bool {
   is_keyword_type(return_type, TsKeywordTypeKind::TsVoidKeyword)
 }
 
-pub fn is_never_type(return_type: &TsType) -> bool {
-  is_keyword_type(return_type, TsKeywordTypeKind::TsNeverKeyword)
-}
-
 fn is_keyword_type(return_type: &TsType, kind: TsKeywordTypeKind) -> bool {
   match return_type {
     TsType::TsKeywordType(TsKeywordType { kind: k, .. }) => k == &kind,

--- a/tests/specs/graph/jsr/DynamicImport.txt
+++ b/tests/specs/graph/jsr/DynamicImport.txt
@@ -126,7 +126,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
       }
     }
   }
-  const test: typeof import('./a.ts') = {} as any;
+  const test: typeof import('./a.ts') = {} as never;
   export { test };
   --- DTS ---
   declare const test: typeof import('./a.ts');

--- a/tests/specs/graph/jsr/FastCheck.txt
+++ b/tests/specs/graph/jsr/FastCheck.txt
@@ -257,13 +257,13 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   export class Test {
     /** Testing */ noReturnTypeVoid(param?: number, param2?: string): void {}
     noReturnTypeAsync(): Promise<void> {
-      return {} as any;
+      return {} as never;
     }
     returnTypeGenerator(): Generator<unknown, any, any> {
-      return {} as any;
+      return {} as never;
     }
     hasReturnType(): A1 & RenamedA3 | A4 | A6 {
-      return {} as any;
+      return {} as never;
     }
     declare private inner: any;
   }

--- a/tests/specs/graph/jsr/FastCheckCache_Basic.txt
+++ b/tests/specs/graph/jsr/FastCheckCache_Basic.txt
@@ -274,13 +274,13 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   export class Test {
     /** Testing */ noReturnTypeVoid(param?: number, param2?: string): void {}
     noReturnTypeAsync(): Promise<void> {
-      return {} as any;
+      return {} as never;
     }
     returnTypeGenerator(): Generator<unknown, any, any> {
-      return {} as any;
+      return {} as never;
     }
     hasReturnType(): A1 & RenamedA3 | A4 | A6 {
-      return {} as any;
+      return {} as never;
     }
     declare private inner: any;
   }

--- a/tests/specs/graph/jsr/FastCheckCache_DiagnosticThenNestedDep.txt
+++ b/tests/specs/graph/jsr/FastCheckCache_DiagnosticThenNestedDep.txt
@@ -179,7 +179,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
 Fast check https://jsr.io/@scope/b/1.0.0/mod.ts:
   {}
   export function add(a: number, b: number): number {
-    return {} as any;
+    return {} as never;
   }
 
 == fast check cache ==

--- a/tests/specs/graph/jsr/FastCheck_AliasedNeverType.txt
+++ b/tests/specs/graph/jsr/FastCheck_AliasedNeverType.txt
@@ -1,0 +1,76 @@
+# https://jsr.io/@scope/a/meta.json
+{"versions": { "1.0.0": {} } }
+
+# https://jsr.io/@scope/a/1.0.0_meta.json
+{ "exports": { ".": "./mod.ts" } }
+
+# https://jsr.io/@scope/a/1.0.0/mod.ts
+export type NeverType = never;
+/**
+ * This should have `return {} as never` instead of `as any`, which will error when type checking.
+ */
+export function myFunction(): NeverType {
+  Deno.exit(1);
+}
+
+# mod.ts
+import 'jsr:@scope/a'
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "jsr:@scope/a",
+          "code": {
+            "specifier": "jsr:@scope/a",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 7
+              },
+              "end": {
+                "line": 0,
+                "character": 21
+              }
+            }
+          }
+        }
+      ],
+      "size": 22,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 198,
+      "mediaType": "TypeScript",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+    }
+  ],
+  "redirects": {
+    "jsr:@scope/a": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+  },
+  "packages": {
+    "@scope/a": "@scope/a@1.0.0"
+  }
+}
+
+Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
+  {}
+  export type NeverType = never;
+  /**
+   * This should have `return {} as never` instead of `as any`, which will error when type checking.
+   */ export function myFunction(): NeverType {
+    return {} as never;
+  }
+  --- DTS ---
+  export type NeverType = never;
+  /**
+   * This should have `return {} as never` instead of `as any`, which will error when type checking.
+   */ export declare function myFunction(): NeverType;

--- a/tests/specs/graph/jsr/FastCheck_ClassGettersAndSetters.txt
+++ b/tests/specs/graph/jsr/FastCheck_ClassGettersAndSetters.txt
@@ -67,7 +67,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   {}
   export class MyClass {
     get value(): string {
-      return {} as any;
+      return {} as never;
     }
     set value(_value: string) {}
   }

--- a/tests/specs/graph/jsr/FastCheck_ClassProperties.txt
+++ b/tests/specs/graph/jsr/FastCheck_ClassProperties.txt
@@ -100,18 +100,18 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     declare right: RedBlackNode<T> | null;
     declare red: boolean;
     constructor(parent: RedBlackNode<T> | null, value: T){
-      super({} as any, {} as any);
+      super({} as never, {} as never);
     }
     static override from<T>(node: RedBlackNode<T>): RedBlackNode<T> {
-      return {} as any;
+      return {} as never;
     }
   }
-  const isSecure: Symbol = {} as any;
-  const public2: Symbol = {} as any;
+  const isSecure: Symbol = {} as never;
+  const public2: Symbol = {} as never;
   export class CookieMapBase {
     declare [isSecure]: boolean;
     [public2](): number {
-      return {} as any;
+      return {} as never;
     }
   }
   export class Bar {

--- a/tests/specs/graph/jsr/FastCheck_ClassPropertiesLeavable.txt
+++ b/tests/specs/graph/jsr/FastCheck_ClassPropertiesLeavable.txt
@@ -118,9 +118,9 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   }
   import type { Foo, Bar } from "./b.ts";
   export class Foo {
-    fizz = (a: string): string =>({} as any);
-    foo = (): Foo =>({} as any);
-    bar = (b: Bar): number =>({} as any);
+    fizz = (a: string): string =>({} as never);
+    foo = (): Foo =>({} as never);
+    bar = (b: Bar): number =>({} as never);
     bax = function(b: Bax): void {};
   }
   --- DTS ---

--- a/tests/specs/graph/jsr/FastCheck_ClassSuper.txt
+++ b/tests/specs/graph/jsr/FastCheck_ClassSuper.txt
@@ -79,7 +79,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   }
   export class Child extends Base {
     constructor(){
-      super({} as any, {} as any);
+      super({} as never, {} as never);
     }
   }
   class SpreadBase {
@@ -87,7 +87,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   }
   export class SpreadChild extends SpreadBase {
     constructor(){
-      super(...({} as any));
+      super(...({} as never));
     }
   }
   --- DTS ---

--- a/tests/specs/graph/jsr/FastCheck_Comments.txt
+++ b/tests/specs/graph/jsr/FastCheck_Comments.txt
@@ -61,7 +61,7 @@ import 'jsr:@scope/a'
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   {}
   // @ts-ignore broken line
-  export const value1: number = {} as any;
+  export const value1: number = {} as never;
   --- DTS ---
   // @ts-ignore broken line
   export declare const value1: number;

--- a/tests/specs/graph/jsr/FastCheck_DefaultExportExprVar.txt
+++ b/tests/specs/graph/jsr/FastCheck_DefaultExportExprVar.txt
@@ -67,7 +67,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   export interface $Type {
     prop: boolean;
   }
-  export const $: $Type = {} as any;
+  export const $: $Type = {} as never;
   export default $;
   --- DTS ---
   export interface $Type {

--- a/tests/specs/graph/jsr/FastCheck_Enums.txt
+++ b/tests/specs/graph/jsr/FastCheck_Enums.txt
@@ -108,7 +108,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     Value1 = "a",
     Value2 = "b"
   }
-  const value: number = {} as any;
+  const value: number = {} as never;
   export enum EnumWithNonConstInits {
     Value1 = new Public1().test,
     Value2 = new Public2().asdf * value + NonExportedEnum.Value
@@ -120,7 +120,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   enum NonExportedEnum {
     Value
   }
-  const NUM: any = {} as any;
+  const NUM: any = {} as never;
   export enum Foo1 {
     A = 1,
     B = "2",

--- a/tests/specs/graph/jsr/FastCheck_Functions.txt
+++ b/tests/specs/graph/jsr/FastCheck_Functions.txt
@@ -128,51 +128,51 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   {}
   export function test1(): void {}
   export function test2(): number {
-    return {} as any;
+    return {} as never;
   }
   /** Some Doc **/ export function test3(param: number): number {
-    return {} as any;
+    return {} as never;
   }
   export function test4(param?: number): number {
-    return {} as any;
+    return {} as never;
   }
   export function test5<T extends PublicOther>(param?: number): T {
-    return {} as any;
+    return {} as never;
   }
   export function test6<T = PublicOther>(param?: number): T {
-    return {} as any;
+    return {} as never;
   }
   export function test7(param?: number): number;
   export function test7(param?: number, param2?: PublicOther2): number;
   export function test7(param0?: any, param1?: any): any {
-    return {} as any;
+    return {} as never;
   }
   function test8(param: number): number;
   function test8(param: string): string;
   function test8(param0?: any): any {
-    return {} as any;
+    return {} as never;
   }
   export { test8 };
   export default function test9(param: number): number;
   export default function test9(param: string): string;
   export default function test9(param0?: any): any {
-    return {} as any;
+    return {} as never;
   }
   export function test10(...params: string[]): string[] {
-    return {} as any;
+    return {} as never;
   }
   export function test11(options = {
     copy: true
   }): void {}
   export interface GlobOptions {
   }
-  export function test12({}: GlobOptions = {} as any): void {}
-  export function test13([]: number[] = [] as any): void {}
+  export function test12({}: GlobOptions = {} as never): void {}
+  export function test13([]: number[] = [] as never): void {}
   export function test14(): never {
     return {} as never;
   }
   export function test15(): Generator<number> {
-    return {} as any;
+    return {} as never;
   }
   class PublicOther {
   }

--- a/tests/specs/graph/jsr/FastCheck_InferredUniqueSymbols.txt
+++ b/tests/specs/graph/jsr/FastCheck_InferredUniqueSymbols.txt
@@ -63,8 +63,8 @@ import 'jsr:@scope/a'
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   {}
-  const key: unique symbol = {} as any;
-  const key2: unique symbol = {} as any;
+  const key: unique symbol = {} as never;
+  const key2: unique symbol = {} as never;
   export class MyClass {
     declare [key]: number;
     declare [key2]: string;

--- a/tests/specs/graph/jsr/FastCheck_Issue22544.txt
+++ b/tests/specs/graph/jsr/FastCheck_Issue22544.txt
@@ -67,10 +67,10 @@ import 'jsr:@scope/a'
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   {}
-  const rawString1: Symbol = {} as any;
-  const rawString2: Symbol = {} as any;
-  const rawString3: Symbol = {} as any;
-  const rawString4: Symbol = {} as any;
+  const rawString1: Symbol = {} as never;
+  const rawString2: Symbol = {} as never;
+  const rawString3: Symbol = {} as never;
+  const rawString4: Symbol = {} as never;
   export interface RawString {
     [rawString1]: string;
     [rawString2](): void;

--- a/tests/specs/graph/jsr/FastCheck_Methods.txt
+++ b/tests/specs/graph/jsr/FastCheck_Methods.txt
@@ -105,29 +105,29 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   export class Test {
     test1(): void {}
     test2(): number {
-      return {} as any;
+      return {} as never;
     }
     test3(param: number): number {
-      return {} as any;
+      return {} as never;
     }
     test4(param?: number): number {
-      return {} as any;
+      return {} as never;
     }
     test5<T extends PublicOther>(param?: number): T {
-      return {} as any;
+      return {} as never;
     }
     test6<T = PublicOther>(param?: number): T {
-      return {} as any;
+      return {} as never;
     }
     test7(param?: number): number;
     test7(param?: number, param2?: PublicOther2): number;
     test7(param0?: any, param1?: any): any {
-      return {} as any;
+      return {} as never;
     }
     test8(param: number): number;
     test8(param: string): string;
     test8(param0?: any): any {
-      return {} as any;
+      return {} as never;
     }
   }
   export class Test2 {

--- a/tests/specs/graph/jsr/FastCheck_RefVarType.txt
+++ b/tests/specs/graph/jsr/FastCheck_RefVarType.txt
@@ -67,7 +67,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   interface Symbols {
     readable: unique symbol;
   }
-  export const symbols: Symbols = {} as any;
+  export const symbols: Symbols = {} as never;
   export type Status = typeof symbols.readable;
   --- DTS ---
   interface Symbols {

--- a/tests/specs/graph/jsr/FastCheck_TypeAssertion.txt
+++ b/tests/specs/graph/jsr/FastCheck_TypeAssertion.txt
@@ -96,9 +96,9 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   }
   export const str: "foo" & {
     __brand: "foo";
-  } = {} as any;
+  } = {} as never;
   export function createMockApp<S extends Record<string | number | symbol, any> = Record<string, any>>(state?: S): Application<S> {
-    return {} as any;
+    return {} as never;
   }
   export class A {
     declare prop: Public1;
@@ -106,7 +106,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     declare handler: Public2<Public3>;
     declare secondProp: Public4;
   }
-  export const var1: Public5<Public6> = {} as any;
+  export const var1: Public5<Public6> = {} as never;
   interface Public1<T> {
   }
   interface Public2 {
@@ -123,7 +123,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   }
   export const str2: "foo" & {
     data: Public7;
-  } = {} as any;
+  } = {} as never;
   --- DTS ---
   export declare class Application<S> {
     prop: S;

--- a/tests/specs/graph/jsr/FastCheck_VarArrowLeavable.txt
+++ b/tests/specs/graph/jsr/FastCheck_VarArrowLeavable.txt
@@ -115,8 +115,8 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     }
   }
   import type { Foo, Bar } from "./b.ts";
-  export const foo = (foo: Foo): string =>({} as any);
-  export const bar = (): Bar =>({} as any);
+  export const foo = (foo: Foo): string =>({} as never);
+  export const bar = (): Bar =>({} as never);
   --- DTS ---
   import type { Foo, Bar } from "./b.ts";
   export declare const foo: (foo: Foo) => string;

--- a/tests/specs/graph/jsr/FastCheck_VarFunctionLeavable.txt
+++ b/tests/specs/graph/jsr/FastCheck_VarFunctionLeavable.txt
@@ -116,10 +116,10 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   }
   import type { Foo, Bar } from "./b.ts";
   export const foo = function(foo: Foo): string {
-    return {} as any;
+    return {} as never;
   };
   export const bar = function(): Bar {
-    return {} as any;
+    return {} as never;
   };
   --- DTS ---
   import type { Foo, Bar } from "./b.ts";

--- a/tests/specs/graph/jsr/FastCheck_Vars.txt
+++ b/tests/specs/graph/jsr/FastCheck_Vars.txt
@@ -109,7 +109,7 @@ import 'jsr:@scope/a'
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   {}
-  const public1: Public1 = {} as any;
+  const public1: Public1 = {} as never;
   export { public1 };
   class Public1 {
   }
@@ -149,27 +149,27 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     ]
   };
   export const func1 = function(): string {
-    return {} as any;
+    return {} as never;
   };
-  export const func2 = (): string =>({} as any);
-  export const func3 = (): string =>({} as any);
+  export const func2 = (): string =>({} as never);
+  export const func3 = (): string =>({} as never);
   export const func4 = ()=>"test" as const;
-  export const func5 = (): Promise<string> =>({} as any);
-  export const func6 = (): Promise<1> =>({} as any);
-  export const func7 = (): Promise<1> =>({} as any);
+  export const func5 = (): Promise<string> =>({} as never);
+  export const func6 = (): Promise<1> =>({} as never);
+  export const func7 = (): Promise<1> =>({} as never);
   export const func8 = async ()=>"test" as const;
-  export const inferred1: 1 = {} as any;
-  export const inferred2: string = {} as any;
-  export const inferred3: true = {} as any;
-  export const inferred4: RegExp = {} as any;
-  export const inferred5: boolean = {} as any;
-  export const inferred6: boolean = {} as any;
-  export const inferred7: 1 | 2 | 3 & 4 = {} as any;
-  export const inferred8: ["test", 1] = {} as any;
-  export const inferred9: [...string] = {} as any;
-  export const inferred10: (1 | 2n)[] = {} as any;
-  export const inferred11: (keyof string)[] = {} as any;
-  export const inferred12: number = {} as any;
+  export const inferred1: 1 = {} as never;
+  export const inferred2: string = {} as never;
+  export const inferred3: true = {} as never;
+  export const inferred4: RegExp = {} as never;
+  export const inferred5: boolean = {} as never;
+  export const inferred6: boolean = {} as never;
+  export const inferred7: 1 | 2 | 3 & 4 = {} as never;
+  export const inferred8: ["test", 1] = {} as never;
+  export const inferred9: [...string] = {} as never;
+  export const inferred10: (1 | 2n)[] = {} as never;
+  export const inferred11: (keyof string)[] = {} as never;
+  export const inferred12: number = {} as never;
   --- DTS ---
   declare const public1: Public1;
   export { public1 };


### PR DESCRIPTION
This works in more scenarios.

```ts
export type NeverType = never;
/**
 * This should have `return {} as never` instead of `as any`, which would error when type checking.
 */
export function myFunction(): NeverType {
  return {} as never;
}
```