### PR TITLE
fix: trace parent classes and interfaces of referenced qualified expressions

### DIFF
--- a/src/fast_check/range_finder.rs
+++ b/src/fast_check/range_finder.rs
@@ -780,11 +780,11 @@ impl<'a> PublicRangeFinder<'a> {
       match trace {
         PendingIdTrace::Id {
           symbol_id,
-          referrer_id,
+          referrer_id: trace_referrer_id,
         } => {
           let symbol = module_info.symbol(symbol_id).unwrap();
           if symbol.is_private_member() {
-            if Some(referrer_id) != symbol.parent_id() {
+            if Some(trace_referrer_id) != symbol.parent_id() {
               diagnostics.push(
                 FastCheckDiagnostic::UnsupportedPrivateMemberReference {
                   range: FastCheckDiagnosticRange {
@@ -796,7 +796,7 @@ impl<'a> PublicRangeFinder<'a> {
                     .fully_qualified_symbol_name(symbol)
                     .unwrap_or_else(|| "<unknown>".to_string()),
                   referrer: module_info
-                    .symbol(referrer_id)
+                    .symbol(trace_referrer_id)
                     .and_then(|symbol| {
                       module_info.fully_qualified_symbol_name(symbol)
                     })
@@ -814,7 +814,6 @@ impl<'a> PublicRangeFinder<'a> {
               impl_with_overload_ranges.insert(decl.range);
               continue;
             }
-            let original_referrer_id = referrer_id;
             let referrer_id = symbol_id;
             match &decl.kind {
               SymbolDeclKind::Target(id) => {

--- a/src/fast_check/range_finder.rs
+++ b/src/fast_check/range_finder.rs
@@ -867,7 +867,7 @@ impl<'a> PublicRangeFinder<'a> {
                   if node.is_member() {
                     if let Some(parent_id) = symbol.parent_id() {
                       // don't add the parent if we analyzed this node from the parent
-                      if original_referrer_id != parent_id {
+                      if trace_referrer_id != parent_id {
                         pending_traces
                           .maybe_add_id_trace(parent_id, referrer_id);
                       }

--- a/tests/specs/graph/fast_check/issue_23658_1.txt
+++ b/tests/specs/graph/fast_check/issue_23658_1.txt
@@ -1,0 +1,106 @@
+# https://jsr.io/@scope/a/meta.json
+{"versions": { "1.0.0": {} } }
+
+# https://jsr.io/@scope/a/1.0.0_meta.json
+{ "exports": { ".": "./mod.ts" } }
+
+# https://jsr.io/@scope/a/1.0.0/base.ts
+export class Base {
+}
+
+# https://jsr.io/@scope/a/1.0.0/mod.ts
+import * as adapter_base from './base.ts'
+
+class ServerAdapter extends adapter_base.Base {
+  static adapt() {
+  }
+}
+
+export const adapt = ServerAdapter.adapt;
+
+# mod.ts
+import 'jsr:@scope/a'
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "jsr:@scope/a",
+          "code": {
+            "specifier": "jsr:@scope/a",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 7
+              },
+              "end": {
+                "line": 0,
+                "character": 21
+              }
+            }
+          }
+        }
+      ],
+      "size": 22,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 22,
+      "mediaType": "TypeScript",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/base.ts"
+    },
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "./base.ts",
+          "code": {
+            "specifier": "https://jsr.io/@scope/a/1.0.0/base.ts",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 30
+              },
+              "end": {
+                "line": 0,
+                "character": 41
+              }
+            }
+          }
+        }
+      ],
+      "size": 159,
+      "mediaType": "TypeScript",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+    }
+  ],
+  "redirects": {
+    "jsr:@scope/a": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+  },
+  "packages": {
+    "@scope/a": "@scope/a@1.0.0"
+  }
+}
+
+Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
+  {}
+  class ServerAdapter extends adapter_base.Base {
+    static adapt(): void {}
+  }
+  export const adapt = ServerAdapter.adapt;
+  --- DTS ---
+  declare class ServerAdapter extends adapter_base.Base {
+    static adapt(): void;
+  }
+  export declare const adapt: any;
+  --- DTS Diagnostics ---
+  unable to infer type, falling back to any type
+      at https://jsr.io/@scope/a/1.0.0/mod.ts@130

--- a/tests/specs/graph/fast_check/issue_23658_1.txt
+++ b/tests/specs/graph/fast_check/issue_23658_1.txt
@@ -90,13 +90,39 @@ import 'jsr:@scope/a'
   }
 }
 
-Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
+Fast check https://jsr.io/@scope/a/1.0.0/base.ts:
   {}
+  export class Base {
+  }
+  --- DTS ---
+  export declare class Base {
+  }
+
+Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
+  {
+    "./base.ts": {
+      "code": {
+        "specifier": "https://jsr.io/@scope/a/1.0.0/base.ts",
+        "span": {
+          "start": {
+            "line": 0,
+            "character": 30
+          },
+          "end": {
+            "line": 0,
+            "character": 41
+          }
+        }
+      }
+    }
+  }
+  import * as adapter_base from "./base.ts";
   class ServerAdapter extends adapter_base.Base {
     static adapt(): void {}
   }
   export const adapt = ServerAdapter.adapt;
   --- DTS ---
+  import * as adapter_base from "./base.ts";
   declare class ServerAdapter extends adapter_base.Base {
     static adapt(): void;
   }

--- a/tests/specs/graph/fast_check/issue_23658_2.txt
+++ b/tests/specs/graph/fast_check/issue_23658_2.txt
@@ -1,0 +1,106 @@
+# https://jsr.io/@scope/a/meta.json
+{"versions": { "1.0.0": {} } }
+
+# https://jsr.io/@scope/a/1.0.0_meta.json
+{ "exports": { ".": "./mod.ts" } }
+
+# https://jsr.io/@scope/a/1.0.0/base.ts
+export class Base {
+}
+
+# https://jsr.io/@scope/a/1.0.0/mod.ts
+import { Base } from './base.ts'
+
+class ServerAdapter extends Base {
+  static adapt() {
+  }
+}
+
+export const adapt = ServerAdapter.adapt;
+
+# mod.ts
+import 'jsr:@scope/a'
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "jsr:@scope/a",
+          "code": {
+            "specifier": "jsr:@scope/a",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 7
+              },
+              "end": {
+                "line": 0,
+                "character": 21
+              }
+            }
+          }
+        }
+      ],
+      "size": 22,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 22,
+      "mediaType": "TypeScript",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/base.ts"
+    },
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "./base.ts",
+          "code": {
+            "specifier": "https://jsr.io/@scope/a/1.0.0/base.ts",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 21
+              },
+              "end": {
+                "line": 0,
+                "character": 32
+              }
+            }
+          }
+        }
+      ],
+      "size": 137,
+      "mediaType": "TypeScript",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+    }
+  ],
+  "redirects": {
+    "jsr:@scope/a": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+  },
+  "packages": {
+    "@scope/a": "@scope/a@1.0.0"
+  }
+}
+
+Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
+  {}
+  class ServerAdapter extends Base {
+    static adapt(): void {}
+  }
+  export const adapt = ServerAdapter.adapt;
+  --- DTS ---
+  declare class ServerAdapter extends Base {
+    static adapt(): void;
+  }
+  export declare const adapt: any;
+  --- DTS Diagnostics ---
+  unable to infer type, falling back to any type
+      at https://jsr.io/@scope/a/1.0.0/mod.ts@108

