### PR TITLE
feat: add request destination

### DIFF
--- a/js/deno.json
+++ b/js/deno.json
@@ -1,6 +1,5 @@
 {
   "name": "@deno/graph",
-  "version": "0.0.0",
   "exports": {
     ".": "./mod.ts",
     "./loader": "./loader.ts",

--- a/js/mod.ts
+++ b/js/mod.ts
@@ -19,7 +19,7 @@
  */
 
 import * as wasm from "./deno_graph_wasm.generated.js";
-import { load as defaultLoad } from "./loader.ts";
+import { load as defaultLoad, type RequestDestination } from "./loader.ts";
 import type {
   CacheInfo,
   LoadResponse,
@@ -28,7 +28,11 @@ import type {
   TypesDependency,
 } from "./types.ts";
 
-export { load, withResolvingRedirects } from "./loader.ts";
+export {
+  load,
+  type RequestDestination,
+  withResolvingRedirects,
+} from "./loader.ts";
 export { MediaType } from "./media_type.ts";
 export type {
   CacheInfo,
@@ -45,6 +49,13 @@ const encoder = new TextEncoder();
 // note: keep this in line with deno_cache
 export type CacheSetting = "only" | "use" | "reload";
 
+export interface LoadOptions {
+  destination: RequestDestination;
+  isDynamic: boolean;
+  cacheSetting: CacheSetting;
+  checksum: string | undefined;
+}
+
 export interface CreateGraphOptions {
   /**
    * A callback that is called with the URL string of the resource to be loaded
@@ -59,6 +70,7 @@ export interface CreateGraphOptions {
    */
   load?(
     specifier: string,
+    destination: RequestDestination,
     isDynamic: boolean,
     cacheSetting: CacheSetting,
     checksum: string | undefined,
@@ -154,10 +166,12 @@ export async function createGraph(
         isDynamic: boolean;
         cacheSetting: CacheSetting;
         checksum: string | undefined;
+        destination: RequestDestination;
       },
     ) => {
       const result = await load(
         specifier,
+        options.destination,
         options.isDynamic,
         options.cacheSetting,
         options.checksum,

--- a/js/mod.ts
+++ b/js/mod.ts
@@ -96,7 +96,7 @@ export interface CreateGraphOptions {
   /** An optional callback that will be called with a URL string of the resource
    * to provide additional meta data about the resource to enrich the module
    * graph. */
-  cacheInfo?(specifier: string): CacheInfo;
+  cacheInfo?(specifier: string, destination: RequestDestination): CacheInfo;
   /** An optional callback that allows the default resolution logic of the
    * module graph to be "overridden". This is intended to allow items like an
    * import map to be used with the module graph. The callback takes the string

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -73,6 +73,7 @@ impl Loader for JsLoader {
       is_dynamic: bool,
       cache_setting: &'static str,
       checksum: Option<String>,
+      destination: &'static str,
     }
 
     if specifier.scheme() == "data" {
@@ -85,6 +86,11 @@ impl Loader for JsLoader {
         is_dynamic: options.is_dynamic,
         cache_setting: options.cache_setting.as_js_str(),
         checksum: options.maybe_checksum.map(|c| c.into_string()),
+        destination: match options.destination {
+          // NOTICE: update the JS code when changing this
+          deno_graph::source::RequestDestination::Script => "script",
+          deno_graph::source::RequestDestination::Json => "json",
+        },
       })
       .unwrap();
       let result = self.load.call2(&context, &arg1, &arg2);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -3208,6 +3208,7 @@ impl FillPassMode {
   }
 }
 
+// this is a diagnostic instead of an error in order to silently ignore this in the lsp
 #[derive(Debug, Clone)]
 pub struct BuildDiagnostic {
   pub maybe_range: Option<Range>,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -3787,12 +3787,14 @@ impl<'a, 'graph> Builder<'a, 'graph> {
       if let ModuleSlot::Module(ref mut module) = slot {
         match module {
           Module::Json(module) => {
-            module.maybe_cache_info =
-              self.loader.get_cache_info(&module.specifier);
+            module.maybe_cache_info = self
+              .loader
+              .get_cache_info(&module.specifier, RequestDestination::Json);
           }
           Module::Js(module) => {
-            module.maybe_cache_info =
-              self.loader.get_cache_info(&module.specifier);
+            module.maybe_cache_info = self
+              .loader
+              .get_cache_info(&module.specifier, RequestDestination::Script);
           }
           Module::External(_) | Module::Npm(_) | Module::Node(_) => {}
         }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -234,9 +234,6 @@ pub enum ModuleLoadError {
   Npm(#[from] NpmLoadError),
   #[error("Too many redirects.")]
   TooManyRedirects,
-  // todo(THIS PR): give this an actual name
-  #[error("No. Stop what you're doing.")]
-  StupidShit,
 }
 
 #[derive(Debug, Clone)]

--- a/src/jsr.rs
+++ b/src/jsr.rs
@@ -196,6 +196,7 @@ impl JsrMetadataStore {
         is_dynamic: false,
         cache_setting,
         maybe_checksum: maybe_expected_checksum,
+        destination: crate::source::RequestDestination::Json,
       },
     );
     let fut = spawn(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2305,7 +2305,7 @@ export const foo = 'bar';"#,
   }
 
   #[tokio::test]
-  async fn test_build_graph_mixed_assertions() {
+  async fn test_build_graph_mixed_import_attributes() {
     let loader = setup(
       vec![
         (
@@ -2315,7 +2315,7 @@ export const foo = 'bar';"#,
             maybe_headers: None,
             content: r#"
             import a from "./a.json";
-            import b from "./a.json" assert { type: "json" };
+            import b from "./a.json" with { type: "json" };
             "#,
           },
         ),
@@ -2354,14 +2354,27 @@ export const foo = 'bar';"#,
               {
                 "specifier": "./a.json",
                 "code": {
-                  "specifier": "file:///a/a.json",
+                  "error": "Inconsistent import attribute type.\n  Previous: <none>\n  Current: json",
                   "span": {
                     "start": {
-                      "line": 1,
+                      "line": 2,
                       "character": 26
                     },
                     "end": {
-                      "line": 1,
+                      "line": 2,
+                      "character": 36
+                    }
+                  }
+                },
+                "type": {
+                  "specifier": "file:///a/a.json",
+                  "span": {
+                    "start": {
+                      "line": 2,
+                      "character": 26
+                    },
+                    "end": {
+                      "line": 2,
                       "character": 36
                     }
                   }
@@ -2370,7 +2383,7 @@ export const foo = 'bar';"#,
               }
             ],
             "kind": "esm",
-            "size": 113,
+            "size": 111,
             "mediaType": "TypeScript",
             "specifier": "file:///a/test01.ts"
           }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -251,10 +251,25 @@ impl Locker for HashMapLocker {
   }
 }
 
+/// What the import attribute was for the request.
+///
+/// https://fetch.spec.whatwg.org/#concept-request-destination
+///
+/// Note: deno_graph does not error for the same specifier requested
+/// multiple times with different request destinations. This will
+/// error in the runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub enum RequestDestination {
+  Script,
+  /// Loaders should use an "application/json,*/*;q=0.5" accept header (https://fetch.spec.whatwg.org/#fetching).
+  Json,
+}
+
 #[derive(Debug, Clone)]
 pub struct LoadOptions {
   pub is_dynamic: bool,
   pub cache_setting: CacheSetting,
+  pub destination: RequestDestination,
   /// It is the loader's responsibility to verify the provided checksum if it
   /// exists because in the CLI we only verify the checksum of the source when
   /// it is loaded from the global cache. We don't verify it when loaded from

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -285,7 +285,11 @@ pub trait Loader {
   }
 
   /// An optional method which returns cache info for a module specifier.
-  fn get_cache_info(&self, _specifier: &ModuleSpecifier) -> Option<CacheInfo> {
+  fn get_cache_info(
+    &self,
+    _specifier: &ModuleSpecifier,
+    _destination: RequestDestination,
+  ) -> Option<CacheInfo> {
     None
   }
 
@@ -699,7 +703,11 @@ impl MemoryLoader {
 }
 
 impl Loader for MemoryLoader {
-  fn get_cache_info(&self, specifier: &ModuleSpecifier) -> Option<CacheInfo> {
+  fn get_cache_info(
+    &self,
+    specifier: &ModuleSpecifier,
+    _destination: RequestDestination,
+  ) -> Option<CacheInfo> {
     self.cache_info.get(specifier).cloned()
   }
 

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -254,10 +254,6 @@ impl Locker for HashMapLocker {
 /// What the import attribute was for the request.
 ///
 /// https://fetch.spec.whatwg.org/#concept-request-destination
-///
-/// Note: deno_graph does not error for the same specifier requested
-/// multiple times with different request destinations. This will
-/// error in the runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub enum RequestDestination {
   Script,

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -16,6 +16,7 @@ use deno_graph::source::LoaderChecksum;
 use deno_graph::source::Locker;
 use deno_graph::source::MemoryLoader;
 use deno_graph::source::NpmResolver;
+use deno_graph::source::RequestDestination;
 use deno_graph::FastCheckCache;
 use deno_graph::GraphKind;
 use deno_graph::ModuleGraph;
@@ -36,8 +37,12 @@ pub struct TestLoader {
 }
 
 impl Loader for TestLoader {
-  fn get_cache_info(&self, specifier: &ModuleSpecifier) -> Option<CacheInfo> {
-    self.cache.get_cache_info(specifier)
+  fn get_cache_info(
+    &self,
+    specifier: &ModuleSpecifier,
+    destination: RequestDestination,
+  ) -> Option<CacheInfo> {
+    self.cache.get_cache_info(specifier, destination)
   }
 
   fn load(

--- a/tests/specs/graph/import_attribute_different_code_and_type_import.txt
+++ b/tests/specs/graph/import_attribute_different_code_and_type_import.txt
@@ -1,0 +1,60 @@
+# mod.ts
+import type dataA from "./a.json" with { type: "json" };
+import dataB from "./a.json";
+
+# a.json
+{"a":"b"}
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "asserted",
+      "specifier": "file:///a.json",
+      "size": 10,
+      "mediaType": "Json"
+    },
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "./a.json",
+          "code": {
+            "error": "Inconsistent import attribute type.\n  Previous: json\n  Current: <none>",
+            "span": {
+              "start": {
+                "line": 1,
+                "character": 18
+              },
+              "end": {
+                "line": 1,
+                "character": 28
+              }
+            }
+          },
+          "type": {
+            "specifier": "file:///a.json",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 23
+              },
+              "end": {
+                "line": 0,
+                "character": 33
+              }
+            }
+          },
+          "assertionType": "json"
+        }
+      ],
+      "size": 87,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    }
+  ],
+  "redirects": {}
+}

--- a/tests/specs/graph/import_attribute_different_code_imports.txt
+++ b/tests/specs/graph/import_attribute_different_code_imports.txt
@@ -1,0 +1,60 @@
+# mod.ts
+import dataA from "./a.json" with { type: "json" };
+import dataB from "./a.json";
+
+# a.json
+{"a":"b"}
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "asserted",
+      "specifier": "file:///a.json",
+      "size": 10,
+      "mediaType": "Json"
+    },
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "./a.json",
+          "code": {
+            "error": "Inconsistent import attribute type.\n  Previous: json\n  Current: <none>",
+            "span": {
+              "start": {
+                "line": 1,
+                "character": 18
+              },
+              "end": {
+                "line": 1,
+                "character": 28
+              }
+            }
+          },
+          "type": {
+            "specifier": "file:///a.json",
+            "span": {
+              "start": {
+                "line": 1,
+                "character": 18
+              },
+              "end": {
+                "line": 1,
+                "character": 28
+              }
+            }
+          },
+          "assertionType": "json"
+        }
+      ],
+      "size": 82,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    }
+  ],
+  "redirects": {}
+}


### PR DESCRIPTION
1. Adds a new `RequestDestination` to the load options.
1. Errors for conflicting import attributes in the graph.