### PR TITLE
refactor: use an `IndexSet` for the graph roots

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1684,7 +1684,7 @@ impl ModuleGraph {
 
     let mut new_graph = ModuleGraph::new(self.graph_kind);
     let entries = self.walk(
-      roots.iter().map(|r| *r),
+      roots.iter().copied(),
       WalkOptions {
         follow_dynamic: true,
         follow_type_only: true,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -53,6 +53,7 @@ use futures::stream::FuturesUnordered;
 use futures::stream::StreamExt;
 use futures::FutureExt;
 use indexmap::IndexMap;
+use indexmap::IndexSet;
 use serde::ser::SerializeSeq;
 use serde::ser::SerializeStruct;
 use serde::Deserialize;
@@ -62,7 +63,6 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
-use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
@@ -1543,7 +1543,7 @@ impl<'a> Iterator for ModuleGraphErrorIterator<'a> {
 pub struct ModuleGraph {
   #[serde(skip_serializing)]
   graph_kind: GraphKind,
-  pub roots: BTreeSet<ModuleSpecifier>,
+  pub roots: IndexSet<ModuleSpecifier>,
   #[serde(rename = "modules")]
   #[serde(serialize_with = "serialize_module_slots")]
   pub(crate) module_slots: BTreeMap<ModuleSpecifier, ModuleSlot>,
@@ -1676,8 +1676,8 @@ impl ModuleGraph {
 
   /// Creates a new cloned module graph from the provided roots.
   pub fn segment(&self, roots: &[ModuleSpecifier]) -> Self {
-    let roots = roots.iter().collect::<BTreeSet<_>>();
-    if roots.iter().all(|r| self.roots.contains(r)) {
+    let roots = roots.iter().collect::<IndexSet<_>>();
+    if roots.iter().all(|r| self.roots.contains(*r)) {
       // perf - do a straight clone since the roots are the same
       return self.clone();
     }
@@ -3253,7 +3253,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
     let provided_imports = imports;
     let roots = provided_roots
       .iter()
-      .filter(|r| !self.graph.roots.contains(r))
+      .filter(|r| !self.graph.roots.contains(*r))
       .cloned()
       .collect::<Vec<_>>();
     let imports = provided_imports

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -62,6 +62,7 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
@@ -1202,7 +1203,7 @@ pub struct ModuleEntryIterator<'a> {
 impl<'a> ModuleEntryIterator<'a> {
   fn new(
     graph: &'a ModuleGraph,
-    roots: &'a [ModuleSpecifier],
+    roots: impl Iterator<Item = &'a ModuleSpecifier>,
     options: WalkOptions,
   ) -> Self {
     let mut seen =
@@ -1542,7 +1543,7 @@ impl<'a> Iterator for ModuleGraphErrorIterator<'a> {
 pub struct ModuleGraph {
   #[serde(skip_serializing)]
   graph_kind: GraphKind,
-  pub roots: Vec<ModuleSpecifier>,
+  pub roots: BTreeSet<ModuleSpecifier>,
   #[serde(rename = "modules")]
   #[serde(serialize_with = "serialize_module_slots")]
   pub(crate) module_slots: BTreeMap<ModuleSpecifier, ModuleSlot>,
@@ -1675,14 +1676,15 @@ impl ModuleGraph {
 
   /// Creates a new cloned module graph from the provided roots.
   pub fn segment(&self, roots: &[ModuleSpecifier]) -> Self {
-    if roots == self.roots {
+    let roots = roots.iter().collect::<BTreeSet<_>>();
+    if roots.iter().all(|r| self.roots.contains(r)) {
       // perf - do a straight clone since the roots are the same
       return self.clone();
     }
 
     let mut new_graph = ModuleGraph::new(self.graph_kind);
     let entries = self.walk(
-      roots,
+      roots.iter().map(|r| *r),
       WalkOptions {
         follow_dynamic: true,
         follow_type_only: true,
@@ -1723,7 +1725,7 @@ impl ModuleGraph {
   /// Iterates over all the module entries in the module graph searching from the provided roots.
   pub fn walk<'a>(
     &'a self,
-    roots: &'a [ModuleSpecifier],
+    roots: impl Iterator<Item = &'a ModuleSpecifier>,
     options: WalkOptions,
   ) -> ModuleEntryIterator<'a> {
     ModuleEntryIterator::new(self, roots, options)
@@ -1945,7 +1947,7 @@ impl ModuleGraph {
   pub fn valid(&self) -> Result<(), ModuleGraphError> {
     self
       .walk(
-        &self.roots,
+        self.roots.iter(),
         WalkOptions {
           check_js: true,
           follow_type_only: false,
@@ -5436,7 +5438,7 @@ mod tests {
     // should not follow the dynamic import error when walking and not following
     let error_count = graph
       .walk(
-        &roots,
+        roots.iter(),
         WalkOptions {
           follow_dynamic: false,
           follow_type_only: true,
@@ -5451,7 +5453,7 @@ mod tests {
     // should return as dynamic import missing when walking
     let errors = graph
       .walk(
-        &roots,
+        roots.iter(),
         WalkOptions {
           follow_dynamic: true,
           follow_type_only: true,
@@ -5589,7 +5591,7 @@ mod tests {
     assert_eq!(graph.specifiers_count(), 4);
     let errors = graph
       .walk(
-        &roots,
+        roots.iter(),
         WalkOptions {
           check_js: true,
           follow_dynamic: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4074,7 +4074,7 @@ export function a(a: A): B {
     assert!(graph.valid().is_ok());
 
     // all true
-    let roots = vec![root.clone()];
+    let roots = [root.clone()];
     let result = graph.walk(
       roots.iter(),
       WalkOptions {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,7 @@ mod tests {
 
   use super::*;
   use indexmap::IndexMap;
+  use indexmap::IndexSet;
   use pretty_assertions::assert_eq;
   use serde_json::json;
   use source::tests::MockResolver;
@@ -195,7 +196,6 @@ mod tests {
   use source::Source;
   use std::cell::RefCell;
   use std::collections::BTreeMap;
-  use std::collections::BTreeSet;
 
   type Sources<'a> = Vec<(&'a str, Source<&'a str>)>;
 
@@ -236,7 +236,7 @@ mod tests {
       .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     assert_eq!(graph.module_slots.len(), 2);
-    assert_eq!(graph.roots, BTreeSet::from([root_specifier.clone()]));
+    assert_eq!(graph.roots, IndexSet::from([root_specifier.clone()]));
     assert!(graph.contains(&root_specifier));
     assert!(
       !graph.contains(&ModuleSpecifier::parse("file:///a/test03.ts").unwrap())
@@ -304,7 +304,7 @@ mod tests {
       ],
       vec![],
     );
-    let roots = BTreeSet::from([
+    let roots = IndexSet::from([
       ModuleSpecifier::parse("file:///a/test01.ts").unwrap(),
       ModuleSpecifier::parse("https://example.com/a.ts").unwrap(),
     ]);
@@ -383,13 +383,13 @@ mod tests {
       .build(vec![first_root.clone()], &loader, Default::default())
       .await;
     assert_eq!(graph.module_slots.len(), 4);
-    assert_eq!(graph.roots, BTreeSet::from([first_root.clone()]));
+    assert_eq!(graph.roots, IndexSet::from([first_root.clone()]));
 
     // now build with the second root
     graph
       .build(vec![second_root.clone()], &loader, Default::default())
       .await;
-    let mut roots = BTreeSet::from([first_root, second_root]);
+    let mut roots = IndexSet::from([first_root, second_root]);
     assert_eq!(graph.module_slots.len(), 5);
     assert_eq!(graph.roots, roots);
     assert!(
@@ -1011,7 +1011,7 @@ console.log(a);
       .build(vec![root_specifier.clone()], &loader, Default::default())
       .await;
     assert_eq!(graph.module_slots.len(), 1);
-    assert_eq!(graph.roots, BTreeSet::from([root_specifier.clone()]));
+    assert_eq!(graph.roots, IndexSet::from([root_specifier.clone()]));
     let module = graph
       .module_slots
       .get(&root_specifier)
@@ -1744,7 +1744,7 @@ export function a(a) {
       .await;
     assert_eq!(
       graph.roots,
-      BTreeSet::from(
+      IndexSet::from(
         [ModuleSpecifier::parse("https://example.com/a").unwrap()]
       ),
     );
@@ -1809,7 +1809,7 @@ export function a(a) {
       .await;
     assert_eq!(
       graph.roots,
-      BTreeSet::from(
+      IndexSet::from(
         [ModuleSpecifier::parse("https://example.com/a").unwrap()]
       ),
     );
@@ -3930,7 +3930,7 @@ export function a(a: A): B {
     let example_a_url =
       ModuleSpecifier::parse("https://example.com/a.ts").unwrap();
     let graph = graph.segment(&[example_a_url.clone()]);
-    assert_eq!(graph.roots, BTreeSet::from([example_a_url]));
+    assert_eq!(graph.roots, IndexSet::from([example_a_url]));
     // should get the redirect
     assert_eq!(
       graph.redirects,
@@ -4579,7 +4579,7 @@ export function a(a: A): B {
       )
       .await;
     assert_eq!(graph.module_slots.len(), 2);
-    assert_eq!(graph.roots, BTreeSet::from([root_specifier.clone()]));
+    assert_eq!(graph.roots, IndexSet::from([root_specifier.clone()]));
     assert!(graph.contains(&root_specifier));
     let module = graph
       .module_slots


### PR DESCRIPTION
Mainly 1, but rarely 2:

1. This better represents the data because there can't be duplicates.
2. It will make us more performant if someone has hundreds of thousands of dynamic imports (which is a secenario I never benchmarked tbh).

Used an `IndexSet` instead of `BTreeSet` because knowing the first specifier is sometimes useful.