--- a/tests/specs/graph/fast_check/issue_23658_2.txt
+++ b/tests/specs/graph/fast_check/issue_23658_2.txt
@@ -8,10 +8,15 @@
 export class Base {
 }
 
+# https://jsr.io/@scope/a/1.0.0/interface.ts
+export class IInterface {
+}
+
 # https://jsr.io/@scope/a/1.0.0/mod.ts
 import { Base } from './base.ts'
+import type { IInterface } from './interface.ts';
 
-class ServerAdapter extends Base {
+class ServerAdapter extends Base implements IInterface {
   static adapt() {
   }
 }
@@ -59,6 +64,12 @@ import 'jsr:@scope/a'
     },
     {
       "kind": "esm",
+      "size": 28,
+      "mediaType": "TypeScript",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/interface.ts"
+    },
+    {
+      "kind": "esm",
       "dependencies": [
         {
           "specifier": "./base.ts",
@@ -75,9 +86,25 @@ import 'jsr:@scope/a'
               }
             }
           }
+        },
+        {
+          "specifier": "./interface.ts",
+          "type": {
+            "specifier": "https://jsr.io/@scope/a/1.0.0/interface.ts",
+            "span": {
+              "start": {
+                "line": 1,
+                "character": 32
+              },
+              "end": {
+                "line": 1,
+                "character": 48
+              }
+            }
+          }
         }
       ],
