### PR TITLE
feat: include if root was dynamic in load options

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -3196,6 +3196,7 @@ impl FillPassMode {
 
 struct Builder<'a, 'graph> {
   in_dynamic_branch: bool,
+  was_dynamic_root: bool,
   file_system: &'a dyn FileSystem,
   jsr_url_provider: &'a dyn JsrUrlProvider,
   passthrough_jsr_specifiers: bool,
@@ -3224,6 +3225,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
     };
     let mut builder = Self {
       in_dynamic_branch: options.is_dynamic,
+      was_dynamic_root: options.is_dynamic,
       file_system: options.file_system,
       jsr_url_provider: options.jsr_url_provider,
       passthrough_jsr_specifiers: options.passthrough_jsr_specifiers,
@@ -3906,6 +3908,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
             specifier,
             LoadOptions {
               is_dynamic: self.in_dynamic_branch,
+              was_dynamic_root: self.was_dynamic_root,
               cache_setting: CacheSetting::Only,
               maybe_checksum: Some(checksum.clone()),
             },
@@ -4262,6 +4265,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
     let module_analyzer = self.module_analyzer;
     let jsr_url_provider = self.jsr_url_provider;
     let is_root = self.roots_contain(&requested_specifier);
+    let was_dynamic_root = self.was_dynamic_root;
     let maybe_nv_when_no_version_info = if maybe_version_info.is_none() {
       self
         .jsr_url_provider
@@ -4302,6 +4306,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
           PendingResult<PendingJsrPackageVersionInfoLoadItem>,
         )>,
         is_dynamic: bool,
+        was_dynamic_root: bool,
         loader: &dyn Loader,
         jsr_url_provider: &dyn JsrUrlProvider,
         module_analyzer: &dyn ModuleAnalyzer,
@@ -4343,6 +4348,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
           &load_specifier,
           LoadOptions {
             is_dynamic,
+            was_dynamic_root,
             cache_setting: CacheSetting::Use,
             maybe_checksum: maybe_checksum.clone(),
           },
@@ -4451,6 +4457,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
         &mut loaded_package_via_https_url,
         maybe_version_load_fut,
         is_dynamic,
+        was_dynamic_root,
         loader,
         jsr_url_provider,
         module_analyzer,
@@ -4541,6 +4548,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
               &specifier,
               LoadOptions {
                 is_dynamic: self.in_dynamic_branch,
+                was_dynamic_root: self.was_dynamic_root,
                 cache_setting: CacheSetting::Use,
                 maybe_checksum: Some(checksum.clone()),
               },
@@ -5274,10 +5282,12 @@ mod tests {
 
   #[tokio::test]
   async fn static_dep_of_dynamic_dep_is_dynamic() {
+    #[derive(Default)]
     struct TestLoader {
       loaded_foo: RefCell<bool>,
       loaded_bar: RefCell<bool>,
       loaded_baz: RefCell<bool>,
+      loaded_dynamic_root: RefCell<bool>,
     }
     impl Loader for TestLoader {
       fn load(
@@ -5289,6 +5299,7 @@ mod tests {
         match specifier.as_str() {
           "file:///foo.js" => {
             assert!(!options.is_dynamic);
+            assert!(!options.was_dynamic_root);
             *self.loaded_foo.borrow_mut() = true;
             Box::pin(async move {
               Ok(Some(LoadResponse::Module {
@@ -5300,6 +5311,7 @@ mod tests {
           }
           "file:///bar.js" => {
             assert!(options.is_dynamic);
+            assert!(!options.was_dynamic_root);
             *self.loaded_bar.borrow_mut() = true;
             Box::pin(async move {
               Ok(Some(LoadResponse::Module {
@@ -5311,7 +5323,20 @@ mod tests {
           }
           "file:///baz.js" => {
             assert!(options.is_dynamic);
+            assert!(!options.was_dynamic_root);
             *self.loaded_baz.borrow_mut() = true;
+            Box::pin(async move {
+              Ok(Some(LoadResponse::Module {
+                specifier: specifier.clone(),
+                maybe_headers: None,
+                content: b"console.log('Hello, world!')".to_vec().into(),
+              }))
+            })
+          }
+          "file:///dynamic_root.js" => {
+            assert!(options.is_dynamic);
+            assert!(options.was_dynamic_root);
+            *self.loaded_dynamic_root.borrow_mut() = true;
             Box::pin(async move {
               Ok(Some(LoadResponse::Module {
                 specifier: specifier.clone(),
@@ -5325,11 +5350,7 @@ mod tests {
       }
     }
 
-    let loader = TestLoader {
-      loaded_foo: RefCell::new(false),
-      loaded_bar: RefCell::new(false),
-      loaded_baz: RefCell::new(false),
-    };
+    let loader = TestLoader::default();
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
       .build(
@@ -5341,7 +5362,21 @@ mod tests {
     assert!(*loader.loaded_foo.borrow());
     assert!(*loader.loaded_bar.borrow());
     assert!(*loader.loaded_baz.borrow());
+    assert!(!*loader.loaded_dynamic_root.borrow());
     assert_eq!(graph.specifiers_count(), 3);
+
+    graph
+      .build(
+        vec![Url::parse("file:///dynamic_root.js").unwrap()],
+        &loader,
+        BuildOptions {
+          is_dynamic: true,
+          ..Default::default()
+        },
+      )
+      .await;
+    assert!(*loader.loaded_dynamic_root.borrow());
+    assert_eq!(graph.specifiers_count(), 4);
   }
 
   #[tokio::test]

--- a/src/jsr.rs
+++ b/src/jsr.rs
@@ -194,6 +194,7 @@ impl JsrMetadataStore {
       &specifier,
       LoadOptions {
         is_dynamic: false,
+        was_dynamic_root: false,
         cache_setting,
         maybe_checksum: maybe_expected_checksum,
       },

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -249,6 +249,9 @@ impl Locker for HashMapLocker {
 pub struct LoadOptions {
   pub is_dynamic: bool,
   /// If the root specifier building the graph was in a dynamic branch.
+  ///
+  /// This can be useful for telling if a dynamic load is statically analyzable
+  /// where `is_dynamic` is `true`` and `was_dynamic_root` is `false`.
   pub was_dynamic_root: bool,
   pub cache_setting: CacheSetting,
   /// It is the loader's responsibility to verify the provided checksum if it

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -248,6 +248,8 @@ impl Locker for HashMapLocker {
 #[derive(Debug, Clone)]
 pub struct LoadOptions {
   pub is_dynamic: bool,
+  /// If the root specifier building the graph was in a dynamic branch.
+  pub was_dynamic_root: bool,
   pub cache_setting: CacheSetting,
   /// It is the loader's responsibility to verify the provided checksum if it
   /// exists because in the CLI we only verify the checksum of the source when


### PR DESCRIPTION
This can be used to tell if a dynamic import was statically analyzable in the CLI.