### PR TITLE
refactor: move redirect handling into deno_graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,10 +448,11 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "file_test_runner"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13bacb20a988be248a13adc6011bce718648f78d4684d4dd0444d05256f4a7b"
+checksum = "b66e9ef00f9f6b82b030b7a9d659030f73498921d4c021b0772e75dfd7090d80"
 dependencies = [
+ "anyhow",
  "crossbeam-channel",
  "deno_terminal",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ url = { version = "2.2.2", features = ["serde"] }
 
 [dev-dependencies]
 bincode = "1.3.3"
-file_test_runner = "0.2.0"
+file_test_runner = "0.4.0"
 pretty_assertions = "1.0.0"
 tempfile = "3.4.0"
 tokio = { version = "1.10.1", features = ["macros", "rt-multi-thread"] }

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ fn main() {
   let roots = vec![ModuleSpecifier::parse("file:///test.ts").unwrap()];
   let future = async move {
     let mut graph = ModuleGraph::new(GraphKind::All);
-    graph.build(roots, &mut loader, Default::default()).await;
+    graph.build(roots, &loader, Default::default()).await;
     println!("{:#?}", graph);
   };
   block_on(future)

--- a/js/loader.ts
+++ b/js/loader.ts
@@ -25,7 +25,7 @@ async function requestNet(host: string): Promise<void> {
 export async function withResolvingRedirects(
   specifier: string,
   customLoad: (specifier: string) => Promise<LoadResponse | undefined> = load,
-): Promise<Exclude<LoadResponse, LoadResponseRedirect> | undefined> { 
+): Promise<Exclude<LoadResponse, LoadResponseRedirect> | undefined> {
   for (let i = 0; i < 10; i++) {
     const response = await customLoad(specifier);
     if (response === undefined || response.kind !== "redirect") {
@@ -33,7 +33,7 @@ export async function withResolvingRedirects(
     }
     specifier = response.specifier;
   }
-  throw new Error("Too many redirects.")
+  throw new Error("Too many redirects.");
 }
 
 /** A Deno specific loader function that can be passed to the

--- a/js/loader.ts
+++ b/js/loader.ts
@@ -26,7 +26,7 @@ export async function withResolvingRedirects(
   specifier: string,
   customLoad: (specifier: string) => Promise<LoadResponse | undefined> = load,
 ): Promise<Exclude<LoadResponse, LoadResponseRedirect> | undefined> {
-  for (let i = 0; i < 10; i++) {
+  for (let i = 0; i <= 10; i++) {
     const response = await customLoad(specifier);
     if (response === undefined || response.kind !== "redirect") {
       return response;

--- a/js/mod.ts
+++ b/js/mod.ts
@@ -28,7 +28,7 @@ import type {
   TypesDependency,
 } from "./types.ts";
 
-export { load } from "./loader.ts";
+export { load, withResolvingRedirects } from "./loader.ts";
 export { MediaType } from "./media_type.ts";
 export type {
   CacheInfo,

--- a/js/test.ts
+++ b/js/test.ts
@@ -1,12 +1,12 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
 import { assert, assertEquals, assertRejects, assertThrows } from "@std/assert";
-import { LoadResponseModule } from "./types.ts";
+import type { LoadResponseModule } from "./types.ts";
 import {
   createGraph,
   init,
   load,
-  LoadResponse,
+  type LoadResponse,
   MediaType,
   parseModule,
 } from "./mod.ts";
@@ -685,7 +685,7 @@ Deno.test({
     const dep = module.dependencies?.find((d) =>
       d.specifier === "http://example.com/preact/jsx-runtime"
     );
-    assert(dep);
+    assert(dep != null);
     assert(dep.type);
     assertEquals(
       dep.type.specifier,

--- a/js/types.ts
+++ b/js/types.ts
@@ -37,15 +37,22 @@ export interface LoadResponseModule {
   content: string | Uint8Array;
 }
 
+export interface LoadResponseRedirect {
+  /** A redirect occurred */
+  kind: "redirect";
+  /** The redirected specifier. */
+  specifier: string;
+}
+
 export interface LoadResponseExternal {
   /** The loaded module is either _external_ or _built-in_ to the runtime. */
   kind: "external";
-  /** The strung URL of the resource. If there were redirects, the final
+  /** The string URL of the resource. If there were redirects, the final
    * specifier should be set here, otherwise the requested specifier. */
   specifier: string;
 }
 
-export type LoadResponse = LoadResponseModule | LoadResponseExternal;
+export type LoadResponse = LoadResponseModule | LoadResponseRedirect | LoadResponseExternal;
 
 export interface PositionJson {
   /** The line number of a position within a source file. The number is a zero

--- a/js/types.ts
+++ b/js/types.ts
@@ -52,7 +52,10 @@ export interface LoadResponseExternal {
   specifier: string;
 }
 
-export type LoadResponse = LoadResponseModule | LoadResponseRedirect | LoadResponseExternal;
+export type LoadResponse =
+  | LoadResponseModule
+  | LoadResponseRedirect
+  | LoadResponseExternal;
 
 export interface PositionJson {
   /** The line number of a position within a source file. The number is a zero

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -222,7 +222,7 @@ pub async fn js_create_graph(
   let maybe_imports_map: Option<HashMap<String, Vec<String>>> =
     serde_wasm_bindgen::from_value(maybe_imports)
       .map_err(|err| JsValue::from(js_sys::Error::new(&err.to_string())))?;
-  let mut loader = JsLoader::new(load, maybe_cache_info);
+  let loader = JsLoader::new(load, maybe_cache_info);
   let maybe_resolver = if maybe_default_jsx_import_source.is_some()
     || maybe_default_jsx_import_source_types.is_some()
     || maybe_jsx_import_source_module.is_some()

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -63,7 +63,7 @@ impl Loader for JsLoader {
   }
 
   fn load(
-    &mut self,
+    &self,
     specifier: &ModuleSpecifier,
     options: LoadOptions,
   ) -> LoadFuture {

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -269,7 +269,7 @@ pub async fn js_create_graph(
   graph
     .build(
       roots,
-      &mut loader,
+      &loader,
       BuildOptions {
         is_dynamic: false,
         resolver: maybe_resolver.as_ref().map(|r| r as &dyn Resolver),

--- a/src/fast_check/transform_dts.rs
+++ b/src/fast_check/transform_dts.rs
@@ -947,7 +947,7 @@ mod tests {
   async fn transform_dts_test(source: &str, expected: &str) {
     let specifier = Url::parse("file:///mod.ts").unwrap();
 
-    let mut loader = MemoryLoader::new(
+    let loader = MemoryLoader::new(
       vec![(
         specifier.to_string(),
         Source::Module {

--- a/src/fast_check/transform_dts.rs
+++ b/src/fast_check/transform_dts.rs
@@ -963,7 +963,7 @@ mod tests {
     graph
       .build(
         vec![specifier.clone()],
-        &mut loader,
+        &loader,
         BuildOptions {
           module_analyzer: &analyzer,
           ..Default::default()

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -5064,7 +5064,7 @@ mod tests {
       }
     }
 
-    let mut loader = TestLoader {
+    let loader = TestLoader {
       loaded_foo: RefCell::new(false),
       loaded_bar: RefCell::new(false),
       loaded_baz: RefCell::new(false),
@@ -5106,7 +5106,7 @@ mod tests {
         }
       }
     }
-    let mut loader = TestLoader;
+    let loader = TestLoader;
     let mut graph = ModuleGraph::new(GraphKind::All);
     let roots = vec![Url::parse("file:///foo.js").unwrap()];
     graph
@@ -5200,7 +5200,7 @@ mod tests {
         }
       }
     }
-    let mut loader = TestLoader;
+    let loader = TestLoader;
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
       .build(
@@ -5283,7 +5283,7 @@ mod tests {
         }
       }
     }
-    let mut loader = TestLoader;
+    let loader = TestLoader;
     let mut graph = ModuleGraph::new(GraphKind::All);
     let roots = vec![Url::parse("https://deno.land/foo.js").unwrap()];
     graph
@@ -5406,7 +5406,7 @@ mod tests {
         }
       }
     }
-    let mut loader = TestLoader {
+    let loader = TestLoader {
       loaded_bar: RefCell::new(false),
     };
     let mut graph = ModuleGraph::new(GraphKind::All);
@@ -5478,7 +5478,7 @@ mod tests {
     graph
       .build(
         vec![Url::parse("file:///foo.ts").unwrap()],
-        &mut TestLoader,
+        &TestLoader,
         Default::default(),
       )
       .await;
@@ -5643,7 +5643,7 @@ mod tests {
     graph
       .build(
         vec![Url::parse("file:///foo.ts").unwrap()],
-        &mut test_loader,
+        &test_loader,
         BuildOptions {
           workspace_members: &workspace_members,
           ..Default::default()
@@ -5726,7 +5726,7 @@ mod tests {
     graph
       .build(
         vec![Url::parse("file:///foo.ts").unwrap()],
-        &mut test_loader,
+        &test_loader,
         BuildOptions {
           workspace_members: &workspace_members,
           ..Default::default()

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -3635,7 +3635,11 @@ impl<'a, 'graph> Builder<'a, 'graph> {
         self.graph.module_slots.remove(&requested_specifier);
       }
     }
-    self.graph.redirects.insert(requested_specifier, specifier);
+    self
+      .graph
+      .redirects
+      .entry(requested_specifier)
+      .or_insert(specifier);
   }
 
   /// Enqueue a request to load the specifier via the loader.

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -5073,7 +5073,7 @@ mod tests {
     graph
       .build(
         vec![Url::parse("file:///foo.js").unwrap()],
-        &mut loader,
+        &loader,
         Default::default(),
       )
       .await;
@@ -5110,7 +5110,7 @@ mod tests {
     let mut graph = ModuleGraph::new(GraphKind::All);
     let roots = vec![Url::parse("file:///foo.js").unwrap()];
     graph
-      .build(roots.clone(), &mut loader, Default::default())
+      .build(roots.clone(), &loader, Default::default())
       .await;
     assert!(graph
       .try_get(&Url::parse("file:///foo.js").unwrap())
@@ -5205,7 +5205,7 @@ mod tests {
     graph
       .build(
         vec![Url::parse("file:///foo.js").unwrap()],
-        &mut loader,
+        &loader,
         Default::default(),
       )
       .await;
@@ -5287,7 +5287,7 @@ mod tests {
     let mut graph = ModuleGraph::new(GraphKind::All);
     let roots = vec![Url::parse("https://deno.land/foo.js").unwrap()];
     graph
-      .build(roots.clone(), &mut loader, Default::default())
+      .build(roots.clone(), &loader, Default::default())
       .await;
     assert_eq!(graph.specifiers_count(), 4);
     let errors = graph
@@ -5413,7 +5413,7 @@ mod tests {
     graph
       .build(
         vec![Url::parse("file:///foo.js").unwrap()],
-        &mut loader,
+        &loader,
         Default::default(),
       )
       .await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,11 +213,7 @@ mod tests {
       ModuleSpecifier::parse("file:///a/test01.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(
-        vec![root_specifier.clone()],
-        &mut loader,
-        Default::default(),
-      )
+      .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     assert_eq!(graph.module_slots.len(), 2);
     assert_eq!(graph.roots, vec![root_specifier.clone()]);
@@ -294,7 +290,7 @@ mod tests {
     ];
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(roots.clone(), &mut loader, Default::default())
+      .build(roots.clone(), &loader, Default::default())
       .await;
     assert_eq!(graph.module_slots.len(), 4);
     assert_eq!(graph.roots, roots);
@@ -364,14 +360,14 @@ mod tests {
       ModuleSpecifier::parse("https://example.com/d.ts").unwrap();
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![first_root.clone()], &mut loader, Default::default())
+      .build(vec![first_root.clone()], &loader, Default::default())
       .await;
     assert_eq!(graph.module_slots.len(), 4);
     assert_eq!(graph.roots, vec![first_root.clone()]);
 
     // now build with the second root
     graph
-      .build(vec![second_root.clone()], &mut loader, Default::default())
+      .build(vec![second_root.clone()], &loader, Default::default())
       .await;
     let mut roots = vec![first_root, second_root];
     assert_eq!(graph.module_slots.len(), 5);
@@ -391,7 +387,7 @@ mod tests {
 
     // now try making one of the already existing modules a root
     graph
-      .build(vec![third_root.clone()], &mut loader, Default::default())
+      .build(vec![third_root.clone()], &loader, Default::default())
       .await;
     roots.push(third_root);
     assert_eq!(graph.module_slots.len(), 5);
@@ -416,7 +412,7 @@ mod tests {
     graph
       .build(
         roots.clone(),
-        &mut loader,
+        &loader,
         BuildOptions {
           is_dynamic: true,
           ..Default::default()
@@ -473,11 +469,7 @@ console.log(a);
       ModuleSpecifier::parse("file:///a/test01.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(
-        vec![root_specifier.clone()],
-        &mut loader,
-        Default::default(),
-      )
+      .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     assert!(graph.valid().is_ok());
   }
@@ -501,11 +493,7 @@ console.log(a);
     let root_specifier = ModuleSpecifier::parse("file:///a/test01.ts").unwrap();
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(
-        vec![root_specifier.clone()],
-        &mut loader,
-        Default::default(),
-      )
+      .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     assert!(graph.valid().is_err());
     assert_eq!(
@@ -534,11 +522,7 @@ console.log(a);
       ModuleSpecifier::parse("https://deno.land/main.ts").unwrap();
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(
-        vec![root_specifier.clone()],
-        &mut loader,
-        Default::default(),
-      )
+      .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     assert!(graph.valid().is_ok());
   }
@@ -575,7 +559,7 @@ console.log(a);
       );
       let mut graph = ModuleGraph::new(GraphKind::All);
       graph
-        .build(vec![root_specifier], &mut loader, Default::default())
+        .build(vec![root_specifier], &loader, Default::default())
         .await;
       assert!(matches!(
         graph.valid().err().unwrap(),
@@ -627,7 +611,7 @@ console.log(a);
       graph
         .build(
           vec![root_specifier.clone()],
-          &mut loader,
+          &loader,
           BuildOptions {
             resolver: maybe_resolver,
             ..Default::default()
@@ -680,7 +664,7 @@ console.log(a);
     graph
       .build(
         vec![root_specifier],
-        &mut loader,
+        &loader,
         BuildOptions {
           imports,
           ..Default::default()
@@ -808,7 +792,7 @@ console.log(a);
     graph
       .build(
         vec![root_specifier],
-        &mut loader,
+        &loader,
         BuildOptions {
           imports,
           ..Default::default()
@@ -934,7 +918,7 @@ console.log(a);
     graph
       .build(
         vec![root_specifier],
-        &mut loader,
+        &loader,
         BuildOptions {
           imports,
           ..Default::default()
@@ -1004,11 +988,7 @@ console.log(a);
       ModuleSpecifier::parse("https://example.com/a").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(
-        vec![root_specifier.clone()],
-        &mut loader,
-        Default::default(),
-      )
+      .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     assert_eq!(graph.module_slots.len(), 1);
     assert_eq!(graph.roots, vec![root_specifier.clone()]);
@@ -1058,11 +1038,7 @@ console.log(a);
       ModuleSpecifier::parse("file:///a/test01.tsx").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(
-        vec![root_specifier.clone()],
-        &mut loader,
-        Default::default(),
-      )
+      .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     assert_eq!(
       json!(graph),
@@ -1157,11 +1133,7 @@ console.log(a);
       ModuleSpecifier::parse("file:///a/test01.tsx").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(
-        vec![root_specifier.clone()],
-        &mut loader,
-        Default::default(),
-      )
+      .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     assert_eq!(
       json!(graph),
@@ -1245,11 +1217,7 @@ console.log(a);
       ModuleSpecifier::parse("file:///a/test.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(
-        vec![root_specifier.clone()],
-        &mut loader,
-        Default::default(),
-      )
+      .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     let result = graph.valid();
     assert!(result.is_err());
@@ -1415,7 +1383,7 @@ console.log(a);
     graph
       .build(
         vec![root_specifier.clone()],
-        &mut loader,
+        &loader,
         BuildOptions {
           npm_resolver: Some(&mock_npm_resolver),
           ..Default::default()
@@ -1428,7 +1396,7 @@ console.log(a);
     graph
       .build(
         vec![root_specifier.clone()],
-        &mut loader,
+        &loader,
         BuildOptions {
           resolver: Some(&mock_import_map_resolver),
           npm_resolver: Some(&mock_npm_resolver),
@@ -1446,7 +1414,7 @@ console.log(a);
     graph
       .build(
         vec![root_specifier.clone()],
-        &mut loader,
+        &loader,
         BuildOptions {
           npm_resolver: Some(&mock_npm_resolver),
           ..Default::default()
@@ -1488,11 +1456,7 @@ console.log(a);
       ModuleSpecifier::parse("file:///a/test.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(
-        vec![root_specifier.clone()],
-        &mut loader,
-        Default::default(),
-      )
+      .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     let result = graph.valid();
     assert!(result.is_err());
@@ -1534,11 +1498,7 @@ console.log(a);
       ModuleSpecifier::parse("file:///a/test01").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(
-        vec![root_specifier.clone()],
-        &mut loader,
-        Default::default(),
-      )
+      .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     assert!(graph.valid().is_ok());
   }
@@ -1570,11 +1530,7 @@ console.log(a);
       ModuleSpecifier::parse("file:///a.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(
-        vec![root_specifier.clone()],
-        &mut loader,
-        Default::default(),
-      )
+      .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     assert_eq!(
       json!(graph),
@@ -1664,7 +1620,7 @@ export function a(a) {
     let root = ModuleSpecifier::parse("file:///a/test.js").unwrap();
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root.clone()], &mut loader, Default::default())
+      .build(vec![root.clone()], &loader, Default::default())
       .await;
     assert_eq!(
       json!(graph),
@@ -1764,11 +1720,7 @@ export function a(a) {
       ModuleSpecifier::parse("https://example.com/a").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(
-        vec![root_specifier.clone()],
-        &mut loader,
-        Default::default(),
-      )
+      .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     assert_eq!(
       graph.roots,
@@ -1831,11 +1783,7 @@ export function a(a) {
       ModuleSpecifier::parse("https://example.com/a").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(
-        vec![root_specifier.clone()],
-        &mut loader,
-        Default::default(),
-      )
+      .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     assert_eq!(
       graph.roots,
@@ -1891,11 +1839,7 @@ export function a(a) {
       ModuleSpecifier::parse("file:///a/test01.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(
-        vec![root_specifier.clone()],
-        &mut loader,
-        Default::default(),
-      )
+      .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     assert_eq!(graph.module_slots.len(), 3);
     let data_specifier = ModuleSpecifier::parse("data:application/typescript,export%20*%20from%20%22https://example.com/c.ts%22;").unwrap();
@@ -1939,7 +1883,7 @@ export function a(a) {
     graph
       .build(
         vec![root_specifier],
-        &mut loader,
+        &loader,
         BuildOptions {
           resolver: maybe_resolver,
           ..Default::default()
@@ -1999,7 +1943,7 @@ export function a(a) {
     graph
       .build(
         vec![root_specifier],
-        &mut loader,
+        &loader,
         BuildOptions {
           resolver: maybe_resolver,
           ..Default::default()
@@ -2079,11 +2023,7 @@ export function a(a) {
       ModuleSpecifier::parse("file:///a/test01.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(
-        vec![root_specifier.clone()],
-        &mut loader,
-        Default::default(),
-      )
+      .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     assert_eq!(
       json!(graph),
@@ -2229,11 +2169,7 @@ export function a(a) {
       ModuleSpecifier::parse("file:///a/test01.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(
-        vec![root_specifier.clone()],
-        &mut loader,
-        Default::default(),
-      )
+      .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     assert_eq!(
       json!(graph),
@@ -2344,11 +2280,7 @@ export function a(a) {
       ModuleSpecifier::parse("file:///a/test01.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(
-        vec![root_specifier.clone()],
-        &mut loader,
-        Default::default(),
-      )
+      .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     assert_eq!(
       json!(graph),
@@ -2554,7 +2486,7 @@ export function a(a) {
     graph
       .build(
         vec![root_specifier.clone()],
-        &mut loader,
+        &loader,
         BuildOptions {
           reporter: Some(&reporter),
           ..Default::default()
@@ -2690,11 +2622,7 @@ export function a(a) {
       ModuleSpecifier::parse("file:///a/test01.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::TypesOnly);
     graph
-      .build(
-        vec![root_specifier.clone()],
-        &mut loader,
-        Default::default(),
-      )
+      .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     assert_eq!(
       json!(graph),
@@ -2925,11 +2853,7 @@ export function a(a) {
       ModuleSpecifier::parse("file:///a/test01.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::CodeOnly);
     graph
-      .build(
-        vec![root_specifier.clone()],
-        &mut loader,
-        Default::default(),
-      )
+      .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     assert_eq!(
       json!(graph),
@@ -3069,11 +2993,7 @@ export function a(a) {
       ModuleSpecifier::parse("file:///a/test01.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(
-        vec![root_specifier.clone()],
-        &mut loader,
-        Default::default(),
-      )
+      .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     assert_eq!(
       json!(graph),
@@ -3741,7 +3661,7 @@ export function a(a: A): B {
     graph
       .build(
         roots.clone(),
-        &mut loader,
+        &loader,
         BuildOptions {
           imports: imports.clone(),
           ..Default::default()
@@ -3889,7 +3809,7 @@ export function a(a: A): B {
     graph
       .build(
         vec![root.clone()],
-        &mut loader,
+        &loader,
         BuildOptions {
           imports: imports.clone(),
           ..Default::default()
@@ -4168,7 +4088,7 @@ export function a(a: A): B {
       graph
         .build(
           vec![root_specifier.clone()],
-          &mut loader,
+          &loader,
           BuildOptions {
             resolver: Some(&resolver),
             ..Default::default()
@@ -4243,7 +4163,7 @@ export function a(a: A): B {
       graph
         .build(
           vec![root_specifier.clone()],
-          &mut loader,
+          &loader,
           BuildOptions {
             resolver: Some(&resolver),
             ..Default::default()
@@ -4348,7 +4268,7 @@ export function a(a: A): B {
     graph
       .build(
         vec![root_specifier.clone()],
-        &mut loader,
+        &loader,
         BuildOptions {
           resolver: Some(&resolver),
           ..Default::default()
@@ -4396,7 +4316,7 @@ export function a(a: A): B {
     graph
       .build(
         vec![root_specifier.clone()],
-        &mut loader,
+        &loader,
         BuildOptions {
           passthrough_jsr_specifiers: true,
           ..Default::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_build_graph() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",
@@ -247,7 +247,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_build_graph_multiple_roots() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",
@@ -308,7 +308,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_build_graph_multiple_times() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",
@@ -396,7 +396,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_build_graph_json_module_root() {
-    let mut loader = setup(
+    let loader = setup(
       vec![(
         "file:///a/test.json",
         Source::Module {
@@ -440,7 +440,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_valid_type_missing() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",
@@ -476,7 +476,7 @@ console.log(a);
 
   #[tokio::test]
   async fn test_valid_code_missing() {
-    let mut loader = setup(
+    let loader = setup(
       vec![(
         "file:///a/test01.ts",
         Source::Module {
@@ -504,7 +504,7 @@ console.log(a);
 
   #[tokio::test]
   async fn test_remote_import_data_url() {
-    let mut loader = setup(
+    let loader = setup(
       vec![(
         "https://deno.land/main.ts",
         Source::Module {
@@ -533,7 +533,7 @@ console.log(a);
       let root_specifier =
         ModuleSpecifier::parse(&format!("{scheme}://deno.land/main.ts"))
           .unwrap();
-      let mut loader = setup(
+      let loader = setup(
         vec![
           (
             root_specifier.as_str(),
@@ -575,7 +575,7 @@ console.log(a);
     for scheme in &["http", "https"] {
       let root_specifier_str = format!("{scheme}://deno.land/main.ts");
       let root_specifier = ModuleSpecifier::parse(&root_specifier_str).unwrap();
-      let mut loader = setup(
+      let loader = setup(
         vec![
           (
             root_specifier.as_str(),
@@ -624,7 +624,7 @@ console.log(a);
 
   #[tokio::test]
   async fn test_build_graph_imports() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",
@@ -743,7 +743,7 @@ console.log(a);
 
   #[tokio::test]
   async fn test_build_graph_imports_imported() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",
@@ -872,7 +872,7 @@ console.log(a);
 
   #[tokio::test]
   async fn test_build_graph_imports_resolve_dependency() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",
@@ -970,7 +970,7 @@ console.log(a);
 
   #[tokio::test]
   async fn test_build_graph_with_headers() {
-    let mut loader = setup(
+    let loader = setup(
       vec![(
         "https://example.com/a",
         Source::Module {
@@ -1005,7 +1005,7 @@ console.log(a);
 
   #[tokio::test]
   async fn test_build_graph_jsx_import_source() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.tsx",
@@ -1087,7 +1087,7 @@ console.log(a);
 
   #[tokio::test]
   async fn test_build_graph_jsx_import_source_types() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.tsx",
@@ -1202,7 +1202,7 @@ console.log(a);
 
   #[tokio::test]
   async fn test_bare_specifier_error() {
-    let mut loader = setup(
+    let loader = setup(
       vec![(
         "file:///a/test.ts",
         Source::Module {
@@ -1366,7 +1366,7 @@ console.log(a);
     };
     let mock_import_map_resolver = MockImportMapResolver {};
 
-    let mut loader = setup(
+    let loader = setup(
       vec![(
         "file:///a/test.ts",
         Source::Module {
@@ -1431,7 +1431,7 @@ console.log(a);
 
   #[tokio::test]
   async fn test_unsupported_media_type() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test.ts",
@@ -1473,7 +1473,7 @@ console.log(a);
 
   #[tokio::test]
   async fn test_root_is_extensionless() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01",
@@ -1505,7 +1505,7 @@ console.log(a);
 
   #[tokio::test]
   async fn test_crate_graph_with_dynamic_imports() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a.ts",
@@ -1578,7 +1578,7 @@ console.log(a);
 
   #[tokio::test]
   async fn test_build_graph_with_jsdoc_imports() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test.js",
@@ -1689,7 +1689,7 @@ export function a(a) {
 
   #[tokio::test]
   async fn test_build_graph_with_redirects() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "https://example.com/a",
@@ -1751,7 +1751,7 @@ export function a(a) {
 
   #[tokio::test]
   async fn test_build_graph_with_circular_redirects() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "https://example.com/a",
@@ -1814,7 +1814,7 @@ export function a(a) {
 
   #[tokio::test]
   async fn test_build_graph_with_data_url() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",
@@ -1852,7 +1852,7 @@ export function a(a) {
 
   #[tokio::test]
   async fn test_build_graph_with_resolver() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",
@@ -1902,7 +1902,7 @@ export function a(a) {
 
   #[tokio::test]
   async fn test_build_graph_with_resolve_types() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a.js",
@@ -1968,7 +1968,7 @@ export function a(a) {
 
   #[tokio::test]
   async fn test_build_graph_import_attributes() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",
@@ -2141,7 +2141,7 @@ export function a(a) {
 
   #[tokio::test]
   async fn test_build_graph_mixed_assertions() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",
@@ -2217,7 +2217,7 @@ export function a(a) {
 
   #[tokio::test]
   async fn test_build_graph_import_assertion_errors() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",
@@ -2430,7 +2430,7 @@ export function a(a) {
 
   #[tokio::test]
   async fn test_build_graph_with_reporter() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",
@@ -2534,7 +2534,7 @@ export function a(a) {
 
   #[tokio::test]
   async fn test_build_graph_types_only() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",
@@ -2757,7 +2757,7 @@ export function a(a) {
 
   #[tokio::test]
   async fn test_build_graph_code_only() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",
@@ -2968,7 +2968,7 @@ export function a(a) {
 
   #[tokio::test]
   async fn test_build_graph_with_builtin_external() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",
@@ -3591,7 +3591,7 @@ export function a(a: A): B {
 
   #[tokio::test]
   async fn test_segment_graph() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",
@@ -3715,7 +3715,7 @@ export function a(a: A): B {
 
   #[tokio::test]
   async fn test_walk() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",
@@ -4047,7 +4047,7 @@ export function a(a: A): B {
       }
     }
 
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",
@@ -4237,7 +4237,7 @@ export function a(a: A): B {
       }
     }
 
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",
@@ -4296,7 +4296,7 @@ export function a(a: A): B {
 
   #[tokio::test]
   async fn test_passthrough_jsr_specifiers() {
-    let mut loader = setup(
+    let loader = setup(
       vec![
         (
           "file:///a/test01.ts",

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -488,6 +488,7 @@ pub enum Source<S> {
     maybe_headers: Option<Vec<(S, S)>>,
     content: S,
   },
+  Redirect(S),
   External(S),
   Err(Error),
 }
@@ -507,6 +508,9 @@ impl<S: AsRef<str>> Source<S> {
             .collect()
         }),
         content: Arc::from(content.as_ref().to_string().into_bytes()),
+      }),
+      Source::Redirect(specifier) => Ok(LoadResponse::Redirect {
+        specifier: ModuleSpecifier::parse(specifier.as_ref()).unwrap(),
       }),
       Source::External(specifier) => Ok(LoadResponse::External {
         specifier: ModuleSpecifier::parse(specifier.as_ref()).unwrap(),

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -35,7 +35,7 @@ impl Loader for TestLoader {
   }
 
   fn load(
-    &mut self,
+    &self,
     specifier: &ModuleSpecifier,
     options: LoadOptions,
   ) -> LoadFuture {

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -238,7 +238,7 @@ impl TestBuilder {
     let diagnostics = graph
       .build(
         roots.clone(),
-        &mut self.loader,
+        &self.loader,
         deno_graph::BuildOptions {
           workspace_members: &self.workspace_members,
           module_analyzer: &capturing_analyzer,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -206,7 +206,7 @@ async fn test_npm_version_not_found_then_found() {
     graph
       .build(
         vec![root.clone()],
-        &mut loader,
+        &loader,
         BuildOptions {
           npm_resolver: Some(&npm_resolver),
           ..Default::default()
@@ -235,7 +235,7 @@ async fn test_npm_version_not_found_then_found() {
     graph
       .build(
         vec![root.clone()],
-        &mut loader,
+        &loader,
         BuildOptions {
           npm_resolver: Some(&npm_resolver),
           ..Default::default()
@@ -328,7 +328,7 @@ async fn test_jsr_version_not_found_then_found() {
   graph
     .build(
       vec![Url::parse("file:///main.ts").unwrap()],
-      &mut loader,
+      &loader,
       Default::default(),
     )
     .await;
@@ -376,7 +376,7 @@ async fn test_dynamic_imports_with_template_arg() {
     graph
       .build(
         vec![Url::parse("file:///dev/main.ts").unwrap()],
-        &mut loader,
+        &loader,
         BuildOptions {
           file_system: &file_system,
           ..Default::default()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -253,18 +253,19 @@ async fn test_npm_version_not_found_then_found() {
 async fn test_jsr_version_not_found_then_found() {
   #[derive(Default)]
   struct TestLoader {
-    requests: Vec<(String, CacheSetting)>,
+    requests: RefCell<Vec<(String, CacheSetting)>>,
   }
 
   impl deno_graph::source::Loader for TestLoader {
     fn load(
-      &mut self,
+      &self,
       specifier: &ModuleSpecifier,
       options: LoadOptions,
     ) -> LoadFuture {
       assert!(!options.is_dynamic);
       self
         .requests
+        .borrow_mut()
         .push((specifier.to_string(), options.cache_setting));
       let specifier = specifier.clone();
       match specifier.as_str() {
@@ -333,7 +334,7 @@ async fn test_jsr_version_not_found_then_found() {
     .await;
   graph.valid().unwrap();
   assert_eq!(
-    loader.requests,
+    *loader.requests.borrow(),
     vec![
       ("file:///main.ts".to_string(), CacheSetting::Use),
       (

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -323,7 +323,7 @@ async fn test_jsr_version_not_found_then_found() {
     }
   }
 
-  let mut loader = TestLoader::default();
+  let loader = TestLoader::default();
   let mut graph = ModuleGraph::new(GraphKind::All);
   graph
     .build(

--- a/tests/specs/graph/multiple_redirects.txt
+++ b/tests/specs/graph/multiple_redirects.txt
@@ -1,0 +1,79 @@
+# mod.ts
+import "https://localhost/redirect.ts";
+import "https://localhost/other_redirect.ts";
+
+# https://localhost/redirect.ts
+HEADERS: {"location":"./redirect2.ts"}
+
+# https://localhost/other_redirect.ts
+HEADERS: {"location":"./redirect2.ts"}
+
+# https://localhost/redirect2.ts
+HEADERS: {"location":"./redirect3.ts"}
+
+# https://localhost/redirect3.ts
+HEADERS: {"location":"./value.ts"}
+
+# https://localhost/value.ts
+console.log('hi');
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "https://localhost/redirect.ts",
+          "code": {
+            "specifier": "https://localhost/redirect.ts",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 7
+              },
+              "end": {
+                "line": 0,
+                "character": 38
+              }
+            }
+          }
+        },
+        {
+          "specifier": "https://localhost/other_redirect.ts",
+          "code": {
+            "specifier": "https://localhost/other_redirect.ts",
+            "span": {
+              "start": {
+                "line": 1,
+                "character": 7
+              },
+              "end": {
+                "line": 1,
+                "character": 44
+              }
+            }
+          }
+        }
+      ],
+      "size": 86,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 19,
+      "mediaType": "TypeScript",
+      "specifier": "https://localhost/value.ts"
+    }
+  ],
+  "redirects": {
+    "https://localhost/other_redirect.ts": "https://localhost/redirect2.ts",
+    "https://localhost/redirect.ts": "https://localhost/redirect2.ts",
+    "https://localhost/redirect2.ts": "https://localhost/redirect3.ts",
+    "https://localhost/redirect3.ts": "https://localhost/value.ts"
+  }
+}

--- a/tests/specs_test.rs
+++ b/tests/specs_test.rs
@@ -20,9 +20,9 @@ use deno_graph::WorkspaceMember;
 use deno_semver::package::PackageNv;
 use deno_semver::package::PackageReq;
 use file_test_runner::collect_and_run_tests;
-use file_test_runner::CollectOptions;
-use file_test_runner::CollectedTest;
-use file_test_runner::FileCollectionStrategy;
+use file_test_runner::collection::strategies::TestPerFileCollectionStrategy;
+use file_test_runner::collection::CollectOptions;
+use file_test_runner::collection::CollectedTest;
 use file_test_runner::RunOptions;
 use file_test_runner::TestResult;
 use helpers::TestLoader;
@@ -41,8 +41,7 @@ fn main() {
   collect_and_run_tests(
     CollectOptions {
       base: "tests/specs".into(),
-      strategy: FileCollectionStrategy::TestPerFile { file_pattern: None },
-      root_category_name: "specs".to_string(),
+      strategy: Box::new(TestPerFileCollectionStrategy { file_pattern: None }),
       filter_override: None,
     },
     RunOptions { parallel: true },

--- a/tests/specs_test.rs
+++ b/tests/specs_test.rs
@@ -421,7 +421,7 @@ fn add_spec_files_to_loader(
     let source = match file.headers.get("location") {
       Some(location) => {
         let location = if location.starts_with("./") {
-          file.url().join(&location).unwrap().to_string()
+          file.url().join(location).unwrap().to_string()
         } else {
           location.to_string()
         };


### PR DESCRIPTION
Part of https://github.com/jsr-io/jsr/issues/322

This is necessary because someone may have a server that does a redirect to a JSR HTTPS URL and we'll need to detect that then use the manifest information to get the url's checksum.

The security issue this prevents against is:

1. The user has `"vendor": true`
2. deno_graph requests to load `https://example.com/mod.ts` with no checksum because it's not a jsr package.
3. That does a redirect to `https://jsr.io/@scope/pkg/0.1.0/mod.ts`, the CLI loads that url and stores it in the vendor folder without checking any checksum
4. The loader returns back `https://jsr.io/@scope/pkg/0.1.0/mod.ts`, but it's too late because the source has been stored in the vendor folder without its checksum being checked (once a file from jsr is in the vendor folder, we never check the checksum in order to allow users to make modifications)

I will follow up in a future PR actually implementing the behaviour to load https specifiers from JSR, but it would be best to land this first because it's a large change.