### PR TITLE
feat: provide full import statement range

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -123,6 +123,8 @@ pub struct StaticDependencyDescriptor {
   pub specifier: String,
   /// The range of the specifier.
   pub specifier_range: PositionRange,
+  /// The range of the import statement.
+  pub range: PositionRange,
   /// Import attributes for this dependency.
   #[serde(skip_serializing_if = "ImportAttributes::is_none", default)]
   pub import_attributes: ImportAttributes,
@@ -172,6 +174,7 @@ pub struct DynamicDependencyDescriptor {
   pub argument: DynamicArgument,
   /// The range of the argument.
   pub argument_range: PositionRange,
+  pub range: PositionRange,
   /// Import attributes for this dependency.
   #[serde(skip_serializing_if = "ImportAttributes::is_none", default)]
   pub import_attributes: ImportAttributes,
@@ -375,6 +378,16 @@ mod test {
               character: 4,
             },
           },
+          range: PositionRange {
+            start: Position {
+              line: 1,
+              character: 0,
+            },
+            end: Position {
+              line: 3,
+              character: 5,
+            },
+          },
           import_attributes: ImportAttributes::None,
         }
         .into(),
@@ -382,6 +395,10 @@ mod test {
           types_specifier: None,
           argument: DynamicArgument::String("./test2".to_string()),
           argument_range: PositionRange {
+            start: Position::zeroed(),
+            end: Position::zeroed(),
+          },
+          range: PositionRange {
             start: Position::zeroed(),
             end: Position::zeroed(),
           },
@@ -414,10 +431,12 @@ mod test {
           },
           "specifier": "./test",
           "specifierRange": [[1, 2], [3, 4]],
+          "range": [[1, 0], [3, 5]],
         }, {
           "type": "dynamic",
           "argument": "./test2",
           "argumentRange": [[0, 0], [0, 0]],
+          "range": [[0, 0], [0, 0]],
           "importAttributes": {
             "known": {
               "key": null,
@@ -596,6 +615,10 @@ mod test {
         start: Position::zeroed(),
         end: Position::zeroed(),
       },
+      range: PositionRange {
+        start: Position::zeroed(),
+        end: Position::zeroed(),
+      },
       import_attributes: ImportAttributes::Unknown,
     });
     run_serialization_test(
@@ -609,6 +632,7 @@ mod test {
         },
         "specifier": "./test",
         "specifierRange": [[0, 0], [0, 0]],
+        "range": [[0, 0], [0, 0]],
         "importAttributes": "unknown",
       }),
     );
@@ -630,6 +654,10 @@ mod test {
           start: Position::zeroed(),
           end: Position::zeroed(),
         },
+        range: PositionRange {
+          start: Position::zeroed(),
+          end: Position::zeroed(),
+        },
         import_attributes: ImportAttributes::Unknown,
       }),
       json!({
@@ -639,6 +667,7 @@ mod test {
           "range": [[0, 0], [0, 0]],
         },
         "argumentRange": [[0, 0], [0, 0]],
+        "range": [[0, 0], [0, 0]],
         "importAttributes": "unknown",
       }),
     );
@@ -651,12 +680,17 @@ mod test {
           start: Position::zeroed(),
           end: Position::zeroed(),
         },
+        range: PositionRange {
+          start: Position::zeroed(),
+          end: Position::zeroed(),
+        },
         import_attributes: ImportAttributes::Unknown,
       }),
       json!({
         "type": "dynamic",
         "argument": "test",
         "argumentRange": [[0, 0], [0, 0]],
+        "range": [[0, 0], [0, 0]],
         "importAttributes": "unknown",
       }),
     );
@@ -728,6 +762,16 @@ mod test {
               character: 4,
             },
           },
+          range: PositionRange {
+            start: Position {
+              line: 1,
+              character: 0,
+            },
+            end: Position {
+              line: 3,
+              character: 5,
+            },
+          },
           types_specifier: Some(SpecifierWithRange {
             text: "./a.d.ts".to_string(),
             range: PositionRange {
@@ -756,6 +800,7 @@ mod test {
         "kind": "import",
         "specifier": "./a.js",
         "specifierRange": [[1, 2], [3, 4]],
+        "range": [[1, 0], [3, 5]],
         "leadingComments": [{
           "text": " @deno-types=\"./a.d.ts\"",
           "range": [[0, 0], [0, 25]],
@@ -782,6 +827,16 @@ mod test {
               character: 4,
             },
           },
+          range: PositionRange {
+            start: Position {
+              line: 1,
+              character: 0,
+            },
+            end: Position {
+              line: 3,
+              character: 5,
+            },
+          },
           types_specifier: None,
           import_attributes: ImportAttributes::None,
         },
@@ -797,7 +852,8 @@ mod test {
         "type": "static",
         "kind": "import",
         "specifier": "./a.js",
-        "specifierRange": [[1, 2], [3, 4]]
+        "specifierRange": [[1, 2], [3, 4]],
+        "range": [[1, 0], [3, 5]],
       }]
     });
     run_v1_deserialization_test(json, &expected);

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -462,6 +462,7 @@ fn analyze_dependencies(
             d.specifier_range,
             text_info,
           ),
+          range: PositionRange::from_source_range(d.range, text_info),
           import_attributes: d.import_attributes,
         })
       }
