### PR TITLE
refactor: make module analysis async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.75.1"
+version = "0.75.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deno_graph"
-version = "0.75.1"
+version = "0.75.2"
 edition = "2021"
 description = "Module graph analysis for deno"
 homepage = "https://deno.land/"

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -292,7 +292,7 @@ pub async fn js_create_graph(
 
 #[allow(clippy::too_many_arguments)]
 #[wasm_bindgen(js_name = parseModule)]
-pub fn js_parse_module(
+pub async fn js_parse_module(
   specifier: String,
   maybe_headers: JsValue,
   maybe_default_jsx_import_source: Option<String>,
@@ -327,14 +327,16 @@ pub fn js_parse_module(
   match deno_graph::parse_module(deno_graph::ParseModuleOptions {
     graph_kind: GraphKind::All,
     specifier,
-    maybe_headers: maybe_headers.as_ref(),
+    maybe_headers,
     content: content.into(),
     file_system: &NullFileSystem,
     jsr_url_provider: Default::default(),
     maybe_resolver: maybe_resolver.as_ref().map(|r| r as &dyn Resolver),
     module_analyzer: Default::default(),
     maybe_npm_resolver: None,
-  }) {
+  })
+  .await
+  {
     Ok(module) => {
       let serializer =
         serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -308,9 +308,10 @@ pub fn module_graph_1_to_2(module_info: &mut serde_json::Value) {
 ///
 /// It can be assumed that the source has not changed since
 /// it was loaded by deno_graph.
+#[async_trait::async_trait(?Send)]
 pub trait ModuleAnalyzer {
   /// Analyzes the module.
-  fn analyze(
+  async fn analyze(
     &self,
     specifier: &ModuleSpecifier,
     source: Arc<str>,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -315,6 +315,22 @@ impl<'a> ParserModuleAnalyzer<'a> {
       jsdoc_imports: analyze_jsdoc_imports(media_type, text_info, comments),
     }
   }
+
+  pub fn analyze_sync(
+    &self,
+    specifier: &deno_ast::ModuleSpecifier,
+    source: Arc<str>,
+    media_type: MediaType,
+  ) -> Result<ModuleInfo, ParseDiagnostic> {
+    let parsed_source = self.parser.parse_module(ParseOptions {
+      specifier,
+      source,
+      media_type,
+      // scope analysis is not necessary for module parsing
+      scope_analysis: false,
+    })?;
+    Ok(ParserModuleAnalyzer::module_info(&parsed_source))
+  }
 }
 
 impl<'a> Default for ParserModuleAnalyzer<'a> {
@@ -333,14 +349,7 @@ impl<'a> ModuleAnalyzer for ParserModuleAnalyzer<'a> {
     source: Arc<str>,
     media_type: MediaType,
   ) -> Result<ModuleInfo, ParseDiagnostic> {
-    let parsed_source = self.parser.parse_module(ParseOptions {
-      specifier,
-      source,
-      media_type,
-      // scope analysis is not necessary for module parsing
-      scope_analysis: false,
-    })?;
-    Ok(ParserModuleAnalyzer::module_info(&parsed_source))
+    self.analyze_sync(specifier, source, media_type)
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ pub struct ReferrerImports {
 pub struct ParseModuleOptions<'a> {
   pub graph_kind: GraphKind,
   pub specifier: ModuleSpecifier,
-  pub maybe_headers: Option<&'a HashMap<String, String>>,
+  pub maybe_headers: Option<HashMap<String, String>>,
   pub content: Arc<[u8]>,
   pub file_system: &'a dyn FileSystem,
   pub jsr_url_provider: &'a dyn JsrUrlProvider,
@@ -141,7 +141,6 @@ pub fn parse_module(
     graph::ParseModuleOptions {
       graph_kind: options.graph_kind,
       module_source_and_info,
-      maybe_headers: options.maybe_headers,
     },
   )
 }
@@ -3607,11 +3606,10 @@ export const foo = 'bar';"#,
       "content-type".to_string(),
       "application/typescript; charset=utf-8".to_string(),
     );
-    let maybe_headers = Some(&headers);
     let result = parse_module(ParseModuleOptions {
       graph_kind: GraphKind::All,
       specifier: specifier.clone(),
-      maybe_headers,
+      maybe_headers: Some(headers),
       content: br#"declare interface A {
   a: string;
 }"#

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,8 +118,8 @@ pub struct ParseModuleOptions<'a> {
 /// Parse an individual module, returning the module as a result, otherwise
 /// erroring with a module graph error.
 #[allow(clippy::result_large_err)]
-pub fn parse_module(
-  options: ParseModuleOptions,
+pub async fn parse_module(
+  options: ParseModuleOptions<'_>,
 ) -> Result<Module, ModuleError> {
   let module_source_and_info = graph::parse_module_source_and_info(
     options.module_analyzer,
@@ -132,7 +132,8 @@ pub fn parse_module(
       is_root: true,
       is_dynamic_branch: false,
     },
-  )?;
+  )
+  .await?;
   graph::parse_module(
     options.file_system,
     options.jsr_url_provider,
@@ -3211,8 +3212,8 @@ export const foo = 'bar';"#,
     );
   }
 
-  #[test]
-  fn test_parse_module() {
+  #[tokio::test]
+  async fn test_parse_module() {
     let specifier = ModuleSpecifier::parse("file:///a/test01.ts").unwrap();
     let code = br#"
     /// <reference types="./a.d.ts" />
@@ -3234,6 +3235,7 @@ export const foo = 'bar';"#,
       maybe_npm_resolver: None,
       module_analyzer: Default::default(),
     })
+    .await
     .unwrap();
     let actual = actual.js().unwrap();
     assert_eq!(actual.dependencies.len(), 7);
@@ -3252,13 +3254,14 @@ export const foo = 'bar';"#,
       maybe_npm_resolver: None,
       module_analyzer: Default::default(),
     })
+    .await
     .unwrap();
     let actual = actual.js().unwrap();
     assert_eq!(actual.dependencies.len(), 4);
   }
 
-  #[test]
-  fn test_parse_module_import_assertions() {
+  #[tokio::test]
+  async fn test_parse_module_import_assertions() {
     let specifier = ModuleSpecifier::parse("file:///a/test01.ts").unwrap();
     let actual = parse_module(ParseModuleOptions {
       graph_kind: GraphKind::All,
@@ -3276,6 +3279,7 @@ export const foo = 'bar';"#,
       maybe_npm_resolver: None,
       module_analyzer: Default::default(),
     })
+    .await
     .unwrap();
     assert_eq!(
       json!(actual),
@@ -3325,8 +3329,8 @@ export const foo = 'bar';"#,
     );
   }
 
-  #[test]
-  fn test_parse_module_jsx_import_source() {
+  #[tokio::test]
+  async fn test_parse_module_jsx_import_source() {
     let specifier = ModuleSpecifier::parse("file:///a/test01.tsx").unwrap();
     let actual = parse_module(ParseModuleOptions {
       graph_kind: GraphKind::All,
@@ -3347,6 +3351,7 @@ export const foo = 'bar';"#,
       maybe_npm_resolver: None,
       module_analyzer: Default::default(),
     })
+    .await
     .unwrap();
     let actual = actual.js().unwrap();
     assert_eq!(actual.dependencies.len(), 1);
@@ -3363,8 +3368,8 @@ export const foo = 'bar';"#,
     assert_eq!(actual.media_type, MediaType::Tsx);
   }
 
-  #[test]
-  fn test_parse_module_jsx_import_source_types() {
+  #[tokio::test]
+  async fn test_parse_module_jsx_import_source_types() {
     let specifier = ModuleSpecifier::parse("file:///a/test01.tsx").unwrap();
     let actual = parse_module(ParseModuleOptions {
       graph_kind: GraphKind::All,
@@ -3386,6 +3391,7 @@ export const foo = 'bar';"#,
       maybe_npm_resolver: None,
       module_analyzer: Default::default(),
     })
+    .await
     .unwrap();
     let actual = actual.js().unwrap();
     assert_eq!(actual.dependencies.len(), 1);
@@ -3406,8 +3412,8 @@ export const foo = 'bar';"#,
     assert_eq!(actual.media_type, MediaType::Tsx);
   }
 
-  #[test]
-  fn test_parse_module_jsx_import_source_types_pragma() {
+  #[tokio::test]
+  async fn test_parse_module_jsx_import_source_types_pragma() {
     #[derive(Debug)]
     struct R;
     impl Resolver for R {
@@ -3436,6 +3442,7 @@ export const foo = 'bar';"#,
       maybe_npm_resolver: None,
       module_analyzer: Default::default(),
     })
+    .await
     .unwrap();
     let actual = actual.js().unwrap();
     assert_eq!(actual.dependencies.len(), 1);
@@ -3456,8 +3463,8 @@ export const foo = 'bar';"#,
     assert_eq!(actual.media_type, MediaType::Tsx);
   }
 
-  #[test]
-  fn test_parse_module_jsx_import_source_pragma() {
+  #[tokio::test]
+  async fn test_parse_module_jsx_import_source_pragma() {
     #[derive(Debug)]
     struct R;
     impl Resolver for R {
@@ -3486,6 +3493,7 @@ export const foo = 'bar';"#,
       maybe_npm_resolver: None,
       module_analyzer: Default::default(),
     })
+    .await
     .unwrap();
     let actual = actual.js().unwrap();
     assert_eq!(actual.dependencies.len(), 1);
@@ -3502,8 +3510,8 @@ export const foo = 'bar';"#,
     assert_eq!(actual.media_type, MediaType::Tsx);
   }
 
-  #[test]
-  fn test_default_jsx_import_source() {
+  #[tokio::test]
+  async fn test_default_jsx_import_source() {
     #[derive(Debug)]
     struct R;
     impl Resolver for R {
@@ -3530,6 +3538,7 @@ export const foo = 'bar';"#,
       maybe_npm_resolver: None,
       module_analyzer: Default::default(),
     })
+    .await
     .unwrap();
     let actual = actual.js().unwrap();
     assert_eq!(actual.dependencies.len(), 1);
@@ -3546,8 +3555,8 @@ export const foo = 'bar';"#,
     assert_eq!(actual.media_type, MediaType::Tsx);
   }
 
-  #[test]
-  fn test_default_jsx_import_source_types() {
+  #[tokio::test]
+  async fn test_default_jsx_import_source_types() {
     #[derive(Debug)]
     struct R;
     impl Resolver for R {
@@ -3578,6 +3587,7 @@ export const foo = 'bar';"#,
       maybe_npm_resolver: None,
       module_analyzer: Default::default(),
     })
+    .await
     .unwrap();
     let actual = actual.js().unwrap();
     assert_eq!(actual.dependencies.len(), 1);
@@ -3598,8 +3608,8 @@ export const foo = 'bar';"#,
     assert_eq!(actual.media_type, MediaType::Tsx);
   }
 
-  #[test]
-  fn test_parse_module_with_headers() {
+  #[tokio::test]
+  async fn test_parse_module_with_headers() {
     let specifier = ModuleSpecifier::parse("https://localhost/file").unwrap();
     let mut headers = HashMap::new();
     headers.insert(
@@ -3620,12 +3630,13 @@ export const foo = 'bar';"#,
       maybe_resolver: None,
       maybe_npm_resolver: None,
       module_analyzer: Default::default(),
-    });
+    })
+    .await;
     assert!(result.is_ok());
   }
 
-  #[test]
-  fn test_parse_module_with_jsdoc_imports() {
+  #[tokio::test]
+  async fn test_parse_module_with_jsdoc_imports() {
     let specifier = ModuleSpecifier::parse("file:///a/test.js").unwrap();
     let code = br#"
 /**
@@ -3649,6 +3660,7 @@ export function a(a) {
       maybe_npm_resolver: None,
       module_analyzer: Default::default(),
     })
+    .await
     .unwrap();
     assert_eq!(
       json!(actual),
@@ -3706,6 +3718,7 @@ export function a(a) {
       maybe_npm_resolver: None,
       module_analyzer: Default::default(),
     })
+    .await
     .unwrap();
     assert_eq!(
       json!(actual),
@@ -3718,8 +3731,8 @@ export function a(a) {
     );
   }
 
-  #[test]
-  fn test_parse_ts_jsdoc_imports_ignored() {
+  #[tokio::test]
+  async fn test_parse_ts_jsdoc_imports_ignored() {
     let specifier = ModuleSpecifier::parse("file:///a/test.ts").unwrap();
     let actual = parse_module(ParseModuleOptions {
       graph_kind: GraphKind::All,
@@ -3744,6 +3757,7 @@ export function a(a: A): B {
       maybe_npm_resolver: None,
       module_analyzer: Default::default(),
     })
+    .await
     .unwrap();
     assert_eq!(
       json!(actual),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,14 +121,9 @@ pub struct ParseModuleOptions<'a> {
 pub fn parse_module(
   options: ParseModuleOptions,
 ) -> Result<Module, ModuleError> {
-  graph::parse_module(
-    options.file_system,
-    options.jsr_url_provider,
-    options.maybe_resolver,
+  let module_source_and_info = graph::parse_module_source_and_info(
     options.module_analyzer,
-    options.maybe_npm_resolver,
-    graph::ParseModuleOptions {
-      graph_kind: options.graph_kind,
+    graph::ParseModuleAndSourceInfoOptions {
       specifier: options.specifier,
       maybe_headers: options.maybe_headers,
       content: options.content,
@@ -136,6 +131,17 @@ pub fn parse_module(
       maybe_referrer: None,
       is_root: true,
       is_dynamic_branch: false,
+    },
+  )?;
+  graph::parse_module(
+    options.file_system,
+    options.jsr_url_provider,
+    options.maybe_resolver,
+    options.maybe_npm_resolver,
+    graph::ParseModuleOptions {
+      graph_kind: options.graph_kind,
+      module_source_and_info,
+      maybe_headers: options.maybe_headers,
     },
   )
 }

--- a/tests/specs/graph/redirects_circular.txt
+++ b/tests/specs/graph/redirects_circular.txt
@@ -38,7 +38,7 @@ HEADERS: {"location":"./redirect.ts"}
       "specifier": "file:///mod.ts"
     },
     {
-      "specifier": "https://localhost/redirect.ts",
+      "specifier": "https://localhost/redirect2.ts",
       "error": "Too many redirects."
     }
   ],

--- a/tests/specs/graph/redirects_max.txt
+++ b/tests/specs/graph/redirects_max.txt
@@ -68,7 +68,7 @@ console.log('hi');
       "specifier": "file:///mod.ts"
     },
     {
-      "specifier": "https://localhost/redirect.ts",
+      "specifier": "https://localhost/value.ts",
       "error": "Too many redirects."
     }
   ],


### PR DESCRIPTION
This allows us to parse source files in parallel:

```
Benchmark 1: ../deno/deno_old run -A ts_morph.ts
  Time (mean ± σ):      2.332 s ±  0.017 s    [User: 2.193 s, System: 0.126 s]
  Range (min … max):    2.307 s …  2.366 s    10 runs
 
Benchmark 2: ../deno/target/release/deno run -A ts_morph.ts
  Time (mean ± σ):      1.052 s ±  0.006 s    [User: 2.259 s, System: 0.132 s]
  Range (min … max):    1.040 s …  1.060 s    10 runs
 
Summary
  ../deno/target/release/deno run -A ts_morph.ts ran
    2.22 ± 0.02 times faster than ../deno/deno_old run -A ts_morph.ts
scratch % cat ts_morph.ts
import "https://deno.land/x/ts_morph@22.0.0/mod.ts";
import "https://deno.land/x/ts_morph@21.0.0/mod.ts";
import "https://deno.land/x/ts_morph@20.0.0/mod.ts";
import "https://deno.land/x/ts_morph@19.0.0/mod.ts";
```