### PR TITLE
fix: `ExpandoPropertyRef` - expose inner assignment expr

### DIFF
--- a/src/symbols/analyzer.rs
+++ b/src/symbols/analyzer.rs
@@ -1051,6 +1051,11 @@ impl<'a> ExpandoPropertyRef<'a> {
     }
   }
 
+  /// The inner assignment expression.
+  pub fn inner(&self) -> &'a AssignExpr {
+    self.0
+  }
+
   pub fn member_expr(&self) -> &'a MemberExpr {
     // these were verified in the constructor, so we can unwrap here
     Self::maybe_member_expr(self.0).unwrap()


### PR DESCRIPTION
Need this for getting jsdocs in deno_doc.