### PR TITLE
fix: store multi-threaded comments in the dts fast check module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ast"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c06f7b0771250e5531bb9f86975b3ec15130d9fa77222674c5be290317221f"
+checksum = "ff757b9a40f67682e34c2806a2d5a0331449acad467ab53e783cad8092675e50"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm_executor = []
 anyhow = "1.0.43"
 async-trait = "0.1.68"
 data-url = "0.3.0"
-deno_ast = { version = "0.36.0", features = ["dep_analysis", "emit"] }
+deno_ast = { version = "0.36.1", features = ["dep_analysis", "emit"] }
 deno_semver = "0.5.4"
 deno_unsync = { version = "0.3.2", optional = true }
 encoding_rs = "0.8.33"

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -5390,7 +5390,7 @@ mod tests {
       SourceMap::single(module.specifier.clone(), module.source.to_string());
     let EmittedSource { text, .. } = emit(
       &dts.program,
-      &dts.comments,
+      &dts.comments.as_single_threaded(),
       &source_map,
       &EmitOptions {
         keep_comments: true,
@@ -5474,7 +5474,7 @@ mod tests {
       );
       let EmittedSource { text, .. } = emit(
         &dts.program,
-        &dts.comments,
+        &dts.comments.as_single_threaded(),
         &source_map,
         &EmitOptions {
           keep_comments: true,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -122,7 +122,7 @@ async fn test_graph_specs() {
             );
             let EmittedSource { text, .. } = emit(
               &dts.program,
-              &dts.comments,
+              &dts.comments.as_single_threaded(),
               &source_map,
               &EmitOptions {
                 keep_comments: true,


### PR DESCRIPTION
Makes the graph `Send` again.

Will test this out in the CLI before merging.