### PR TITLE
fix: CachedInfo - remove unused emit and map field

### DIFF
--- a/js/types.ts
+++ b/js/types.ts
@@ -9,9 +9,6 @@ export interface CacheInfo {
    * non `file:` URLs, this is the location of the cached content, otherwise it
    * is the absolute path to the local file. */
   local?: string;
-  /** The string path to where a transpiled version of the source content is
-   * located, if any. */
-  emit?: string;
 }
 
 export interface TypesDependency {

--- a/js/types.ts
+++ b/js/types.ts
@@ -12,9 +12,6 @@ export interface CacheInfo {
   /** The string path to where a transpiled version of the source content is
    * located, if any. */
   emit?: string;
-  /** The string path to where an external source map of the transpiled source
-   * content is located, if any. */
-  map?: string;
 }
 
 export interface TypesDependency {

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -43,9 +43,6 @@ pub struct CacheInfo {
   /// path to the original file, if a remote file, the path to the file in the
   /// cache.
   pub local: Option<PathBuf>,
-  /// If the file has been transpiled, the path to the cached version of the
-  /// transpiled JavaScript.
-  pub emit: Option<PathBuf>,
 }
 
 /// The response that is expected from a loader's `.load()` method.

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -46,9 +46,6 @@ pub struct CacheInfo {
   /// If the file has been transpiled, the path to the cached version of the
   /// transpiled JavaScript.
   pub emit: Option<PathBuf>,
-  /// If the file has been transpiled and there is a source map separate from
-  /// the transpiled JavaScript, the path to this file.
-  pub map: Option<PathBuf>,
 }
 
 /// The response that is expected from a loader's `.load()` method.


### PR DESCRIPTION
Part of https://github.com/denoland/deno/issues/17703

The `map` field has been empty for years now and we don't want the `emit` file to be exposed so it allows us to iterate on making the cache faster. Additionally, it's racy to rely on this information. Instead, people should emit the TS files themselves.