### PR TITLE
fix(fast_check/dts): remove initializers in class methods/ctors

### DIFF
--- a/tests/specs/graph/fast_check/class_params_initializers.txt
+++ b/tests/specs/graph/fast_check/class_params_initializers.txt
@@ -1,0 +1,109 @@
+# https://jsr.io/@scope/a/meta.json
+{"versions": { "1.0.0": {} } }
+
+# https://jsr.io/@scope/a/1.0.0_meta.json
+{ "exports": { ".": "./mod.ts" } }
+
+# https://jsr.io/@scope/a/1.0.0/mod.ts
+export class Object {
+  constructor(
+    values: {},
+    {
+      a,
+      b,
+    }: {
+      a?: A;
+      b?: B;
+    } = {},
+  ) {
+  }
+
+  method(
+    values: {},
+    {
+      a,
+      b,
+    }: {
+      a?: A;
+      b?: B;
+    } = {},
+    value = 1,
+  ) {
+  }
+}
+
+# mod.ts
+import 'jsr:@scope/a'
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "jsr:@scope/a",
+          "code": {
+            "specifier": "jsr:@scope/a",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 7
+              },
+              "end": {
+                "line": 0,
+                "character": 21
+              }
+            }
+          }
+        }
+      ],
+      "size": 22,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 259,
+      "mediaType": "TypeScript",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+    }
+  ],
+  "redirects": {
+    "jsr:@scope/a": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+  },
+  "packages": {
+    "@scope/a@*": "@scope/a@1.0.0"
+  }
+}
+
+Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
+  {}
+  export class Object {
+    constructor(values: {
+    }, {}: {
+      a?: A;
+      b?: B;
+    } = {} as never){}
+    method(values: {
+    }, {}: {
+      a?: A;
+      b?: B;
+    } = {} as never, value?: number): void {}
+  }
+  --- DTS ---
+  export declare class Object {
+    constructor(values: {
+    }, {}?: {
+      a?: A;
+      b?: B;
+    });
+    method(values: {
+    }, {}?: {
+      a?: A;
+      b?: B;
+    }, value?: number): void;
+  }


### PR DESCRIPTION
Surprising nobody has reported this before (I guess typescript just ignores these due to people skipping lib check).

Closes #519