### PR TITLE
feat: teach the module graph about jsr modules

### DIFF
--- a/src/fast_check/range_finder.rs
+++ b/src/fast_check/range_finder.rs
@@ -1240,7 +1240,8 @@ fn is_module_typed(module: &crate::Module) -> bool {
       m.media_type.is_typed() || m.maybe_types_dependency.is_some()
     }
     crate::Module::Json(_) => true,
-    crate::Module::Npm(_)
+    crate::Module::Jsr(_)
+    | crate::Module::Npm(_)
     | crate::Module::Node(_)
     | crate::Module::External(_) => false,
   }
@@ -1250,6 +1251,7 @@ fn is_module_external(module: &crate::Module) -> bool {
   match module {
     crate::Module::Js(_) | crate::Module::Json(_) => false,
     crate::Module::External(_)
+    | crate::Module::Jsr(_)
     | crate::Module::Node(_)
     | crate::Module::Npm(_) => true,
   }

--- a/src/symbols/analyzer.rs
+++ b/src/symbols/analyzer.rs
@@ -101,7 +101,8 @@ impl<'a> RootSymbol<'a> {
       crate::Module::Json(json_module) => {
         Some(self.analyze_json_module(json_module))
       }
-      crate::Module::Npm(_)
+      crate::Module::Jsr(_)
+      | crate::Module::Npm(_)
       | crate::Module::Node(_)
       | crate::Module::External(_) => None,
     }


### PR DESCRIPTION
In order for us to map jsr modules to other NPM/external packages we need to teach the module graph about JsrModules.

This is a requirement in order to merge https://github.com/denoland/dnt/pull/411