@@ -498,6 +499,7 @@ fn analyze_dependencies(
             d.argument_range,
             text_info,
           ),
+          range: PositionRange::from_source_range(d.range, text_info),
           import_attributes: d.import_attributes,
         })
       }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3316,11 +3316,16 @@ export const foo = 'bar';"#,
           imports: vec![Import {
             specifier: "./a.js".to_string(),
             kind: ImportKind::Es,
-            range: Range {
+            specifier_range: Range {
               specifier: specifier.clone(),
               start: Position::new(2, 22),
               end: Position::new(2, 30),
             },
+            full_range: Some(Range {
+              specifier: specifier.clone(),
+              start: Position::new(2, 4),
+              end: Position::new(2, 31),
+            }),
             is_dynamic: false,
             attributes: Default::default(),
           }],

--- a/tests/specs/ecosystem/amit/neon_serverless_driver/0_0_3.test
+++ b/tests/specs/ecosystem/amit/neon_serverless_driver/0_0_3.test
@@ -72,8 +72,6 @@ amit/neon-serverless-driver/0.0.3
 -- stdout --
 
 -- stderr --
-error: TS2834 [ERROR]: Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path.
-export { DatabaseError } from "./pg-protocol";
-                              ~~~~~~~~~~~~~~~
+error: Module not found "file://<tmpdir>/pg-protocol".
     at file://<tmpdir>/index.d.ts:1:31
 

--- a/tests/specs/ecosystem/kwhinnery/animals/0_0_14.test
+++ b/tests/specs/ecosystem/kwhinnery/animals/0_0_14.test
@@ -9,9 +9,9 @@ kwhinnery/animals/0.0.14
 
 == FAST CHECK EMIT PASSED ==
 
-<== TYPE CHECK FAILED ==
-<-- stdout --
-<
-<-- stderr --
-<error: Module not found "file://<tmpdir>/dist/animal.js".
-<    at file://<tmpdir>/dist/mod.d.ts:1:15
+== TYPE CHECK FAILED ==
+-- stdout --
+
+-- stderr --
+error: Module not found "file://<tmpdir>/dist/animal.js".
+    at file://<tmpdir>/dist/mod.d.ts:1:15

--- a/tests/specs/ecosystem/kwhinnery/animals/0_0_14.test
+++ b/tests/specs/ecosystem/kwhinnery/animals/0_0_14.test
@@ -9,4 +9,9 @@ kwhinnery/animals/0.0.14
 
 == FAST CHECK EMIT PASSED ==
 
-== TYPE CHECK PASSED ==
+<== TYPE CHECK FAILED ==
+<-- stdout --
+<
+<-- stderr --
+<error: Module not found "file://<tmpdir>/dist/animal.js".
+<    at file://<tmpdir>/dist/mod.d.ts:1:15

--- a/tests/specs/ecosystem/kwhinnery/animals/0_0_15.test
+++ b/tests/specs/ecosystem/kwhinnery/animals/0_0_15.test
@@ -9,9 +9,9 @@ kwhinnery/animals/0.0.15
 
 == FAST CHECK EMIT PASSED ==
 
-<== TYPE CHECK FAILED ==
-<-- stdout --
-<
-<-- stderr --
-<error: Module not found "file://<tmpdir>/dist/animal.js".
-<    at file://<tmpdir>/dist/mod.d.ts:1:15
+== TYPE CHECK FAILED ==
+-- stdout --
+
+-- stderr --
+error: Module not found "file://<tmpdir>/dist/animal.js".
+    at file://<tmpdir>/dist/mod.d.ts:1:15

--- a/tests/specs/ecosystem/kwhinnery/animals/0_0_15.test
+++ b/tests/specs/ecosystem/kwhinnery/animals/0_0_15.test
@@ -9,4 +9,9 @@ kwhinnery/animals/0.0.15
 
 == FAST CHECK EMIT PASSED ==
 
-== TYPE CHECK PASSED ==
+<== TYPE CHECK FAILED ==
+<-- stdout --
+<
+<-- stderr --
+<error: Module not found "file://<tmpdir>/dist/animal.js".
+<    at file://<tmpdir>/dist/mod.d.ts:1:15

--- a/tests/specs/ecosystem/kwhinnery/animals/0_0_16.test
+++ b/tests/specs/ecosystem/kwhinnery/animals/0_0_16.test
@@ -13,20 +13,6 @@ kwhinnery/animals/0.0.16
 -- stdout --
 
 -- stderr --
-error: TS2834 [ERROR]: Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path.
-export * from "./animal";
-              ~~~~~~~~~~
+error: Module not found "file://<tmpdir>/types/animal".
     at file://<tmpdir>/types/mod.d.ts:1:15
-
-TS2834 [ERROR]: Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path.
-export * from "./cat";
-              ~~~~~~~
-    at file://<tmpdir>/types/mod.d.ts:2:15
-
-TS2834 [ERROR]: Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path.
-export * from "./dog";
-              ~~~~~~~
-    at file://<tmpdir>/types/mod.d.ts:3:15
-
-Found 3 errors.
 

--- a/tests/specs/ecosystem/kwhinnery/animals/0_0_17.test
+++ b/tests/specs/ecosystem/kwhinnery/animals/0_0_17.test
@@ -13,20 +13,6 @@ kwhinnery/animals/0.0.17
 -- stdout --
 
 -- stderr --
-error: TS2834 [ERROR]: Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path.
-export * from "./animal";
-              ~~~~~~~~~~
+error: Module not found "file://<tmpdir>/types/animal".
     at file://<tmpdir>/types/mod.d.ts:1:15
-
-TS2834 [ERROR]: Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path.
-export * from "./cat";
-              ~~~~~~~
-    at file://<tmpdir>/types/mod.d.ts:2:15
-
-TS2834 [ERROR]: Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path.
-export * from "./dog";
-              ~~~~~~~
-    at file://<tmpdir>/types/mod.d.ts:3:15
-
-Found 3 errors.
 

--- a/tests/specs/ecosystem/neon/serverless/0_9_0.test
+++ b/tests/specs/ecosystem/neon/serverless/0_9_0.test
@@ -72,8 +72,6 @@ neon/serverless/0.9.0
 -- stdout --
 
 -- stderr --
-error: TS2834 [ERROR]: Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path.
-export { DatabaseError } from "./pg-protocol";
-                              ~~~~~~~~~~~~~~~
+error: Module not found "file://<tmpdir>/pg-protocol".
     at file://<tmpdir>/index.d.ts:1:31
 

--- a/tests/specs/ecosystem/neon/serverless/0_9_2.test
+++ b/tests/specs/ecosystem/neon/serverless/0_9_2.test
@@ -72,8 +72,6 @@ neon/serverless/0.9.2
 -- stdout --
 
 -- stderr --
-error: TS2834 [ERROR]: Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path.
-export { DatabaseError } from "./pg-protocol";
-                              ~~~~~~~~~~~~~~~
+error: Module not found "file://<tmpdir>/pg-protocol".
     at file://<tmpdir>/index.d.ts:1:31
 

--- a/tests/specs/graph/jsr/module_graph_info_1.txt
+++ b/tests/specs/graph/jsr/module_graph_info_1.txt
@@ -16,7 +16,8 @@
           "type": "static",
           "kind": "import",
           "specifier": "./a.ts",
-          "specifierRange": [[5, 6], [7, 8]]
+          "specifierRange": [[5, 6], [7, 8]],
+          "range": [[5, 0], [7, 8]]
       }]
     },
     "/a.ts": {
@@ -24,12 +25,14 @@
           "type": "static",
           "kind": "import",
           "specifier": "./b.ts",
-          "specifierRange": [[13, 14], [15, 16]]
+          "specifierRange": [[13, 14], [15, 16]],
+          "range": [[13, 0], [15, 16]]
       }, {
           "type": "static",
           "kind": "import",
           "specifier": "jsr:@scope/b/export",
-          "specifierRange": [[5, 6], [7, 8]]
+          "specifierRange": [[5, 6], [7, 8]],
+          "range": [[5, 0], [7, 8]]
       }]
     }
   }
