### PR TITLE
fix: jsr specifiers sometimes not resolved in dynamic imports

### DIFF
--- a/tests/specs/graph/jsr/DynamicImportOfJsr.txt
+++ b/tests/specs/graph/jsr/DynamicImportOfJsr.txt
@@ -1,0 +1,68 @@
+# https://jsr.io/@scope/a/meta.json
+{"versions": { "1.0.0": {} } }
+
+# https://jsr.io/@scope/a/1.0.0_meta.json
+{
+  "exports": {
+    ".": "./mod.ts"
+  }
+}
+# https://jsr.io/@scope/a/1.0.0/mod.ts
+export class Test {}
+
+# mod.ts
+await import("jsr:@scope/a");
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "jsr:@scope/a",
+          "code": {
+            "specifier": "jsr:@scope/a",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 13
+              },
+              "end": {
+                "line": 0,
+                "character": 27
+              }
+            }
+          },
+          "isDynamic": true
+        }
+      ],
+      "size": 30,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 21,
+      "mediaType": "TypeScript",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+    }
+  ],
+  "redirects": {
+    "jsr:@scope/a": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+  },
+  "packages": {
+    "@scope/a": "@scope/a@1.0.0"
+  }
+}
+
+Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
+  {}
+  export class Test {
+  }
+  --- DTS ---
+  export declare class Test {
+  }


### PR DESCRIPTION
This is a bug that's existed for a long time. Previously a JSR specifier would not be resolved in a dynamic import if it was the last thing being resolved.