-      "size": 137,
+      "size": 209,
       "mediaType": "TypeScript",
       "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
     }
@@ -90,17 +117,68 @@ import 'jsr:@scope/a'
   }
 }
 
-Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
+Fast check https://jsr.io/@scope/a/1.0.0/base.ts:
   {}
-  class ServerAdapter extends Base {
+  export class Base {
+  }
+  --- DTS ---
+  export declare class Base {
+  }
+
+Fast check https://jsr.io/@scope/a/1.0.0/interface.ts:
+  {}
+  export class IInterface {
+  }
+  --- DTS ---
+  export declare class IInterface {
+  }
+
+Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
+  {
+    "./base.ts": {
+      "code": {
+        "specifier": "https://jsr.io/@scope/a/1.0.0/base.ts",
+        "span": {
+          "start": {
+            "line": 0,
+            "character": 21
+          },
+          "end": {
+            "line": 0,
+            "character": 32
+          }
+        }
+      }
+    },
+    "./interface.ts": {
+      "type": {
+        "specifier": "https://jsr.io/@scope/a/1.0.0/interface.ts",
+        "span": {
+          "start": {
+            "line": 1,
+            "character": 32
+          },
+          "end": {
+            "line": 1,
+            "character": 48
+          }
+        }
+      }
+    }
+  }
+  import { Base } from "./base.ts";
+  import type { IInterface } from "./interface.ts";
+  class ServerAdapter extends Base implements IInterface {
     static adapt(): void {}
   }
   export const adapt = ServerAdapter.adapt;
   --- DTS ---
-  declare class ServerAdapter extends Base {
+  import { Base } from "./base.ts";
+  import type { IInterface } from "./interface.ts";
+  declare class ServerAdapter extends Base implements IInterface {
     static adapt(): void;
   }
   export declare const adapt: any;
   --- DTS Diagnostics ---
   unable to infer type, falling back to any type
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@108
+      at https://jsr.io/@scope/a/1.0.0/mod.ts@180


### PR DESCRIPTION
We were tracing into a class' static method in this scenario, but not tracing the parent class.

```
> ../deno/target/debug/deno publish --dry-run
Checking for slow types in the public API...
Check file:///V:/ts-rpc/client.ts
Check file:///V:/ts-rpc/adapters/oak.ts
Simulating publish of @andykais/ts-rpc@0.1.0 with files:
   file:///V:/ts-rpc/.github/workflows/deno.yml (1.01KB)
   file:///V:/ts-rpc/README.md (2.6KB)
   file:///V:/ts-rpc/adapters/mod.ts (2.91KB)
   file:///V:/ts-rpc/adapters/oak.ts (2.32KB)
   file:///V:/ts-rpc/client.ts (7.36KB)
   file:///V:/ts-rpc/deno.jsonc (380B)
   file:///V:/ts-rpc/deno.lock (31.6KB)
   file:///V:/ts-rpc/server.ts (1.89KB)
   file:///V:/ts-rpc/src/contracts.ts (1.41KB)
   file:///V:/ts-rpc/src/errors.ts (4.12KB)
   file:///V:/ts-rpc/src/types.ts (2.17KB)
   file:///V:/ts-rpc/tests/tools/deps.ts (499B)
   file:///V:/ts-rpc/tests/tools/fetch_mock.ts (5.34KB)
   file:///V:/ts-rpc/tests/tools/tools.ts (3.65KB)
   file:///V:/ts-rpc/tests/ts-rpc.test.ts (8.37KB)
Warning Aborting due to --dry-run
```

For https://github.com/denoland/deno/issues/23658