### PR TITLE
feat(unstable): add support for @ts-self-types pragma

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ast"
-version = "0.37.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67f9b18b22c707b59cf1ee9cb6f0afbfcf0d03a59b9244ddadacf6a4dc7cfeba"
+checksum = "b2be70f80fee64edfbbc4a61c50f18b4a0fbff0b2657d26f6f0443e1db279af9"
 dependencies = [
  "anyhow",
  "base64",
@@ -337,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "deno_media_type"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a798670c20308e5770cc0775de821424ff9e85665b602928509c8c70430b3ee0"
+checksum = "a8978229b82552bf8457a0125aa20863f023619cfc21ebb007b1e571d68fd85b"
 dependencies = [
  "data-url",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ harness = false
 anyhow = "1.0.43"
 async-trait = "0.1.68"
 data-url = "0.3.0"
-deno_ast = { version = "0.37.0", features = ["dep_analysis", "emit"] }
+deno_ast = { version = "0.37.1", features = ["dep_analysis", "emit"] }
 deno_semver = "0.5.4"
 deno_unsync = { version = "0.3.2", optional = true }
 encoding_rs = "0.8.33"

--- a/src/fast_check/range_finder.rs
+++ b/src/fast_check/range_finder.rs
@@ -8,7 +8,6 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use deno_ast::swc::ast::Expr;
-use deno_ast::MediaType;
 use deno_ast::SourceRange;
 use deno_ast::SourceRangedForSpanned;
 use deno_semver::package::PackageNv;
@@ -1212,7 +1211,7 @@ impl<'a> PublicRangeFinder<'a> {
 fn is_module_typed(module: &crate::Module) -> bool {
   match module {
     crate::Module::Js(m) => {
-      is_typed_media_type(m.media_type) || m.maybe_types_dependency.is_some()
+      m.media_type.is_typed() || m.maybe_types_dependency.is_some()
     }
     crate::Module::Json(_) => true,
     crate::Module::Npm(_)
@@ -1227,27 +1226,6 @@ fn is_module_external(module: &crate::Module) -> bool {
     crate::Module::External(_)
     | crate::Module::Node(_)
     | crate::Module::Npm(_) => true,
-  }
-}
-
-fn is_typed_media_type(media_type: MediaType) -> bool {
-  match media_type {
-    MediaType::JavaScript
-    | MediaType::Jsx
-    | MediaType::Mjs
-    | MediaType::Cjs
-    | MediaType::TsBuildInfo
-    | MediaType::SourceMap
-    | MediaType::Unknown => false,
-    MediaType::TypeScript
-    | MediaType::Mts
-    | MediaType::Cts
-    | MediaType::Dts
-    | MediaType::Dmts
-    | MediaType::Dcts
-    | MediaType::Tsx
-    | MediaType::Json
-    | MediaType::Wasm => true,
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2011,11 +2011,11 @@ export const foo = 'bar';"#,
           specifier: ModuleSpecifier::parse("file:///test01.js").unwrap(),
           start: Position {
             line: 0,
-            character: 20
+            character: 18
           },
           end: Position {
             line: 0,
-            character: 35
+            character: 33
           },
         }
       }

--- a/tests/specs/graph/fast_check/dts.txt
+++ b/tests/specs/graph/fast_check/dts.txt
@@ -91,7 +91,7 @@ import 'jsr:@scope/a/foo'
     },
     {
       "kind": "esm",
-      "size": 54,
+      "size": 52,
       "typesDependency": {
         "specifier": "./foo.d.ts",
         "dependency": {
@@ -99,11 +99,11 @@ import 'jsr:@scope/a/foo'
           "span": {
             "start": {
               "line": 0,
-              "character": 20
+              "character": 18
             },
             "end": {
               "line": 0,
-              "character": 32
+              "character": 30
             }
           }
         }

--- a/tests/specs/graph/fast_check/dts.txt
+++ b/tests/specs/graph/fast_check/dts.txt
@@ -2,7 +2,7 @@
 {"versions": { "1.0.0": {} } }
 
 # https://jsr.io/@scope/a/1.0.0_meta.json
-{ "exports": { ".": "./mod.js" } }
+{ "exports": { ".": "./mod.js", "./foo": "./foo.js" } }
 
 # https://jsr.io/@scope/a/1.0.0/other.d.ts
 export class Other {}
@@ -25,8 +25,17 @@ declare var public: number;
 /// <reference types="./mod.d.ts" />
 export class Test {}
 
+# https://jsr.io/@scope/a/1.0.0/foo.d.ts
+export class Test {
+}
+
+# https://jsr.io/@scope/a/1.0.0/foo.js
+// @ts-self-types="./foo.d.ts"
+export class Test {}
+
 # mod.ts
 import 'jsr:@scope/a'
+import 'jsr:@scope/a/foo'
 
 # output
 {
@@ -52,11 +61,55 @@ import 'jsr:@scope/a'
               }
             }
           }
+        },
+        {
+          "specifier": "jsr:@scope/a/foo",
+          "code": {
+            "specifier": "jsr:@scope/a/foo",
+            "span": {
+              "start": {
+                "line": 1,
+                "character": 7
+              },
+              "end": {
+                "line": 1,
+                "character": 25
+              }
+            }
+          }
         }
       ],
-      "size": 22,
+      "size": 48,
       "mediaType": "TypeScript",
       "specifier": "file:///mod.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 22,
+      "mediaType": "Dts",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/foo.d.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 54,
+      "typesDependency": {
+        "specifier": "./foo.d.ts",
+        "dependency": {
+          "specifier": "https://jsr.io/@scope/a/1.0.0/foo.d.ts",
+          "span": {
+            "start": {
+              "line": 0,
+              "character": 20
+            },
+            "end": {
+              "line": 0,
+              "character": 32
+            }
+          }
+        }
+      },
+      "mediaType": "JavaScript",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/foo.js"
     },
     {
       "kind": "esm",
@@ -112,12 +165,21 @@ import 'jsr:@scope/a'
     }
   ],
   "redirects": {
-    "jsr:@scope/a": "https://jsr.io/@scope/a/1.0.0/mod.js"
+    "jsr:@scope/a": "https://jsr.io/@scope/a/1.0.0/mod.js",
+    "jsr:@scope/a/foo": "https://jsr.io/@scope/a/1.0.0/foo.js"
   },
   "packages": {
     "@scope/a": "@scope/a@1.0.0"
   }
 }
+
+Fast check https://jsr.io/@scope/a/1.0.0/foo.d.ts:
+  {}
+  export class Test {
+  }
+  --- DTS ---
+  export declare class Test {
+  }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.d.ts:
   {}


### PR DESCRIPTION
This commit adds a `@ts-self-types="..."` pragma that
may be placed at the top of untyped code files,
such as JS and JSX files. The specifier in this
pragma will then be used as the types for this
file when it is imported into a different file.

This is effectively the same as the existing
`/// <reference types="..." />` support in untyped
files, but with the added benefit of not
overloading the TypeScript triple-slash directive
syntax, and working with block comments.

Closes #442