### PR TITLE
chore: use pretty diagnostics in spec tests

### DIFF
--- a/tests/specs/graph/fast_check/cache__diagnostic.txt
+++ b/tests/specs/graph/fast_check/cache__diagnostic.txt
@@ -140,8 +140,17 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  missing explicit return type in the public API
-      at https://jsr.io/@scope/a/1.0.0/c.ts@16
+  error[missing-explicit-return-type]: missing explicit return type in the public API
+   --> https://jsr.io/@scope/a/1.0.0/c.ts:1:17
+    |
+  1 | export function add(a: number, b: number) {
+    |                 ^^^ this function is missing an explicit return type
+    = hint: add an explicit return type to the function
+
+    info: all functions in the public API must have an explicit return type
+    docs: https://jsr.io/go/slow-type-missing-explicit-return-type
+
+
 == fast check cache ==
 FastCheckCacheKey(4741815020074927300):
     Deps - []

--- a/tests/specs/graph/fast_check/cache__diagnostic_deep.txt
+++ b/tests/specs/graph/fast_check/cache__diagnostic_deep.txt
@@ -141,8 +141,17 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  missing explicit return type in the public API
-      at https://jsr.io/@scope/a/1.0.0/c.ts@16
+  error[missing-explicit-return-type]: missing explicit return type in the public API
+   --> https://jsr.io/@scope/a/1.0.0/c.ts:1:17
+    |
+  1 | export function add(a: number, b: number) {
+    |                 ^^^ this function is missing an explicit return type
+    = hint: add an explicit return type to the function
+
+    info: all functions in the public API must have an explicit return type
+    docs: https://jsr.io/go/slow-type-missing-explicit-return-type
+
+
 == fast check cache ==
 FastCheckCacheKey(4741815020074927300):
     Deps - []

--- a/tests/specs/graph/fast_check/cache__diagnostic_multiple_exports.txt
+++ b/tests/specs/graph/fast_check/cache__diagnostic_multiple_exports.txt
@@ -162,11 +162,29 @@ import 'jsr:@scope/a/c'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/c.ts:
-  missing explicit return type in the public API
-      at https://jsr.io/@scope/a/1.0.0/a.ts@16
+  error[missing-explicit-return-type]: missing explicit return type in the public API
+   --> https://jsr.io/@scope/a/1.0.0/a.ts:1:17
+    |
+  1 | export function add(a: number, b: number) {
+    |                 ^^^ this function is missing an explicit return type
+    = hint: add an explicit return type to the function
+
+    info: all functions in the public API must have an explicit return type
+    docs: https://jsr.io/go/slow-type-missing-explicit-return-type
+
+
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  missing explicit return type in the public API
-      at https://jsr.io/@scope/a/1.0.0/a.ts@16
+  error[missing-explicit-return-type]: missing explicit return type in the public API
+   --> https://jsr.io/@scope/a/1.0.0/a.ts:1:17
+    |
+  1 | export function add(a: number, b: number) {
+    |                 ^^^ this function is missing an explicit return type
+    = hint: add an explicit return type to the function
+
+    info: all functions in the public API must have an explicit return type
+    docs: https://jsr.io/go/slow-type-missing-explicit-return-type
+
+
 == fast check cache ==
 FastCheckCacheKey(2640350593211828171):
     Deps - []

--- a/tests/specs/graph/fast_check/cache__diagnostic_then_nested_dep.txt
+++ b/tests/specs/graph/fast_check/cache__diagnostic_then_nested_dep.txt
@@ -174,8 +174,17 @@ jsr deps: {
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  missing explicit return type in the public API
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@16
+  error[missing-explicit-return-type]: missing explicit return type in the public API
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:1:17
+    |
+  1 | export function add(a: number, b: number) {
+    |                 ^^^ this function is missing an explicit return type
+    = hint: add an explicit return type to the function
+
+    info: all functions in the public API must have an explicit return type
+    docs: https://jsr.io/go/slow-type-missing-explicit-return-type
+
+
 Fast check https://jsr.io/@scope/b/1.0.0/mod.ts:
   {}
   export function add(a: number, b: number): number {

--- a/tests/specs/graph/fast_check/class_member_ref_additional_prop_on_member.txt
+++ b/tests/specs/graph/fast_check/class_member_ref_additional_prop_on_member.txt
@@ -62,5 +62,17 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  the reference 'MyClass.prototype.member.additional' from 'Export.prototype.prop' was too complex
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@70
+  error[unsupported-complex-reference]: the reference 'MyClass.prototype.member.additional' from 'Export.prototype.prop' was too complex
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:5:1
+    |
+  5 | class MyClass {
+    | ^^^^^^^^^^^^^^^
+  6 |   member: string;
+    | ^^^^^^^^^^^^^^^^^
+  7 | }
+    | ^ this is the reference
+    = hint: extract the shared type to a type alias and reference the type alias instead
+
+    info: the reference was too complex to be resolved by fast check
+    docs: https://jsr.io/go/slow-type-unsupported-complex-reference
+

--- a/tests/specs/graph/fast_check/class_member_ref_not_found.txt
+++ b/tests/specs/graph/fast_check/class_member_ref_not_found.txt
@@ -61,5 +61,17 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  could not resolve 'Public1.prototype.nonExistent' referenced from 'Export.prototype.prop'
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@70
+  error[not-found-reference]: could not resolve 'Public1.prototype.nonExistent' referenced from 'Export.prototype.prop'
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:4:1
+    |
+  4 | class Public1 {
+    | ^^^^^^^^^^^^^^^
+  5 |   prop: string;
+    | ^^^^^^^^^^^^^^^
+  6 | }
+    | ^ this is the reference
+    = hint: fix the reference to point to a symbol that exists
+
+    info: this error may be the result of a bug in Deno - if you think this is the case, please open an issue
+    docs: https://jsr.io/go/slow-type-not-found-reference
+

--- a/tests/specs/graph/fast_check/class_static_member_ref_not_found.txt
+++ b/tests/specs/graph/fast_check/class_static_member_ref_not_found.txt
@@ -61,5 +61,17 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  could not resolve 'Public1.nonExistent' referenced from 'Export.prototype.prop'
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@60
+  error[not-found-reference]: could not resolve 'Public1.nonExistent' referenced from 'Export.prototype.prop'
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:4:1
+    |
+  4 | class Public1 {
+    | ^^^^^^^^^^^^^^^
+  5 |   static prop: string;
+    | ^^^^^^^^^^^^^^^^^^^^^^
+  6 | }
+    | ^ this is the reference
+    = hint: fix the reference to point to a symbol that exists
+
+    info: this error may be the result of a bug in Deno - if you think this is the case, please open an issue
+    docs: https://jsr.io/go/slow-type-not-found-reference
+

--- a/tests/specs/graph/fast_check/class_super_unsupported.txt
+++ b/tests/specs/graph/fast_check/class_super_unsupported.txt
@@ -60,5 +60,13 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  super class expression was too complex
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@121
+  error[unsupported-super-class-expr]: super class expression was too complex
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:4:28
+    |
+  4 | export class Child extends MyFunction(Base) {
+    |                            ^^^^^^^^^^^^^^^^ this is the superclass expression
+    = hint: extract the superclass expression into a variable
+
+    info: fast check was unable to infer the type of the superclass expression
+    docs: https://jsr.io/go/slow-type-unsupported-super-class-expr
+

--- a/tests/specs/graph/fast_check/const_infer_function_missing_return.txt
+++ b/tests/specs/graph/fast_check/const_infer_function_missing_return.txt
@@ -56,5 +56,13 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  missing explicit return type in the public API
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@13
+  error[missing-explicit-return-type]: missing explicit return type in the public API
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:1:14
+    |
+  1 | export const test4 = function () { return "test" };
+    |              ^^^^^ this function is missing an explicit return type
+    = hint: add an explicit return type to the function
+
+    info: all functions in the public API must have an explicit return type
+    docs: https://jsr.io/go/slow-type-missing-explicit-return-type
+

--- a/tests/specs/graph/fast_check/cross_file_ref_module_not_found.txt
+++ b/tests/specs/graph/fast_check/cross_file_ref_module_not_found.txt
@@ -137,5 +137,19 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  could not resolve 'A.prototype.notExistent' referenced from '<unknown>'
-      at https://jsr.io/@scope/a/1.0.0/a.ts@0
+  error[not-found-reference]: could not resolve 'A.prototype.notExistent' referenced from '<unknown>'
+   --> https://jsr.io/@scope/a/1.0.0/a.ts:1:1
+    |
+  1 | export class A {
+    | ^^^^^^^^^^^^^^^^
+  2 |   member: string;
+    | ^^^^^^^^^^^^^^^^^
+  3 |   member2: string;
+    | ^^^^^^^^^^^^^^^^^^
+  4 | }
+    | ^ this is the reference
+    = hint: fix the reference to point to a symbol that exists
+
+    info: this error may be the result of a bug in Deno - if you think this is the case, please open an issue
+    docs: https://jsr.io/go/slow-type-not-found-reference
+

--- a/tests/specs/graph/fast_check/entrypoint_js.txt
+++ b/tests/specs/graph/fast_check/entrypoint_js.txt
@@ -60,5 +60,11 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.js:
-  used a JavaScript module without type declarations as an entrypoint
-      at https://jsr.io/@scope/a/1.0.0/mod.js
+  warning[unsupported-javascript-entrypoint]: used a JavaScript module without type declarations as an entrypoint
+   --> https://jsr.io/@scope/a/1.0.0/mod.js
+    = hint: add a type declaration (d.ts) for the JavaScript module, or rewrite it to TypeScript
+
+    info: JavaScript files with no corresponding declaration require type inference to be type checked
+    info: fast check avoids type inference, so JavaScript entrypoints should be avoided
+    docs: https://jsr.io/go/slow-type-unsupported-javascript-entrypoint
+

--- a/tests/specs/graph/fast_check/expando_props/same_name_local_var_ref.txt
+++ b/tests/specs/graph/fast_check/expando_props/same_name_local_var_ref.txt
@@ -63,5 +63,13 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  expando property referencing 'localDecl' conflicts with 'test.localDecl'
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@79
+  error[unsupported-expando-property]: expando property referencing 'localDecl' conflicts with 'test.localDecl'
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:5:18
+    |
+  5 | test.localDecl = localDecl;
+    |                  ^^^^^^^^^
+    = hint: rename 'localDecl' to something else to avoid conflicts or create a temporary variable with a different name to use in the expando property reference
+
+    info: expando properties get converted to a namespace and the reference conflicts with a namespace export
+    docs: https://jsr.io/go/slow-type-unsupported-expando-property
+

--- a/tests/specs/graph/fast_check/expando_props/same_name_namespace_export.txt
+++ b/tests/specs/graph/fast_check/expando_props/same_name_namespace_export.txt
@@ -67,5 +67,13 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  expando property referencing 'localDecl' conflicts with 'test.localDecl'
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@146
+  error[unsupported-expando-property]: expando property referencing 'localDecl' conflicts with 'test.localDecl'
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:9:13
+    |
+  9 | test.prop = localDecl;
+    |             ^^^^^^^^^
+    = hint: rename 'localDecl' to something else to avoid conflicts or create a temporary variable with a different name to use in the expando property reference
+
+    info: expando properties get converted to a namespace and the reference conflicts with a namespace export
+    docs: https://jsr.io/go/slow-type-unsupported-expando-property
+

--- a/tests/specs/graph/fast_check/export_equals.txt
+++ b/tests/specs/graph/fast_check/export_equals.txt
@@ -56,5 +56,13 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  export assignments are a Common JS feature, which are not supported in ES modules
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@0
+  error[unsupported-ts-export-assignment]: export assignments are a Common JS feature, which are not supported in ES modules
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:1:1
+    |
+  1 | export = 5;
+    | ^^^^^^^^^^^
+    = hint: use an export statement instead
+
+    info: CommonJS features such as export assignments are not supported in ES modules
+    docs: https://jsr.io/go/slow-type-unsupported-ts-export-assignment
+

--- a/tests/specs/graph/fast_check/global_module.txt
+++ b/tests/specs/graph/fast_check/global_module.txt
@@ -58,5 +58,17 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  found global augmentations, which are not supported
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@0
+  error[unsupported-global-module]: found global augmentations, which are not supported
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:1:1
+    |
+  1 | global {
+    | ^^^^^^^^
+  2 |   declare var Test: 5;
+    | ^^^^^^^^^^^^^^^^^^^^^^
+  3 | }
+    | ^
+    = hint: remove the 'global' augmentation
+
+    info: global augmentations are not supported because they can modify global types, which can affect other modules type checking
+    docs: https://jsr.io/go/slow-type-unsupported-global-module
+

--- a/tests/specs/graph/fast_check/inferred_unique_symbols__not_global.txt
+++ b/tests/specs/graph/fast_check/inferred_unique_symbols__not_global.txt
@@ -65,5 +65,13 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  missing explicit type in the public API
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@70
+  error[missing-explicit-type]: missing explicit type in the public API
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:4:7
+    |
+  4 | const key = Symbol("#keys");
+    |       ^^^ this symbol is missing an explicit type
+    = hint: add an explicit type annotation to the symbol
+
+    info: all symbols in the public API must have an explicit type
+    docs: https://jsr.io/go/slow-type-missing-explicit-type
+

--- a/tests/specs/graph/fast_check/missing_return_type.txt
+++ b/tests/specs/graph/fast_check/missing_return_type.txt
@@ -58,5 +58,13 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  missing explicit return type in the public API
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@16
+  error[missing-explicit-return-type]: missing explicit return type in the public API
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:1:17
+    |
+  1 | export function missingReturnType() {
+    |                 ^^^^^^^^^^^^^^^^^ this function is missing an explicit return type
+    = hint: add an explicit return type to the function
+
+    info: all functions in the public API must have an explicit return type
+    docs: https://jsr.io/go/slow-type-missing-explicit-return-type
+

--- a/tests/specs/graph/fast_check/missing_return_type_generator.txt
+++ b/tests/specs/graph/fast_check/missing_return_type_generator.txt
@@ -57,5 +57,13 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  missing explicit return type in the public API
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@17
+  error[missing-explicit-return-type]: missing explicit return type in the public API
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:1:18
+    |
+  1 | export function* missingReturnType() {
+    |                  ^^^^^^^^^^^^^^^^^ this function is missing an explicit return type
+    = hint: add an explicit return type to the function
+
+    info: all functions in the public API must have an explicit return type
+    docs: https://jsr.io/go/slow-type-missing-explicit-return-type
+

--- a/tests/specs/graph/fast_check/nested_java_script.txt
+++ b/tests/specs/graph/fast_check/nested_java_script.txt
@@ -89,5 +89,11 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  referenced a JavaScript module without type declarations from a TypeScript module
-      at https://jsr.io/@scope/a/1.0.0/a.js
+  error[unsupported-nested-javascript]: referenced a JavaScript module without type declarations from a TypeScript module
+   --> https://jsr.io/@scope/a/1.0.0/a.js
+    = hint: add a type declaration (d.ts) for the JavaScript module, or rewrite it to TypeScript
+
+    info: JavaScript files with no corresponding declaration require type inference to be type checked
+    info: fast check avoids type inference, so referencing a JavaScript file with no type declarations is not supported
+    docs: https://jsr.io/go/slow-type-unsupported-nested-javascript
+

--- a/tests/specs/graph/fast_check/require.txt
+++ b/tests/specs/graph/fast_check/require.txt
@@ -84,5 +84,13 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  require statements are a CommonJS feature, which are not supported in ES modules
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@0
+  error[unsupported-require]: require statements are a CommonJS feature, which are not supported in ES modules
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:1:1
+    |
+  1 | import test = require("./other.ts");
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    = hint: use an import statement instead
+
+    info: CommonJS features such as require are not supported in ES modules
+    docs: https://jsr.io/go/slow-type-unsupported-require
+

--- a/tests/specs/graph/fast_check/return_inference/multiple_value_return_err.txt
+++ b/tests/specs/graph/fast_check/return_inference/multiple_value_return_err.txt
@@ -66,11 +66,43 @@ export class D {
 }
 
 Fast check file:///mod.ts:
-  missing explicit return type in the public API
-      at file:///mod.ts@13
-  missing explicit return type in the public API
-      at file:///mod.ts@81
-  missing explicit return type in the public API
-      at file:///mod.ts@157
-  missing explicit return type in the public API
-      at file:///mod.ts@225
+  error[missing-explicit-return-type]: missing explicit return type in the public API
+   --> /mod.ts:1:14
+    |
+  1 | export const a = () => {
+    |              ^ this function is missing an explicit return type
+    = hint: add an explicit return type to the function
+
+    info: all functions in the public API must have an explicit return type
+    docs: https://jsr.io/go/slow-type-missing-explicit-return-type
+
+  error[missing-explicit-return-type]: missing explicit return type in the public API
+   --> /mod.ts:6:14
+    |
+  6 | export const b = function() {
+    |              ^ this function is missing an explicit return type
+    = hint: add an explicit return type to the function
+
+    info: all functions in the public API must have an explicit return type
+    docs: https://jsr.io/go/slow-type-missing-explicit-return-type
+
+  error[missing-explicit-return-type]: missing explicit return type in the public API
+    --> /mod.ts:11:17
+     |
+  11 | export function c() {
+     |                 ^ this function is missing an explicit return type
+     = hint: add an explicit return type to the function
+
+    info: all functions in the public API must have an explicit return type
+    docs: https://jsr.io/go/slow-type-missing-explicit-return-type
+
+  error[missing-explicit-return-type]: missing explicit return type in the public API
+    --> /mod.ts:17:3
+     |
+  17 |   d() {
+     |   ^ this function is missing an explicit return type
+     = hint: add an explicit return type to the function
+
+    info: all functions in the public API must have an explicit return type
+    docs: https://jsr.io/go/slow-type-missing-explicit-return-type
+

--- a/tests/specs/graph/fast_check/return_inference/no_return_err.txt
+++ b/tests/specs/graph/fast_check/return_inference/no_return_err.txt
@@ -57,7 +57,27 @@ export const b = function() {
 }
 
 Fast check file:///mod.ts:
-  missing explicit return type in the public API
-      at file:///mod.ts@46
-  missing explicit return type in the public API
-      at file:///mod.ts@84
+  error[missing-explicit-return-type]: missing explicit return type in the public API
+   --> /mod.ts:3:14
+    |
+  3 | export const a = () => {
+    |              ^ this function is missing an explicit return type
+    = hint: add an explicit return type of 'void' or 'never' to the function
+
+    info: all functions in the public API must have an explicit return type
+    info: function expressions without a return statement can have a return type of either 'void' or 'never'
+    info: this function has no return statements, so a return type could not be inferred automatically
+    docs: https://jsr.io/go/slow-type-missing-explicit-return-type
+
+  error[missing-explicit-return-type]: missing explicit return type in the public API
+   --> /mod.ts:7:14
+    |
+  7 | export const b = function() {
+    |              ^ this function is missing an explicit return type
+    = hint: add an explicit return type of 'void' or 'never' to the function
+
+    info: all functions in the public API must have an explicit return type
+    info: function expressions without a return statement can have a return type of either 'void' or 'never'
+    info: this function has no return statements, so a return type could not be inferred automatically
+    docs: https://jsr.io/go/slow-type-missing-explicit-return-type
+

--- a/tests/specs/graph/fast_check/return_inference/value_return_err.txt
+++ b/tests/specs/graph/fast_check/return_inference/value_return_err.txt
@@ -60,11 +60,43 @@ export class D {
 }
 
 Fast check file:///mod.ts:
-  missing explicit return type in the public API
-      at file:///mod.ts@13
-  missing explicit return type in the public API
-      at file:///mod.ts@53
-  missing explicit return type in the public API
-      at file:///mod.ts@101
-  missing explicit return type in the public API
-      at file:///mod.ts@141
+  error[missing-explicit-return-type]: missing explicit return type in the public API
+   --> /mod.ts:1:14
+    |
+  1 | export const a = () => {
+    |              ^ this function is missing an explicit return type
+    = hint: add an explicit return type to the function
+
+    info: all functions in the public API must have an explicit return type
+    docs: https://jsr.io/go/slow-type-missing-explicit-return-type
+
+  error[missing-explicit-return-type]: missing explicit return type in the public API
+   --> /mod.ts:5:14
+    |
+  5 | export const b = function() {
+    |              ^ this function is missing an explicit return type
+    = hint: add an explicit return type to the function
+
+    info: all functions in the public API must have an explicit return type
+    docs: https://jsr.io/go/slow-type-missing-explicit-return-type
+
+  error[missing-explicit-return-type]: missing explicit return type in the public API
+   --> /mod.ts:9:17
+    |
+  9 | export function c() {
+    |                 ^ this function is missing an explicit return type
+    = hint: add an explicit return type to the function
+
+    info: all functions in the public API must have an explicit return type
+    docs: https://jsr.io/go/slow-type-missing-explicit-return-type
+
+  error[missing-explicit-return-type]: missing explicit return type in the public API
+    --> /mod.ts:14:3
+     |
+  14 |   d() {
+     |   ^ this function is missing an explicit return type
+     = hint: add an explicit return type to the function
+
+    info: all functions in the public API must have an explicit return type
+    docs: https://jsr.io/go/slow-type-missing-explicit-return-type
+

--- a/tests/specs/graph/fast_check/ts_namespace_export.txt
+++ b/tests/specs/graph/fast_check/ts_namespace_export.txt
@@ -58,5 +58,13 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  found namespace export, which is a global augmentation, which are not unsupported
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@17
+  error[unsupported-ts-namespace-export]: found namespace export, which is a global augmentation, which are not unsupported
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:3:1
+    |
+  3 | export as namespace test;
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^
+    = hint: remove the namespace export
+
+    info: namespace exports are not supported because they can modify the types of a module from outside of that module
+    docs: https://jsr.io/go/slow-type-unsupported-ts-namespace-export
+

--- a/tests/specs/graph/fast_check/unsupported_ambient_decl.txt
+++ b/tests/specs/graph/fast_check/unsupported_ambient_decl.txt
@@ -58,5 +58,13 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  found an ambient module, which is a global augmentation, which are not unsupported
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@15
+  error[unsupported-ambient-module]: found an ambient module, which is a global augmentation, which are not unsupported
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:1:16
+    |
+  1 | declare module "test" {
+    |                ^^^^^^
+    = hint: remove the ambient module declaration
+
+    info: ambient modules are not supported because they can modify the types of a module from outside of that module
+    docs: https://jsr.io/go/slow-type-unsupported-ambient-module
+

--- a/tests/specs/graph/fast_check/unsupported_default_export_expr.txt
+++ b/tests/specs/graph/fast_check/unsupported_default_export_expr.txt
@@ -60,5 +60,17 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  default export expression was too complex
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@16
+  error[unsupported-default-export-expr]: default export expression was too complex
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:3:1
+    |
+  3 | export default {
+    | ^^^^^^^^^^^^^^^^
+  4 |   test: new Class(),
+    | ^^^^^^^^^^^^^^^^^^^^
+  5 | };
+    | ^^
+    = hint: add an 'as' clause with an explicit type after the expression, or extract to a variable
+
+    info: fast check was unable to infer the type of the default export expression
+    docs: https://jsr.io/go/slow-type-unsupported-default-export-expr
+

--- a/tests/specs/graph/fast_check/unsupported_destructuring.txt
+++ b/tests/specs/graph/fast_check/unsupported_destructuring.txt
@@ -61,5 +61,13 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  found destructuring, which is not supported in the public API
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@113
+  error[unsupported-destructuring]: found destructuring, which is not supported in the public API
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:6:14
+    |
+  6 | export const { a, b }: Other = other;
+    |              ^^^^^^^^
+    = hint: separate each destructured symbol into its own export statement
+
+    info: destructuring can not be inferred by fast check
+    docs: https://jsr.io/go/slow-type-unsupported-destructuring
+

--- a/tests/specs/graph/fast_check/unsupported_private_member_ref.txt
+++ b/tests/specs/graph/fast_check/unsupported_private_member_ref.txt
@@ -59,5 +59,14 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  public API member (MyClass.prototype.prop) is referencing or transitively referencing a class private member (MyClass.prototype.myPrivateMember)
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@76
+  error[unsupported-private-member-reference]: public API member (MyClass.prototype.prop) is referencing or transitively referencing a class private member (MyClass.prototype.myPrivateMember)
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:3:3
+    |
+  3 |   private myPrivateMember!: string;
+    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this is the reference
+    = hint: extract the type of the private member to a type alias and reference the type alias instead
+
+    info: private members can not be referenced from public API members
+    info: this is because fast check removes private members from the types
+    docs: https://jsr.io/go/slow-type-unsupported-private-member-reference
+

--- a/tests/specs/graph/fast_check/unsupported_using_public_api.txt
+++ b/tests/specs/graph/fast_check/unsupported_using_public_api.txt
@@ -58,5 +58,14 @@ import 'jsr:@scope/a'
 }
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
-  using declarations are not supproted in the public API
-      at https://jsr.io/@scope/a/1.0.0/mod.ts@6
+  error[unsupported-using]: using declarations are not supproted in the public API
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:1:7
+    |
+  1 | using A = test;
+    |       ^^^^^^^^
+    = hint: use 'const' instead of 'using'
+
+    info: using declarations have unclear semantics in the public API
+    info: they are thus not supported in the public API
+    docs: https://jsr.io/go/slow-type-unsupported-using
+

--- a/tests/specs_test.rs
+++ b/tests/specs_test.rs
@@ -179,8 +179,7 @@ fn run_graph_test(test: &CollectedTest) {
       deno_graph::FastCheckTypeModuleSlot::Error(diagnostics) => {
         let mut printed_diagnostics = "".to_owned();
         for diagnostic in diagnostics {
-          write!(&mut printed_diagnostics, "{}", diagnostic.display())
-            .unwrap();
+          write!(&mut printed_diagnostics, "{}", diagnostic.display()).unwrap();
         }
         output_text.push_str(&indent(&printed_diagnostics));
       }

--- a/tests/specs_test.rs
+++ b/tests/specs_test.rs
@@ -4,7 +4,9 @@ use std::collections::BTreeMap;
 use std::panic::AssertUnwindSafe;
 
 use std::collections::HashMap;
+use std::fmt::Write;
 
+use deno_ast::diagnostics::Diagnostic;
 use deno_ast::emit;
 use deno_ast::EmitOptions;
 use deno_ast::EmittedSource;
@@ -37,6 +39,9 @@ use crate::helpers::TestBuilder;
 mod helpers;
 
 fn main() {
+  // Disable colors so that deno_ast diagnostics do not contain escape sequences.
+  std::env::set_var("NO_COLOR", "true");
+
   collect_and_run_tests(
     CollectOptions {
       base: "tests/specs".into(),
@@ -172,17 +177,12 @@ fn run_graph_test(test: &CollectedTest) {
         }
       }
       deno_graph::FastCheckTypeModuleSlot::Error(diagnostics) => {
-        let message = diagnostics
-          .iter()
-          .map(|d| match d.range() {
-            Some(range) => {
-              format!("{}\n    at {}@{}", d, range.specifier, range.range.start)
-            }
-            None => format!("{}\n    at {}", d, d.specifier()),
-          })
-          .collect::<Vec<_>>()
-          .join("\n");
-        output_text.push_str(&indent(&message));
+        let mut printed_diagnostics = "".to_owned();
+        for diagnostic in diagnostics {
+          write!(&mut printed_diagnostics, "{}", diagnostic.display())
+            .unwrap();
+        }
+        output_text.push_str(&indent(&printed_diagnostics));
       }
     }
   }


### PR DESCRIPTION
This allows us to ensure the accuracy of the printed diagnostics does not regress.