@@ -53,7 +56,8 @@
         "type": "static",
         "kind": "import",
         "specifier": "./inner.ts",
-        "specifierRange": [[5, 6], [7, 8]]
+        "specifierRange": [[5, 6], [7, 8]],
+        "range": [[5, 0], [7, 8]]
       }]
     }
   }

--- a/tests/specs/graph/jsr/module_graph_info_1_leading_comments.txt
+++ b/tests/specs/graph/jsr/module_graph_info_1_leading_comments.txt
@@ -20,7 +20,8 @@
             "range": [[0, 0], [0, 25]]
           }],
           "specifier": "./a.js",
-          "specifierRange": [[5, 6], [7, 8]]
+          "specifierRange": [[5, 6], [7, 8]],
+          "range": [[5, 0], [7, 8]]
       }]
     },
     "/a.js": {},

--- a/tests/specs/graph/jsr/module_graph_info_2.txt
+++ b/tests/specs/graph/jsr/module_graph_info_2.txt
@@ -16,7 +16,8 @@
           "type": "static",
           "kind": "import",
           "specifier": "./a.ts",
-          "specifierRange": [[5, 6], [7, 8]]
+          "specifierRange": [[5, 6], [7, 8]],
+          "range": [[5, 0], [7, 8]]
       }]
     },
     "/a.ts": {
@@ -24,12 +25,14 @@
           "type": "static",
           "kind": "import",
           "specifier": "./b.ts",
-          "specifierRange": [[13, 14], [15, 16]]
+          "specifierRange": [[13, 14], [15, 16]],
+          "range": [[13, 0], [15, 16]]
       }, {
           "type": "static",
           "kind": "import",
           "specifier": "jsr:@scope/b/export",
-          "specifierRange": [[5, 6], [7, 8]]
+          "specifierRange": [[5, 6], [7, 8]],
+          "range": [[5, 0], [7, 8]]
       }]
     }
   }
