### PR TITLE
fix: resolve jsxImportSource with types mode in absence of jsxImportSourceTypes

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2486,14 +2486,7 @@ pub(crate) fn parse_js_module_from_module_info(
           if types_resolution.maybe_specifier()
             != dep.maybe_code.maybe_specifier()
           {
-            dep.maybe_type = resolve(
-              &specifier_text,
-              range.clone(),
-              ResolutionMode::Types,
-              jsr_url_provider,
-              maybe_resolver,
-              maybe_npm_resolver,
-            );
+            dep.maybe_type = types_resolution;
           }
         }
       }


### PR DESCRIPTION
When there is a `jsxImportSource` and no `jsxImportSourceTypes`, we need to try and resolve the same specifier with `ResolutionMode::Types` to see if it resolves somewhere else, as we do with ES deps.

I hit this bug in the LSP specifically when using jsx import source `npm:preact` with byonm.