### PR TITLE
perf: avoid allocations in graph.resolve

### DIFF
--- a/src/fast_check/range_finder.rs
+++ b/src/fast_check/range_finder.rs
@@ -671,15 +671,14 @@ impl<'a> PublicRangeFinder<'a> {
               /* prefer types */ true,
             ) {
               // only analyze registry specifiers
-              if let Some(dep_nv) = self
-                .url_converter
-                .registry_package_url_to_nv(&dep_specifier)
+              if let Some(dep_nv) =
+                self.url_converter.registry_package_url_to_nv(dep_specifier)
               {
                 self.add_pending_nv(&dep_nv, pkg_nv);
 
                 self.add_pending_trace(
                   &dep_nv,
-                  &dep_specifier,
+                  dep_specifier,
                   ImportedExports::star(),
                 );
               }
@@ -731,7 +730,7 @@ impl<'a> PublicRangeFinder<'a> {
                 /* prefer types */ true,
               ) {
                 if let Some(module_info) =
-                  self.root_symbol.module_from_specifier(&dep_specifier)
+                  self.root_symbol.module_from_specifier(dep_specifier)
                 {
                   let module_exports = module_info.exports(self.root_symbol);
 
@@ -864,13 +863,13 @@ impl<'a> PublicRangeFinder<'a> {
                   /* prefer types */ true,
                 ) {
                   if let Some(dep_nv) =
-                    self.url_converter.registry_package_url_to_nv(&specifier)
+                    self.url_converter.registry_package_url_to_nv(specifier)
                   {
                     if dep_nv == *pkg_nv {
                       // just add this specifier
                       self.add_pending_trace(
                         &dep_nv,
-                        &specifier,
+                        specifier,
                         ImportedExports::from_file_dep_name(&file_dep.name),
                       );
                     } else {
@@ -947,13 +946,13 @@ impl<'a> PublicRangeFinder<'a> {
                         ) {
                           if let Some(dep_nv) = self
                             .url_converter
-                            .registry_package_url_to_nv(&specifier)
+                            .registry_package_url_to_nv(specifier)
                           {
                             if dep_nv == *pkg_nv {
                               // just add this specifier
                               self.add_pending_trace(
                                 &dep_nv,
-                                &specifier,
+                                specifier,
                                 if parts.is_empty() {
                                   ImportedExports::star_with_default()
                                 } else {
@@ -1048,7 +1047,7 @@ impl<'a> PublicRangeFinder<'a> {
                   /* prefer types */ true,
                 ) {
                   if let Some(dep_nv) =
-                    self.url_converter.registry_package_url_to_nv(&specifier)
+                    self.url_converter.registry_package_url_to_nv(specifier)
                   {
                     if dep_nv == *pkg_nv {
                       let named_exports = match &file_dep.name {
@@ -1066,11 +1065,7 @@ impl<'a> PublicRangeFinder<'a> {
                         }
                       };
                       // just add this specifier
-                      self.add_pending_trace(
-                        &dep_nv,
-                        &specifier,
-                        named_exports,
-                      );
+                      self.add_pending_trace(&dep_nv, specifier, named_exports);
                     } else {
                       // need to analyze the whole package
                       self.add_pending_nv(&dep_nv, pkg_nv);

--- a/src/fast_check/transform.rs
+++ b/src/fast_check/transform.rs
@@ -392,7 +392,7 @@ impl<'a> FastCheckTransformer<'a> {
     else {
       return;
     };
-    if let Some(relative) = self.specifier.make_relative(&resolved_specifier) {
+    if let Some(relative) = self.specifier.make_relative(resolved_specifier) {
       if !relative.starts_with("../") {
         src.value = format!("./{}", relative).into();
       } else {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1777,8 +1777,8 @@ impl ModuleGraph {
   pub fn resolve(&self, specifier: &ModuleSpecifier) -> ModuleSpecifier {
     const MAX_REDIRECTS: usize = 10;
     let mut redirected_specifier = specifier;
-    // only allocate if there's a redirect
     if let Some(specifier) = self.redirects.get(specifier) {
+      // only allocate if there's a redirect
       let mut seen = HashSet::with_capacity(MAX_REDIRECTS);
       seen.insert(redirected_specifier);
       seen.insert(specifier);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -952,6 +952,7 @@ console.log(a);
         false
       ),
       Some(ModuleSpecifier::parse("https://example.com/jsx-runtime").unwrap())
+        .as_ref()
     );
     assert_eq!(
       graph.resolve_dependency(
@@ -962,6 +963,7 @@ console.log(a);
       Some(
         ModuleSpecifier::parse("https://example.com/jsx-runtime.d.ts").unwrap()
       )
+      .as_ref()
     );
     assert_eq!(
       graph
@@ -3950,6 +3952,7 @@ export function a(a: A): B {
         false
       ),
       Some(ModuleSpecifier::parse("https://example.com/jsx-runtime").unwrap())
+        .as_ref()
     );
     assert_eq!(
       graph.resolve_dependency(
@@ -3960,6 +3963,7 @@ export function a(a: A): B {
       Some(
         ModuleSpecifier::parse("https://example.com/jsx-runtime.d.ts").unwrap()
       )
+      .as_ref()
     );
   }
 

--- a/src/symbols/cross_module.rs
+++ b/src/symbols/cross_module.rs
@@ -322,7 +322,7 @@ fn go_to_file_export<'a>(
       referrer_module.specifier(),
       /* prefer types */ true,
     )
-    .and_then(|dep| specifier_to_module(&dep));
+    .and_then(specifier_to_module);
 
   let Some(dep_module) = maybe_dep_module else {
     return vec![DefinitionPathNode::Unresolved(DefinitionUnresolved {
@@ -355,8 +355,7 @@ fn go_to_file_export<'a>(
             dep_module.specifier(),
             /* prefer_types */ true,
           );
-          let maybe_module =
-            maybe_specifier.and_then(|s| specifier_to_module(&s));
+          let maybe_module = maybe_specifier.and_then(specifier_to_module);
           let mut visited = HashSet::new();
           if let Some(module) = maybe_module {
             // todo(dsherret): this could be optimized to use an iterator
@@ -452,8 +451,7 @@ pub fn resolve_symbol_dep<'a>(
         module.specifier(),
         /* prefer types */ true,
       );
-      let maybe_module =
-        maybe_dep_specifier.as_ref().and_then(specifier_to_module);
+      let maybe_module = maybe_dep_specifier.and_then(specifier_to_module);
       let Some(module) = maybe_module else {
         return vec![ResolvedSymbolDepEntry::Path(
           DefinitionPathNode::Unresolved(DefinitionUnresolved {
@@ -665,7 +663,7 @@ fn resolve_qualified_name_internal<'a>(
               /* prefer types */ true,
             );
             let specifier_module =
-              maybe_dep_specifier.and_then(|s| specifier_to_module(&s));
+              maybe_dep_specifier.and_then(specifier_to_module);
             if let Some(module) = specifier_module {
               next.extend(resolve_qualified_export_name_internal(
                 graph,
@@ -841,7 +839,7 @@ fn exports_and_re_exports_inner<'a>(
         module.specifier(),
         /* prefer_types */ true,
       );
-      let maybe_module = maybe_specifier.and_then(|s| specifier_to_module(&s));
+      let maybe_module = maybe_specifier.and_then(specifier_to_module);
       if let Some(module) = maybe_module {
         let inner = exports_and_re_exports_inner(
           module_graph,


### PR DESCRIPTION
1. Conditionally allocates the redirect HashSet.
2. Returns a reference from `graph.resolve` instead of cloning.