@@ -53,7 +56,8 @@
         "type": "static",
         "kind": "import",
         "specifier": "./inner.ts",
-        "specifierRange": [[5, 6], [7, 8]]
+        "specifierRange": [[5, 6], [7, 8]],
+        "range": [[5, 0], [7, 8]]
       }]
     }
   }

--- a/tests/specs/graph/jsr/module_graph_info_modified_cached_files.txt
+++ b/tests/specs/graph/jsr/module_graph_info_modified_cached_files.txt
@@ -16,7 +16,8 @@
           "type": "static",
           "kind": "import",
           "specifier": "./a.ts",
-          "specifierRange": [[5, 6], [7, 8]]
+          "specifierRange": [[5, 6], [7, 8]],
+          "range": [[5, 0], [7, 8]]
       }]
     },
     "/a.ts": {
@@ -24,12 +25,14 @@
           "type": "static",
           "kind": "import",
           "specifier": "./b.ts",
-          "specifierRange": [[13, 14], [15, 16]]
+          "specifierRange": [[13, 14], [15, 16]],
+          "range": [[13, 0], [15, 16]]
       }, {
           "type": "static",
           "kind": "import",
           "specifier": "jsr:@scope/b",
-          "specifierRange": [[5, 6], [7, 8]]
+          "specifierRange": [[5, 6], [7, 8]],
+          "range": [[5, 0], [7, 8]]
       }]
     },
     "/b.ts": {
@@ -37,7 +40,8 @@
           "type": "static",
           "kind": "import",
           "specifier": "./c.ts",
-          "specifierRange": [[13, 14], [15, 16]]
+          "specifierRange": [[13, 14], [15, 16]],
+          "range": [[13, 0], [15, 16]]
       }]
     },
     "/c.ts": {}
@@ -62,7 +66,8 @@
         "type": "static",
         "kind": "import",
         "specifier": "./inner.ts",
-        "specifierRange": [[5, 6], [7, 8]]
+        "specifierRange": [[5, 6], [7, 8]],
+        "range": [[5, 0], [7, 8]]
       }]
     }
   }

--- a/tests/specs/graph/jsr/same_package_multiple_times.txt
+++ b/tests/specs/graph/jsr/same_package_multiple_times.txt
@@ -16,7 +16,8 @@
           "type": "static",
           "kind": "import",
           "specifier": "jsr:@scope/b@1",
-          "specifierRange": [[5, 6], [7, 8]]
+          "specifierRange": [[5, 6], [7, 8]],
+          "range": [[5, 0], [7, 8]]
       }]
     }
   }


### PR DESCRIPTION
Renames `Import::range` to `Import::specifier_range`, adds `Import::full_range`.

Towards https://github.com/denoland/deno/issues/18884.