### PR TITLE
fix: disallow cjs modules in deno_graph

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -277,7 +277,7 @@ impl ModuleError {
       Self::UnsupportedMediaType(_, _, maybe_referrer) => {
         maybe_referrer.as_ref()
       }
-      Self::ParseErr(_, _) => None,
+      Self::ParseErr { .. } => None,
       Self::InvalidTypeAssertion { range, .. } => Some(range),
       Self::UnsupportedImportAttributeType { range, .. } => Some(range),
     }
@@ -297,10 +297,10 @@ impl std::error::Error for ModuleError {
   fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
     match self {
       Self::LoadingErr(_, _, err) => Some(err),
-      Self::Missing(_, _)
-      | Self::MissingDynamic(_, _)
-      | Self::ParseErr(_, _)
-      | Self::UnsupportedMediaType(_, _, _)
+      Self::Missing { .. }
+      | Self::MissingDynamic { .. }
+      | Self::ParseErr { .. }
+      | Self::UnsupportedMediaType { .. }
       | Self::InvalidTypeAssertion { .. }
       | Self::UnsupportedImportAttributeType { .. } => None,
     }
@@ -2211,11 +2211,9 @@ pub(crate) async fn parse_module_source_and_info(
   match media_type {
     MediaType::JavaScript
     | MediaType::Mjs
-    | MediaType::Cjs
     | MediaType::Jsx
     | MediaType::TypeScript
     | MediaType::Mts
-    | MediaType::Cts
     | MediaType::Tsx
     | MediaType::Dts
     | MediaType::Dmts
@@ -2242,7 +2240,9 @@ pub(crate) async fn parse_module_source_and_info(
         }
       }
     }
-    MediaType::Json
+    MediaType::Cjs
+    | MediaType::Cts
+    | MediaType::Json
     | MediaType::Wasm
     | MediaType::TsBuildInfo
     | MediaType::SourceMap

--- a/tests/specs/ecosystem/bureaudouble/bureau/0_0_98.test
+++ b/tests/specs/ecosystem/bureaudouble/bureau/0_0_98.test
@@ -11,6 +11,5 @@ bureaudouble/bureau/0.0.98
 
 -- stderr --
 error: Failed resolving types. Relative import path "@types/react" not prefixed with / or ./ or ../
-  hint: If you want to use a JSR or npm package, try running `deno add @types/react`
     at https://jsr.io/@bureaudouble/islet/0.0.43/src/react/use-client.ts:3:16
 

--- a/tests/specs/graph/cjs_errors.txt
+++ b/tests/specs/graph/cjs_errors.txt
@@ -1,0 +1,43 @@
+# mod.ts
+import "./file.cjs";
+
+# file.cjs
+module.exports.test = {};
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "specifier": "file:///file.cjs",
+      "error": "Expected a JavaScript or TypeScript module, but identified a Cjs module. Importing these types of modules is currently not supported.\n  Specifier: file:///file.cjs"
+    },
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "./file.cjs",
+          "code": {
+            "specifier": "file:///file.cjs",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 7
+              },
+              "end": {
+                "line": 0,
+                "character": 19
+              }
+            }
+          }
+        }
+      ],
+      "size": 21,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    }
+  ],
+  "redirects": {}
+}

--- a/tests/specs_test.rs
+++ b/tests/specs_test.rs
@@ -501,7 +501,10 @@ impl SpecFile {
       .specifier
       .strip_prefix("cache:")
       .unwrap_or(&self.specifier);
-    if !specifier.starts_with("http") && !specifier.starts_with("file") {
+    if !specifier.starts_with("http:")
+      && !specifier.starts_with("https:")
+      && !specifier.starts_with("file:")
+    {
       Url::parse(&format!("file:///{}", specifier)).unwrap()
     } else {
       Url::parse(specifier).unwrap()


### PR DESCRIPTION
This disallows cjs modules in deno_graph, but we'll support them in the CLI by changing the loader to mark them as external for file specifiers only.