### PR TITLE
refactor(BREAKING): parse_module - take owned specifier

### DIFF
--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -326,7 +326,7 @@ pub fn js_parse_module(
   };
   match deno_graph::parse_module(deno_graph::ParseModuleOptions {
     graph_kind: GraphKind::All,
-    specifier: &specifier,
+    specifier,
     maybe_headers: maybe_headers.as_ref(),
     content: content.into(),
     file_system: &NullFileSystem,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2066,7 +2066,6 @@ pub(crate) struct ParseModuleOptions<'a> {
 }
 
 /// With the provided information, parse a module and return its "module slot"
-#[allow(clippy::too_many_arguments)]
 #[allow(clippy::result_large_err)]
 pub(crate) fn parse_module(
   file_system: &dyn FileSystem,


### PR DESCRIPTION
The main point of this PR was the refactor for parse_module to take a struct instead of having so many arguments. Then I noticed the specifier is always cloned so it can be taken as owned instead.