### PR TITLE
fix: store resolved root specifiers

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -3903,6 +3903,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
     )
   }
 
+  #[allow(clippy::too_many_arguments)]
   fn load_with_redirect_count(
     &mut self,
     redirect_count: usize,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -62,6 +62,7 @@ use serde::Serializer;
 use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
@@ -3257,7 +3258,7 @@ struct Builder<'a, 'graph> {
   state: PendingState<'a>,
   fill_pass_mode: FillPassMode,
   executor: &'a dyn Executor,
-  resolved_roots: IndexSet<ModuleSpecifier>,
+  resolved_roots: BTreeSet<ModuleSpecifier>,
 }
 
 impl<'a, 'graph> Builder<'a, 'graph> {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -565,7 +565,8 @@ async fn test_json_root() {
       Default::default(),
     )
     .await;
-  for error in graph.module_errors() {
+  let mut errors = graph.module_errors();
+  if let Some(error) = errors.next() {
     panic!("unexpected error: {error}");
   }
 }


### PR DESCRIPTION
Basically carry the "rootness" around until the specifier is fully resolved. Once it's resolved, store the resolved specifier in a separate set for later comparison.

This fixes an issue where we would error on `JSON` roots. Ref https://github.com/denoland/deno/issues/26509