### PR TITLE
fix(node): change resolution mode based on import construct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /npm
+.vs
 .vscode
 js/deno_graph_wasm_bg.wasm
 js/deno_graph_wasm.generated.d.ts

--- a/js/test.ts
+++ b/js/test.ts
@@ -191,6 +191,7 @@ Deno.test({
             {
               "specifier": "./b.js",
               "code": {
+                "mode": "import",
                 "specifier": "file:///a/b.js",
                 "span": {
                   "start": {
@@ -270,6 +271,7 @@ Deno.test({
               "specifier": "./deno.json",
               "code": {
                 "specifier": "file:///a/deno.json",
+                "mode": "import",
                 "span": {
                   "start": {
                     "line": 0,
@@ -365,6 +367,7 @@ Deno.test({
               "specifier": "./b.js",
               "code": {
                 "specifier": "file:///a/b.js",
+                "mode": "import",
                 "span": {
                   "start": {
                     "line": 0,
@@ -461,6 +464,7 @@ Deno.test({
               "specifier": "builtin:fs",
               "code": {
                 "specifier": "builtin:fs",
+                "mode": "import",
                 "span": {
                   "start": {
                     "line": 0,
@@ -477,6 +481,7 @@ Deno.test({
               "specifier": "https://example.com/bundle",
               "code": {
                 "specifier": "https://example.com/bundle",
+                "mode": "import",
                 "span": {
                   "start": {
                     "line": 1,
@@ -553,6 +558,7 @@ Deno.test({
       "dependencies": [{
         "specifier": "./a.ts",
         "code": {
+          "mode": "import",
           "specifier": "file:///a/a.ts",
           "span": {
             "start": { "line": 2, "character": 26 },
@@ -563,6 +569,7 @@ Deno.test({
         "specifier": "./b.ts",
         "code": {
           "specifier": "file:///a/b.ts",
+          "mode": "import",
           "span": {
             "start": { "line": 3, "character": 27 },
             "end": { "line": 3, "character": 35 },
@@ -572,6 +579,7 @@ Deno.test({
         "specifier": "./c.ts",
         "code": {
           "specifier": "file:///a/c.ts",
+          "mode": "import",
           "span": {
             "start": { "line": 4, "character": 26 },
             "end": { "line": 4, "character": 34 },
@@ -581,6 +589,7 @@ Deno.test({
         "specifier": "./d.ts",
         "code": {
           "specifier": "file:///a/d.ts",
+          "mode": "import",
           "span": {
             "start": { "line": 5, "character": 31 },
             "end": { "line": 5, "character": 39 },
@@ -745,6 +754,7 @@ Deno.test({
           "specifier": "./a.json",
           "code": {
             "specifier": "file:///a/a.json",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -762,6 +772,7 @@ Deno.test({
           "specifier": "./b.json",
           "code": {
             "specifier": "file:///a/b.json",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 2,
@@ -916,6 +927,7 @@ Deno.test({
             "specifier": "jsr:@denotest/a",
             "code": {
               "specifier": "jsr:@denotest/a",
+              "mode": "import",
               "span": {
                 "start": {
                   "character": 7,

--- a/js/test.ts
+++ b/js/test.ts
@@ -191,7 +191,7 @@ Deno.test({
             {
               "specifier": "./b.js",
               "code": {
-                "mode": "import",
+                "resolutionMode": "import",
                 "specifier": "file:///a/b.js",
                 "span": {
                   "start": {
@@ -271,7 +271,7 @@ Deno.test({
               "specifier": "./deno.json",
               "code": {
                 "specifier": "file:///a/deno.json",
-                "mode": "import",
+                "resolutionMode": "import",
                 "span": {
                   "start": {
                     "line": 0,
@@ -367,7 +367,7 @@ Deno.test({
               "specifier": "./b.js",
               "code": {
                 "specifier": "file:///a/b.js",
-                "mode": "import",
+                "resolutionMode": "import",
                 "span": {
                   "start": {
                     "line": 0,
@@ -464,7 +464,7 @@ Deno.test({
               "specifier": "builtin:fs",
               "code": {
                 "specifier": "builtin:fs",
-                "mode": "import",
+                "resolutionMode": "import",
                 "span": {
                   "start": {
                     "line": 0,
@@ -481,7 +481,7 @@ Deno.test({
               "specifier": "https://example.com/bundle",
               "code": {
                 "specifier": "https://example.com/bundle",
-                "mode": "import",
+                "resolutionMode": "import",
                 "span": {
                   "start": {
                     "line": 1,
@@ -558,7 +558,7 @@ Deno.test({
       "dependencies": [{
         "specifier": "./a.ts",
         "code": {
-          "mode": "import",
+          "resolutionMode": "import",
           "specifier": "file:///a/a.ts",
           "span": {
             "start": { "line": 2, "character": 26 },
@@ -569,7 +569,7 @@ Deno.test({
         "specifier": "./b.ts",
         "code": {
           "specifier": "file:///a/b.ts",
-          "mode": "import",
+          "resolutionMode": "import",
           "span": {
             "start": { "line": 3, "character": 27 },
             "end": { "line": 3, "character": 35 },
@@ -579,7 +579,7 @@ Deno.test({
         "specifier": "./c.ts",
         "code": {
           "specifier": "file:///a/c.ts",
-          "mode": "import",
+          "resolutionMode": "import",
           "span": {
             "start": { "line": 4, "character": 26 },
             "end": { "line": 4, "character": 34 },
@@ -589,7 +589,7 @@ Deno.test({
         "specifier": "./d.ts",
         "code": {
           "specifier": "file:///a/d.ts",
-          "mode": "import",
+          "resolutionMode": "import",
           "span": {
             "start": { "line": 5, "character": 31 },
             "end": { "line": 5, "character": 39 },
@@ -754,7 +754,7 @@ Deno.test({
           "specifier": "./a.json",
           "code": {
             "specifier": "file:///a/a.json",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -772,7 +772,7 @@ Deno.test({
           "specifier": "./b.json",
           "code": {
             "specifier": "file:///a/b.json",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 2,
@@ -927,7 +927,7 @@ Deno.test({
             "specifier": "jsr:@denotest/a",
             "code": {
               "specifier": "jsr:@denotest/a",
-              "mode": "import",
+              "resolutionMode": "import",
               "span": {
                 "start": {
                   "character": 7,

--- a/js/types.ts
+++ b/js/types.ts
@@ -81,6 +81,7 @@ export interface ResolvedDependency {
    * resolvable in the module graph. If there was an error, `error` will be set
    * and this will be undefined. */
   specifier?: string;
+  mode?: "import" | "require";
   /** Any error encountered when trying to resolved the specifier. If this is
    * defined, `specifier` will be undefined. */
   error?: string;

--- a/js/types.ts
+++ b/js/types.ts
@@ -81,7 +81,8 @@ export interface ResolvedDependency {
    * resolvable in the module graph. If there was an error, `error` will be set
    * and this will be undefined. */
   specifier?: string;
-  mode?: "import" | "require";
+  /** Resolution mode used to resolve the dependency. */
+  resolutionMode?: "import" | "require";
   /** Any error encountered when trying to resolved the specifier. If this is
    * defined, `specifier` will be undefined. */
   error?: string;

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -350,7 +350,7 @@ pub async fn js_parse_module(
 mod tests {
   use super::*;
 
-  use deno_graph::Position;
+  use deno_graph::PositionRange;
   use serde_json::from_value;
   use serde_json::json;
 
@@ -369,8 +369,7 @@ mod tests {
         types: ModuleSpecifier::parse("https://deno.land/x/mod.d.ts").unwrap(),
         source: Some(Range {
           specifier: ModuleSpecifier::parse("file:///package.json").unwrap(),
-          start: Position::zeroed(),
-          end: Position::zeroed(),
+          range: PositionRange::zeroed(),
           mode: None,
         })
       })

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -14,7 +14,7 @@ use deno_graph::source::LoadFuture;
 use deno_graph::source::LoadOptions;
 use deno_graph::source::Loader;
 use deno_graph::source::NullFileSystem;
-use deno_graph::source::ResolutionMode;
+use deno_graph::source::ResolutionKind;
 use deno_graph::source::ResolveError;
 use deno_graph::source::Resolver;
 use deno_graph::source::DEFAULT_JSX_IMPORT_SOURCE_MODULE;
@@ -160,7 +160,7 @@ impl Resolver for JsResolver {
     &self,
     specifier: &str,
     referrer_range: &Range,
-    _mode: ResolutionMode,
+    _kind: ResolutionKind,
   ) -> Result<ModuleSpecifier, ResolveError> {
     if let Some(resolve) = &self.maybe_resolve {
       let this = JsValue::null();
@@ -371,7 +371,7 @@ mod tests {
           specifier: ModuleSpecifier::parse("file:///package.json").unwrap(),
           start: Position::zeroed(),
           end: Position::zeroed(),
-          kind: None,
+          mode: None,
         })
       })
     );

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -371,6 +371,7 @@ mod tests {
           specifier: ModuleSpecifier::parse("file:///package.json").unwrap(),
           start: Position::zeroed(),
           end: Position::zeroed(),
+          kind: None,
         })
       })
     );

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -370,7 +370,7 @@ mod tests {
         source: Some(Range {
           specifier: ModuleSpecifier::parse("file:///package.json").unwrap(),
           range: PositionRange::zeroed(),
-          mode: None,
+          resolution_mode: None,
         })
       })
     );

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -18,7 +18,7 @@ use serde::Serializer;
 
 use crate::ast::DENO_TYPES_RE;
 use crate::graph::Position;
-use crate::source::ResolutionKind;
+use crate::source::ResolutionMode;
 use crate::DefaultModuleAnalyzer;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize)]
@@ -214,10 +214,10 @@ impl TypeScriptTypesResolutionMode {
     }
   }
 
-  pub fn as_resolution_kind(&self) -> ResolutionKind {
+  pub fn as_deno_graph(&self) -> ResolutionMode {
     match self {
-      Self::Require => ResolutionKind::Cjs,
-      Self::Import => ResolutionKind::Esm,
+      Self::Require => ResolutionMode::Require,
+      Self::Import => ResolutionMode::Import,
     }
   }
 }
@@ -227,6 +227,7 @@ impl TypeScriptTypesResolutionMode {
 #[serde(tag = "type")]
 pub enum TypeScriptReference {
   Path(SpecifierWithRange),
+  #[serde(rename_all = "camelCase")]
   Types {
     #[serde(flatten)]
     specifier: SpecifierWithRange,

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -21,9 +21,11 @@ use crate::graph::Position;
 use crate::source::ResolutionMode;
 use crate::DefaultModuleAnalyzer;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Hash)]
 pub struct PositionRange {
+  #[serde(default = "Position::zeroed")]
   pub start: Position,
+  #[serde(default = "Position::zeroed")]
   pub end: Position,
 }
 
@@ -33,6 +35,11 @@ impl PositionRange {
       start: Position::zeroed(),
       end: Position::zeroed(),
     }
+  }
+
+  /// Determines if a given position is within the range.
+  pub fn includes(&self, position: Position) -> bool {
+    (position >= self.start) && (position <= self.end)
   }
 
   pub fn from_source_range(

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -4,12 +4,14 @@ use crate::analyzer::DependencyDescriptor;
 use crate::analyzer::DynamicArgument;
 use crate::analyzer::DynamicDependencyDescriptor;
 use crate::analyzer::DynamicTemplatePart;
+use crate::analyzer::JsDocImportInfo;
 use crate::analyzer::ModuleAnalyzer;
 use crate::analyzer::ModuleInfo;
 use crate::analyzer::PositionRange;
 use crate::analyzer::SpecifierWithRange;
 use crate::analyzer::StaticDependencyDescriptor;
 use crate::analyzer::TypeScriptReference;
+use crate::analyzer::TypeScriptTypesResolutionMode;
 use crate::graph::Position;
 use crate::module_specifier::ModuleSpecifier;
 
@@ -31,10 +33,6 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-/// Matches a JSDoc import type reference (`{import("./example.js")}`
-static JSDOC_DYNAMIC_IMPORT_RE: Lazy<Regex> = Lazy::new(|| {
-  Regex::new(r#"\{[^}]*import\(['"]([^'"]+)['"]\)[^}]*}"#).unwrap()
-});
 /// Matches the `@jsxImportSource` pragma.
 static JSX_IMPORT_SOURCE_RE: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"(?i)^[\s*]*@jsxImportSource\s+(\S+)").unwrap());
@@ -53,6 +51,10 @@ static PATH_REFERENCE_RE: Lazy<Regex> =
 /// a dependency.
 static TYPES_REFERENCE_RE: Lazy<Regex> =
   Lazy::new(|| Regex::new(r#"(?i)\stypes\s*=\s*["']([^"']*)["']"#).unwrap());
+/// Ex. `resolution-mode="require"` in `/// <reference types="pkg" resolution-mode="require" />`
+static RESOLUTION_MODE_RE: Lazy<Regex> = Lazy::new(|| {
+  Regex::new(r#"(?i)\sresolution-mode\s*=\s*["']([^"']*)["']"#).unwrap()
+});
 /// Matches the `@ts-self-types` pragma.
 static TS_SELF_TYPES_RE: Lazy<Regex> = Lazy::new(|| {
   Regex::new(r#"(?i)^\s*@ts-self-types\s*=\s*["']([^"']+)["']"#).unwrap()
@@ -530,15 +532,22 @@ fn analyze_ts_references(
           TYPES_REFERENCE_RE.captures(&comment.text)
         {
           let m = captures.get(1).unwrap();
-          references.push(TypeScriptReference::Types(SpecifierWithRange {
-            text: m.as_str().to_string(),
-            range: comment_source_to_position_range(
-              comment_start,
-              m.range(),
-              text_info,
-              false,
-            ),
-          }));
+          let resolution_mode = RESOLUTION_MODE_RE
+            .captures(&comment.text)
+            .and_then(|m| m.get(1))
+            .and_then(|m| TypeScriptTypesResolutionMode::from_str(m.as_str()));
+          references.push(TypeScriptReference::Types {
+            specifier: SpecifierWithRange {
+              text: m.as_str().to_string(),
+              range: comment_source_to_position_range(
+                comment_start,
+                m.range(),
+                text_info,
+                false,
+              ),
+            },
+            resolution_mode,
+          });
         }
       }
     }
@@ -680,7 +689,7 @@ fn analyze_jsdoc_imports(
   media_type: MediaType,
   text_info: &SourceTextInfo,
   comments: &MultiThreadedComments,
-) -> Vec<SpecifierWithRange> {
+) -> Vec<JsDocImportInfo> {
   // Analyze any JSDoc type imports
   // We only analyze these on JavaScript types of modules, since they are
   // ignored by TypeScript when type checking anyway and really shouldn't be
@@ -697,42 +706,52 @@ fn analyze_jsdoc_imports(
     if comment.kind != CommentKind::Block || !comment.text.starts_with('*') {
       continue;
     }
-    for captures in JSDOC_DYNAMIC_IMPORT_RE.captures_iter(&comment.text) {
-      if let Some(m) = captures.get(1) {
-        deps.push(SpecifierWithRange {
-          text: m.as_str().to_string(),
-          range: comment_source_to_position_range(
-            comment.range().start,
-            m.range(),
-            text_info,
-            false,
-          ),
-        });
-      }
-    }
 
-    for (i, _) in comment.text.match_indices("@import") {
-      if let Ok((_, js_doc)) = parse_jsdoc_import_decl(&comment.text[i..]) {
-        deps.push(SpecifierWithRange {
+    let js_docs = comment
+      .text
+      .match_indices("{")
+      .map(|(i, _)| {
+        parse_jsdoc_dynamic_import(&comment.text[i..])
+          .ok()
+          .map(|(_input, jsdoc)| (i, jsdoc))
+      })
+      .flatten()
+      .chain(
+        comment
+          .text
+          .match_indices("@import")
+          .map(|(i, _)| {
+            parse_jsdoc_import_decl(&comment.text[i..])
+              .ok()
+              .map(|(_input, jsdoc)| (i, jsdoc))
+          })
+          .flatten(),
+      );
+    for (byte_index, js_doc) in js_docs {
+      deps.push(JsDocImportInfo {
+        specifier: SpecifierWithRange {
           text: js_doc.specifier,
           range: comment_source_to_position_range(
             comment.range().start,
-            i + js_doc.range.start..i + js_doc.range.end,
+            byte_index + js_doc.specifier_range.start
+              ..byte_index + js_doc.specifier_range.end,
             text_info,
             false,
           ),
-        });
-      }
+        },
+        resolution_mode: js_doc.resolution_mode,
+      });
     }
   }
-  deps.sort_by(|a, b| a.range.start.cmp(&b.range.start));
+  deps.sort_by(|a, b| a.specifier.range.start.cmp(&b.specifier.range.start));
   deps
 }
 
 #[derive(Debug, Clone)]
 struct JsDocImport {
   specifier: String,
-  range: std::ops::Range<usize>,
+  specifier_range: std::ops::Range<usize>,
+  resolution_mode: Option<TypeScriptTypesResolutionMode>,
 }
 
 fn parse_jsdoc_import_decl(input: &str) -> monch::ParseResult<JsDocImport> {
@@ -746,22 +765,24 @@ fn parse_jsdoc_import_decl(input: &str) -> monch::ParseResult<JsDocImport> {
     Ok((input, ()))
   }
 
-  fn skip_ident(input: &str) -> monch::ParseResult<()> {
-    let (input, c) = next_char(input)?;
-    if !c.is_alphabetic() {
-      return Err(monch::ParseError::Backtrace);
-    }
-    map(take_while(|c| !c.is_whitespace()), |_| ())(input)
-  }
-
   fn skip_namespace_import(input: &str) -> monch::ParseResult<()> {
     // * as ns
     let (input, _) = ch('*')(input)?;
     let (input, _) = skip_whitespace(input)?;
     let (input, _) = tag("as")(input)?;
     let (input, _) = whitespace(input)?;
-    let (input, _) = skip_ident(input)?;
+    let (input, _) = parse_ident(input)?;
     Ok((input, ()))
+  }
+
+  fn parse_attributes(
+    input: &str,
+  ) -> ParseResult<Option<TypeScriptTypesResolutionMode>> {
+    let (input, _) = tag("with")(input)?;
+    let (input, _) = skip_whitespace(input)?;
+    let (input, maybe_resolution_mode) =
+      parse_import_attribute_block_for_resolution_mode(input)?;
+    Ok((input, maybe_resolution_mode))
   }
 
   let initial_input = input;
@@ -770,25 +791,145 @@ fn parse_jsdoc_import_decl(input: &str) -> monch::ParseResult<JsDocImport> {
   let (input, _) = or3(
     skip_named_imports,
     terminated(skip_namespace_import, whitespace),
-    terminated(skip_ident, whitespace),
+    terminated(map(parse_ident, |_| ()), whitespace),
   )(input)?;
   let (input, _) = skip_whitespace(input)?;
   let (input, _) = tag("from")(input)?;
   let (input, _) = skip_whitespace(input)?;
-  let (input, open_char) = or(ch('"'), ch('\''))(input)?;
   let start_specifier_input = input;
-  let (input, specifier) = take_while(|c| c != open_char)(input)?;
+  let (input, specifier) = parse_quote(input)?;
   let end_specifier_input = input;
-  let (input, _) = ch(open_char)(input)?;
+  let (input, _) = skip_whitespace(input)?;
+  let (input, maybe_resolution_mode) = maybe(parse_attributes)(input)?;
 
   Ok((
     input,
     JsDocImport {
       specifier: specifier.to_string(),
-      range: initial_input.len() - start_specifier_input.len()
-        ..initial_input.len() - end_specifier_input.len(),
+      specifier_range: initial_input.len() - start_specifier_input.len() + 1
+        ..initial_input.len() - end_specifier_input.len() - 1,
+      resolution_mode: maybe_resolution_mode.flatten(),
     },
   ))
+}
+
+/// Matches a JSDoc import type reference (`{import("./example.js")}`
+fn parse_jsdoc_dynamic_import(input: &str) -> monch::ParseResult<JsDocImport> {
+  fn parse_second_param_obj_with_leading_comma(
+    input: &str,
+  ) -> monch::ParseResult<Option<TypeScriptTypesResolutionMode>> {
+    let (input, _) = ch(',')(input)?;
+    let (input, _) = skip_whitespace(input)?;
+    let (input, _) = ch('{')(input)?;
+    let (input, _) = skip_whitespace(input)?;
+    let (input, _) = tag("with")(input)?;
+    let (input, _) = skip_whitespace(input)?;
+    let (input, _) = ch(':')(input)?;
+    let (input, _) = skip_whitespace(input)?;
+
+    let (input, maybe_resolution_mode) =
+      parse_import_attribute_block_for_resolution_mode(input)?;
+    let (input, _) = skip_whitespace(input)?;
+    let (input, _) = ch('}')(input)?;
+
+    Ok((input, maybe_resolution_mode))
+  }
+
+  // \{[^}]*import\(['"]([^'"]+)['"]\)[^}]*}"
+  use monch::*;
+  let original_input = input;
+  let (mut input, _) = ch('{')(input)?;
+  for (index, c) in input.char_indices() {
+    if c == '}' {
+      return ParseError::backtrace();
+    }
+    input = &original_input[index..];
+    if input.starts_with("import") {
+      break;
+    }
+  }
+  let (input, _) = tag("import")(input)?;
+  let (input, _) = skip_whitespace(input)?;
+  let (input, _) = ch('(')(input)?;
+  let (input, _) = skip_whitespace(input)?;
+  let start_specifier_input = input;
+  let (input, specifier) = parse_quote(input)?;
+  let end_specifier_input = input;
+  let (input, _) = skip_whitespace(input)?;
+  let (input, maybe_resolution_mode) =
+    maybe(parse_second_param_obj_with_leading_comma)(input)?;
+  let (input, _) = skip_whitespace(input)?;
+  let (input, _) = ch(')')(input)?;
+  let (input, _) = take_while(|c| c != '}')(input)?;
+  let (input, _) = ch('}')(input)?;
+
+  Ok((
+    input,
+    JsDocImport {
+      specifier: specifier.to_string(),
+      specifier_range: original_input.len() - start_specifier_input.len() + 1
+        ..original_input.len() - end_specifier_input.len() - 1,
+      resolution_mode: maybe_resolution_mode.flatten(),
+    },
+  ))
+}
+
+fn parse_import_attribute_block_for_resolution_mode(
+  input: &str,
+) -> monch::ParseResult<Option<TypeScriptTypesResolutionMode>> {
+  use monch::*;
+  map(parse_import_attribute_block, |attributes| {
+    attributes
+      .iter()
+      .find(|(key, _)| *key == "resolution-mode")
+      .and_then(|(_, value)| TypeScriptTypesResolutionMode::from_str(value))
+  })(input)
+}
+
+fn parse_import_attribute_block(
+  input: &str,
+) -> monch::ParseResult<Vec<(&str, &str)>> {
+  use monch::*;
+  fn parse_attribute(input: &str) -> ParseResult<(&str, &str)> {
+    let (input, key) = or(parse_quote, parse_ident)(input)?;
+    let (input, _) = skip_whitespace(input)?;
+    let (input, _) = ch(':')(input)?;
+    let (input, _) = skip_whitespace(input)?;
+    let (input, value) = parse_quote(input)?;
+    Ok((input, (key, value)))
+  }
+
+  let (input, _) = ch('{')(input)?;
+  let (input, _) = skip_whitespace(input)?;
+
+  let (input, attributes) = separated_list(
+    parse_attribute,
+    delimited(skip_whitespace, ch(','), skip_whitespace),
+  )(input)?;
+  let (input, _) = skip_whitespace(input)?;
+  let (input, _) = ch('}')(input)?;
+  Ok((input, attributes))
+}
+
+fn parse_ident(input: &str) -> monch::ParseResult<&str> {
+  use monch::*;
+  let start_input = input;
+  let (input, c) = next_char(input)?;
+  if !c.is_alphabetic() {
+    return Err(monch::ParseError::Backtrace);
+  }
+  // good enough for now
+  let (input, _) =
+    take_while(|c| !c.is_whitespace() && c != ':' && c != '-')(input)?;
+  Ok((input, &start_input[..start_input.len() - input.len()]))
+}
+
+fn parse_quote(input: &str) -> monch::ParseResult<&str> {
+  use monch::*;
+  let (input, open_char) = or(ch('"'), ch('\''))(input)?;
+  let (input, text) = take_while(|c| c != open_char)(input)?;
+  let (input, _) = ch(open_char)(input)?;
+  Ok((input, text))
 }
 
 fn comment_source_to_position_range(
@@ -815,6 +956,8 @@ fn comment_source_to_position_range(
 
 #[cfg(test)]
 mod tests {
+  use crate::analyzer::JsDocImportInfo;
+
   use super::*;
   use pretty_assertions::assert_eq;
 
@@ -879,11 +1022,15 @@ mod tests {
           r#""./ref.d.ts""#
         );
       }
-      TypeScriptReference::Types(_) => panic!("expected path"),
+      TypeScriptReference::Types { .. } => panic!("expected path"),
     }
     match &ts_references[1] {
       TypeScriptReference::Path(_) => panic!("expected types"),
-      TypeScriptReference::Types(specifier) => {
+      TypeScriptReference::Types {
+        specifier,
+        resolution_mode: mode,
+      } => {
+        assert_eq!(*mode, None);
         assert_eq!(specifier.text, "./types.d.ts");
         assert_eq!(
           text_info.range_text(&specifier.range.as_source_range(text_info)),
@@ -962,6 +1109,58 @@ mod tests {
     );
 
     assert!(module_info.self_types_specifier.is_none());
+  }
+
+  #[test]
+  fn test_parse_resolution_mode() {
+    let specifier =
+      ModuleSpecifier::parse("file:///a/test.mts").expect("bad specifier");
+    let source = r#"
+    /// <reference types="./types.d.ts" resolution-mode="require" />
+    /// <reference types="node" resolution-mode="import" />
+    /// <reference types="other" resolution-mode="asdf" />
+    "#;
+    let parsed_source = DefaultEsParser
+      .parse_program(ParseOptions {
+        specifier: &specifier,
+        source: source.into(),
+        media_type: MediaType::Mts,
+        scope_analysis: false,
+      })
+      .unwrap();
+    let module_info = ParserModuleAnalyzer::module_info(&parsed_source);
+    let ts_references = module_info.ts_references;
+    assert_eq!(ts_references.len(), 3);
+    match &ts_references[0] {
+      TypeScriptReference::Path(_) => unreachable!(),
+      TypeScriptReference::Types {
+        specifier,
+        resolution_mode: mode,
+      } => {
+        assert_eq!(*mode, Some(TypeScriptTypesResolutionMode::Require));
+        assert_eq!(specifier.text, "./types.d.ts");
+      }
+    }
+    match &ts_references[1] {
+      TypeScriptReference::Path(_) => unreachable!(),
+      TypeScriptReference::Types {
+        specifier,
+        resolution_mode: mode,
+      } => {
+        assert_eq!(*mode, Some(TypeScriptTypesResolutionMode::Import));
+        assert_eq!(specifier.text, "node");
+      }
+    }
+    match &ts_references[2] {
+      TypeScriptReference::Path(_) => unreachable!(),
+      TypeScriptReference::Types {
+        specifier,
+        resolution_mode: mode,
+      } => {
+        assert_eq!(*mode, None);
+        assert_eq!(specifier.text, "other");
+      }
+    }
   }
 
   #[test]
@@ -1102,13 +1301,13 @@ function b(c) {
 }
 
 /**
- * @type {Set<import("./e.js").F>}
+ * @type {Set<import("./e.js", { with: { "resolution-mode": "require" } }).F>}
  */
 const f = new Set();
 
 /** @import { SomeType } from "./a.ts" */
 /** @import * as namespace from "./b.ts" */
-/** @import defaultImport from './c.ts' */
+/** @import defaultImport from './c.ts' with { "resolution-mode": "require" } */
 "#;
     let parsed_source = DefaultEsParser
       .parse_program(ParseOptions {
@@ -1124,96 +1323,117 @@ const f = new Set();
     assert_eq!(
       dependencies,
       [
-        SpecifierWithRange {
-          text: "./a.js".to_string(),
-          range: PositionRange {
-            start: Position {
-              line: 6,
-              character: 17
-            },
-            end: Position {
-              line: 6,
-              character: 25
+        JsDocImportInfo {
+          specifier: SpecifierWithRange {
+            text: "./a.js".to_string(),
+            range: PositionRange {
+              start: Position {
+                line: 6,
+                character: 17
+              },
+              end: Position {
+                line: 6,
+                character: 25
+              }
             }
-          }
+          },
+          resolution_mode: None,
         },
-        SpecifierWithRange {
-          text: "./b.js".to_string(),
-          range: PositionRange {
-            start: Position {
-              line: 13,
-              character: 18
-            },
-            end: Position {
-              line: 13,
-              character: 26
+        JsDocImportInfo {
+          specifier: SpecifierWithRange {
+            text: "./b.js".to_string(),
+            range: PositionRange {
+              start: Position {
+                line: 13,
+                character: 18
+              },
+              end: Position {
+                line: 13,
+                character: 26
+              }
             }
-          }
+          },
+          resolution_mode: None,
         },
-        SpecifierWithRange {
-          text: "./d.js".to_string(),
-          range: PositionRange {
-            start: Position {
-              line: 14,
-              character: 20
-            },
-            end: Position {
-              line: 14,
-              character: 28
+        JsDocImportInfo {
+          specifier: SpecifierWithRange {
+            text: "./d.js".to_string(),
+            range: PositionRange {
+              start: Position {
+                line: 14,
+                character: 20
+              },
+              end: Position {
+                line: 14,
+                character: 28
+              }
             }
-          }
+          },
+          resolution_mode: None,
         },
-        SpecifierWithRange {
-          text: "./e.js".to_string(),
-          range: PositionRange {
-            start: Position {
-              line: 21,
-              character: 21
-            },
-            end: Position {
-              line: 21,
-              character: 29
+        JsDocImportInfo {
+          specifier: SpecifierWithRange {
+            text: "./e.js".to_string(),
+            range: PositionRange {
+              start: Position {
+                line: 21,
+                character: 21
+              },
+              end: Position {
+                line: 21,
+                character: 29
+              }
             }
-          }
+          },
+          resolution_mode: Some(TypeScriptTypesResolutionMode::Require),
         },
-        SpecifierWithRange {
-          text: "./a.ts".to_string(),
-          range: PositionRange {
-            start: Position {
-              line: 25,
-              character: 30,
-            },
-            end: Position {
-              line: 25,
-              character: 38,
+        JsDocImportInfo {
+          specifier: SpecifierWithRange {
+            text: "./a.ts".to_string(),
+            range: PositionRange {
+              start: Position {
+                line: 25,
+                character: 30,
+              },
+              end: Position {
+                line: 25,
+                character: 38,
+              },
             },
           },
+          resolution_mode: None,
         },
-        SpecifierWithRange {
-          text: "./b.ts".to_string(),
-          range: PositionRange {
-            start: Position {
-              line: 26,
-              character: 32,
-            },
-            end: Position {
-              line: 26,
-              character: 40,
+        JsDocImportInfo {
+          specifier: SpecifierWithRange {
+            text: "./b.ts".to_string(),
+            range: PositionRange {
+              start: Position {
+                line: 26,
+                character: 32,
+              },
+              end: Position {
+                line: 26,
+                character: 40,
+              },
             },
           },
+          resolution_mode: None,
         },
-        SpecifierWithRange {
-          text: "./c.ts".to_string(),
-          range: PositionRange {
-            start: Position {
-              line: 27,
-              character: 31,
-            },
-            end: Position {
-              line: 27,
-              character: 39,
+        JsDocImportInfo {
+          specifier: SpecifierWithRange {
+            text: "./c.ts".to_string(),
+            range: PositionRange {
+              start: Position {
+                line: 27,
+                character: 31,
+              },
+              end: Position {
+                line: 27,
+                character: 39,
+              },
             },
           },
+          resolution_mode: Some(TypeScriptTypesResolutionMode::Require),
         }
       ]
     );
@@ -1292,6 +1512,14 @@ export {};
 
   #[test]
   fn test_parse_jsdoc_import_decl() {
+    fn parse_resolution_mode(
+      text: &str,
+    ) -> Option<TypeScriptTypesResolutionMode> {
+      parse_jsdoc_import_decl(text)
+        .ok()
+        .and_then(|v| v.1.resolution_mode)
+    }
+
     // named imports
     assert!(
       parse_jsdoc_import_decl("@import { SomeType } from \"./a.ts\"").is_ok()
@@ -1310,5 +1538,45 @@ export {};
     // mixing quotes (invalid)
     assert!(parse_jsdoc_import_decl("@import test from \"./a.ts'").is_err());
     assert!(parse_jsdoc_import_decl("@import test from './a.ts\"").is_err());
+    assert_eq!(
+      parse_resolution_mode("@import { SomeType } from \"./a.ts\" with { 'resolution-mode': 'import' }"),
+      Some(TypeScriptTypesResolutionMode::Import)
+    );
+    assert_eq!(
+      parse_resolution_mode(
+        "@import v from 'test' with { 'resolution-mode': \"require\" }"
+      ),
+      Some(TypeScriptTypesResolutionMode::Require)
+    );
+    assert_eq!(
+      parse_resolution_mode("@import v from 'test' with { type: 'other', 'resolution-mode': \"require\" }"),
+      Some(TypeScriptTypesResolutionMode::Require)
+    );
+  }
+
+  #[test]
+  fn test_parse_jsdoc_dynamic_import() {
+    fn parse_resolution_mode(
+      text: &str,
+    ) -> Option<TypeScriptTypesResolutionMode> {
+      parse_jsdoc_import_decl(text)
+        .ok()
+        .and_then(|v| v.1.resolution_mode)
+    }
+
+    assert!(parse_jsdoc_dynamic_import("{ import('testing') }").is_ok());
+    assert!(parse_jsdoc_dynamic_import("{ Test<import('testing')> }").is_ok());
+    assert_eq!(
+      parse_resolution_mode(
+        r#"{Set<import("./e.js", { with: { "resolution-mode": "require" } }).F>}"#
+      ),
+      Some(TypeScriptTypesResolutionMode::Require)
+    );
+    assert_eq!(
+      parse_resolution_mode(
+        r#"{import("a", { with: { type: "test", "resolution-mode": "import" } })}"#
+      ),
+      Some(TypeScriptTypesResolutionMode::Import)
+    );
   }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1559,7 +1559,7 @@ export {};
     fn parse_resolution_mode(
       text: &str,
     ) -> Option<TypeScriptTypesResolutionMode> {
-      parse_jsdoc_import_decl(text)
+      parse_jsdoc_dynamic_import(text)
         .ok()
         .and_then(|v| v.1.resolution_mode)
     }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -710,23 +710,16 @@ fn analyze_jsdoc_imports(
     let js_docs = comment
       .text
       .match_indices("{")
-      .map(|(i, _)| {
+      .filter_map(|(i, _)| {
         parse_jsdoc_dynamic_import(&comment.text[i..])
           .ok()
           .map(|(_input, jsdoc)| (i, jsdoc))
       })
-      .flatten()
-      .chain(
-        comment
-          .text
-          .match_indices("@import")
-          .map(|(i, _)| {
-            parse_jsdoc_import_decl(&comment.text[i..])
-              .ok()
-              .map(|(_input, jsdoc)| (i, jsdoc))
-          })
-          .flatten(),
-      );
+      .chain(comment.text.match_indices("@import").filter_map(|(i, _)| {
+        parse_jsdoc_import_decl(&comment.text[i..])
+          .ok()
+          .map(|(_input, jsdoc)| (i, jsdoc))
+      }));
     for (byte_index, js_doc) in js_docs {
       deps.push(JsDocImportInfo {
         specifier: SpecifierWithRange {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -5300,7 +5300,10 @@ impl Serialize for Resolution {
         let mut state = serializer.serialize_struct("ResolvedSpecifier", 3)?;
         state.serialize_field("specifier", &resolved.specifier)?;
         if resolved.range.resolution_mode.is_some() {
-          state.serialize_field("mode", &resolved.range.resolution_mode)?;
+          state.serialize_field(
+            "resolutionMode",
+            &resolved.range.resolution_mode,
+          )?;
         }
         state.serialize_field("span", &resolved.range)?;
         state.end()
@@ -5310,7 +5313,7 @@ impl Serialize for Resolution {
         state.serialize_field("error", &err.to_string())?;
         let range = err.range();
         if range.resolution_mode.is_some() {
-          state.serialize_field("mode", &range.resolution_mode)?;
+          state.serialize_field("resolutionMode", &range.resolution_mode)?;
         }
         state.serialize_field("span", range)?;
         state.end()

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -139,7 +139,7 @@ pub struct Range {
   #[serde(flatten, serialize_with = "serialize_position")]
   pub range: PositionRange,
   #[serde(default, skip_serializing)]
-  pub mode: Option<ResolutionMode>,
+  pub resolution_mode: Option<ResolutionMode>,
 }
 
 fn serialize_position<S: Serializer>(
@@ -1149,7 +1149,7 @@ impl GraphImport {
         let referrer_range = Range {
           specifier: referrer.clone(),
           range: PositionRange::zeroed(),
-          mode: None,
+          resolution_mode: None,
         };
         let maybe_type = resolve(
           &import,
@@ -2498,7 +2498,7 @@ pub(crate) fn parse_js_module_from_module_info(
       let range = Range {
         specifier: module.specifier.clone(),
         range: specifier.range,
-        mode: None,
+        resolution_mode: None,
       };
       module.maybe_types_dependency = Some(TypesDependency {
         specifier: specifier.text.clone(),
@@ -2523,7 +2523,7 @@ pub(crate) fn parse_js_module_from_module_info(
           let range = Range {
             specifier: module.specifier.clone(),
             range: specifier.range,
-            mode: None,
+            resolution_mode: None,
           };
           if dep.maybe_type.is_none() {
             dep.maybe_type = resolve(
@@ -2554,7 +2554,7 @@ pub(crate) fn parse_js_module_from_module_info(
           let range = Range {
             specifier: module.specifier.clone(),
             range: specifier.range,
-            mode: mode.map(|mode| mode.as_deno_graph()),
+            resolution_mode: mode.map(|mode| mode.as_deno_graph()),
           };
           let dep_resolution = resolve(
             &specifier.text,
@@ -2639,7 +2639,7 @@ pub(crate) fn parse_js_module_from_module_info(
       let range = Range {
         specifier: module.specifier.clone(),
         range: import_source.range,
-        mode: None,
+        resolution_mode: None,
       };
       if dep.maybe_code.is_none() {
         dep.maybe_code = resolve(
@@ -2674,7 +2674,7 @@ pub(crate) fn parse_js_module_from_module_info(
           let range = Range {
             specifier: module.specifier.clone(),
             range: import_source_types.range,
-            mode: None,
+            resolution_mode: None,
           };
           dep.maybe_type = resolve(
             &specifier_text,
@@ -2722,7 +2722,7 @@ pub(crate) fn parse_js_module_from_module_info(
       let specifier_range = Range {
         specifier: module.specifier.clone(),
         range: specifier.range,
-        mode: jsdoc_import
+        resolution_mode: jsdoc_import
           .resolution_mode
           .map(|mode| mode.as_deno_graph()),
       };
@@ -2753,7 +2753,7 @@ pub(crate) fn parse_js_module_from_module_info(
         let range = Range {
           specifier: module.specifier.clone(),
           range: PositionRange::zeroed(),
-          mode: None,
+          resolution_mode: None,
         };
         module.maybe_types_dependency = Some(TypesDependency {
           specifier: types_header.to_string(),
@@ -2789,7 +2789,7 @@ pub(crate) fn parse_js_module_from_module_info(
                 range: maybe_range.unwrap_or_else(|| Range {
                   specifier,
                   range: PositionRange::zeroed(),
-                  mode: None,
+                  resolution_mode: None,
                 }),
               })),
             })
@@ -2804,7 +2804,7 @@ pub(crate) fn parse_js_module_from_module_info(
                 range: Range {
                   specifier: module.specifier.clone(),
                   range: PositionRange::zeroed(),
-                  mode: None,
+                  resolution_mode: None,
                 },
               },
             )),
@@ -2889,7 +2889,7 @@ fn fill_module_dependencies(
         let specifier_range = Range {
           specifier: module_specifier.clone(),
           range: desc.specifier_range,
-          mode: match desc.kind {
+          resolution_mode: match desc.kind {
             StaticDependencyKind::Import
             | StaticDependencyKind::Export
             | StaticDependencyKind::ImportType
@@ -2957,7 +2957,7 @@ fn fill_module_dependencies(
         let specifier_range = Range {
           specifier: module_specifier.clone(),
           range: desc.argument_range,
-          mode: match desc.kind {
+          resolution_mode: match desc.kind {
             DynamicDependencyKind::Import => {
               if media_type.is_declaration() {
                 None
@@ -3005,7 +3005,7 @@ fn fill_module_dependencies(
             Range {
               specifier: module_specifier.clone(),
               range: types_specifier.range,
-              mode: import.specifier_range.mode,
+              resolution_mode: import.specifier_range.resolution_mode,
             },
             ResolutionKind::Types,
             jsr_url_provider,
@@ -5299,8 +5299,8 @@ impl Serialize for Resolution {
       Resolution::Ok(resolved) => {
         let mut state = serializer.serialize_struct("ResolvedSpecifier", 3)?;
         state.serialize_field("specifier", &resolved.specifier)?;
-        if resolved.range.mode.is_some() {
-          state.serialize_field("mode", &resolved.range.mode)?;
+        if resolved.range.resolution_mode.is_some() {
+          state.serialize_field("mode", &resolved.range.resolution_mode)?;
         }
         state.serialize_field("span", &resolved.range)?;
         state.end()
@@ -5309,8 +5309,8 @@ impl Serialize for Resolution {
         let mut state = serializer.serialize_struct("ResolvedError", 3)?;
         state.serialize_field("error", &err.to_string())?;
         let range = err.range();
-        if range.mode.is_some() {
-          state.serialize_field("mode", &range.mode)?;
+        if range.resolution_mode.is_some() {
+          state.serialize_field("mode", &range.resolution_mode)?;
         }
         state.serialize_field("span", range)?;
         state.end()
@@ -5452,7 +5452,7 @@ mod tests {
               character: 27,
             },
           },
-          mode: None,
+          resolution_mode: None,
         },
       })),
       imports: vec![
@@ -5471,7 +5471,7 @@ mod tests {
                 character: 27,
               },
             },
-            mode: None,
+            resolution_mode: None,
           },
           is_dynamic: false,
           attributes: Default::default(),
@@ -5491,7 +5491,7 @@ mod tests {
                 character: 27,
               },
             },
-            mode: None,
+            resolution_mode: None,
           },
           is_dynamic: false,
           attributes: Default::default(),
@@ -5516,7 +5516,7 @@ mod tests {
             character: 27
           },
         },
-        mode: None,
+        resolution_mode: None,
       })
     );
     assert_eq!(
@@ -5536,7 +5536,7 @@ mod tests {
             character: 27
           },
         },
-        mode: None,
+        resolution_mode: None,
       })
     );
     assert_eq!(
@@ -5557,7 +5557,7 @@ mod tests {
         range: Range {
           specifier: referrer.clone(),
           range: PositionRange::zeroed(),
-          mode: None,
+          resolution_mode: None,
         },
       })),
       maybe_type: Resolution::Ok(Box::new(ResolutionResolved {
@@ -5565,7 +5565,7 @@ mod tests {
         range: Range {
           specifier: referrer.clone(),
           range: PositionRange::zeroed(),
-          mode: None,
+          resolution_mode: None,
         },
       })),
       maybe_deno_types_specifier: Some("./b.d.ts".to_string()),
@@ -5581,7 +5581,7 @@ mod tests {
           range: Range {
             specifier: referrer.clone(),
             range: PositionRange::zeroed(),
-            mode: None,
+            resolution_mode: None,
           },
         })),
         maybe_type: Resolution::Ok(Box::new(ResolutionResolved {
@@ -5589,7 +5589,7 @@ mod tests {
           range: Range {
             specifier: referrer.clone(),
             range: PositionRange::zeroed(),
-            mode: None,
+            resolution_mode: None,
           },
         })),
         maybe_deno_types_specifier: Some("./b.d.ts".to_string()),
@@ -5608,7 +5608,7 @@ mod tests {
         range: Range {
           specifier: referrer.clone(),
           range: PositionRange::zeroed(),
-          mode: None,
+          resolution_mode: None,
         },
       })),
     };
@@ -5623,7 +5623,7 @@ mod tests {
           range: Range {
             specifier: referrer.clone(),
             range: PositionRange::zeroed(),
-            mode: None,
+            resolution_mode: None,
           },
         })),
       }
@@ -5973,7 +5973,7 @@ mod tests {
               character: 82,
             },
           },
-          mode: Some(ResolutionMode::Import),
+          resolution_mode: Some(ResolutionMode::Import),
         },
         specifier: ModuleSpecifier::parse("http://deno.land/foo.js").unwrap(),
       },
@@ -5994,7 +5994,7 @@ mod tests {
               character: 48,
             },
           },
-          mode: Some(ResolutionMode::Import),
+          resolution_mode: Some(ResolutionMode::Import),
         },
         specifier: ModuleSpecifier::parse("file:///bar.js").unwrap(),
       },
@@ -6016,7 +6016,7 @@ mod tests {
               character: 23,
             },
           },
-          mode: Some(ResolutionMode::Import),
+          resolution_mode: Some(ResolutionMode::Import),
         },
         specifier: ModuleSpecifier::parse("file:///baz.js").unwrap(),
       },
@@ -6160,7 +6160,7 @@ mod tests {
                 character: 52,
               },
             },
-            mode: None,
+            resolution_mode: None,
           },
           is_dynamic: false,
           attributes: ImportAttributes::None,
@@ -6180,7 +6180,7 @@ mod tests {
                 character: 53,
               },
             },
-            mode: None,
+            resolution_mode: None,
           },
           is_dynamic: false,
           attributes: ImportAttributes::None,
@@ -6200,7 +6200,7 @@ mod tests {
                 character: 39,
               },
             },
-            mode: Some(ResolutionMode::Import),
+            resolution_mode: Some(ResolutionMode::Import),
           },
           is_dynamic: false,
           attributes: ImportAttributes::None,
@@ -6220,7 +6220,7 @@ mod tests {
                 character: 45,
               },
             },
-            mode: Some(ResolutionMode::Import),
+            resolution_mode: Some(ResolutionMode::Import),
           },
           is_dynamic: true,
           attributes: ImportAttributes::None,
@@ -6240,7 +6240,7 @@ mod tests {
                 character: 45,
               },
             },
-            mode: Some(ResolutionMode::Import),
+            resolution_mode: Some(ResolutionMode::Import),
           },
           is_dynamic: true,
           attributes: ImportAttributes::Unknown,
@@ -6260,7 +6260,7 @@ mod tests {
                 character: 52,
               },
             },
-            mode: Some(ResolutionMode::Import),
+            resolution_mode: Some(ResolutionMode::Import),
           },
           is_dynamic: false,
           attributes: ImportAttributes::None,
@@ -6284,7 +6284,7 @@ mod tests {
               character: 41,
             },
           },
-          mode: Some(ResolutionMode::Import),
+          resolution_mode: Some(ResolutionMode::Import),
         },
         is_dynamic: false,
         attributes: ImportAttributes::Known(HashMap::from_iter(vec![(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,7 @@ mod tests {
   use source::CacheInfo;
   use source::MemoryLoader;
   use source::NpmResolvePkgReqsResult;
+  use source::ResolutionKind;
   use source::Source;
   use std::cell::RefCell;
   use std::collections::BTreeMap;
@@ -1924,6 +1925,7 @@ export const foo = 'bar';"#,
             line: 0,
             character: 36
           },
+          kind: None,
         }
       }
     );
@@ -1978,6 +1980,7 @@ export const foo = 'bar';"#,
             line: 0,
             character: 33
           },
+          kind: Some(ResolutionKind::Esm),
         }
       }
     );
@@ -2102,6 +2105,7 @@ export const foo = 'bar';"#,
             specifier: ModuleSpecifier::parse("file:///package.json").unwrap(),
             start: Position::zeroed(),
             end: Position::zeroed(),
+            kind: None,
           }),
         ),
       )],
@@ -2130,6 +2134,7 @@ export const foo = 'bar';"#,
           specifier: ModuleSpecifier::parse("file:///package.json").unwrap(),
           start: Position::zeroed(),
           end: Position::zeroed(),
+          kind: None,
         }
       }
     );
@@ -3305,6 +3310,7 @@ export const foo = 'bar';"#,
               specifier: specifier.clone(),
               start: Position::new(2, 22),
               end: Position::new(2, 30),
+              kind: Some(ResolutionKind::Esm),
             },
           })),
           maybe_type: Resolution::Ok(Box::new(ResolutionResolved {
@@ -3313,6 +3319,7 @@ export const foo = 'bar';"#,
               specifier: specifier.clone(),
               start: Position::new(1, 19),
               end: Position::new(1, 29),
+              kind: Some(ResolutionKind::Esm),
             },
           })),
           maybe_deno_types_specifier: Some("./a.d.ts".to_string()),
@@ -3323,6 +3330,7 @@ export const foo = 'bar';"#,
               specifier: specifier.clone(),
               start: Position::new(2, 22),
               end: Position::new(2, 30),
+              kind: Some(ResolutionKind::Esm),
             },
             is_dynamic: false,
             attributes: Default::default(),
@@ -3740,11 +3748,13 @@ export function a(a) {
     assert_eq!(
       json!(actual),
       json!({
+        "kind": "esm",
         "dependencies": [
           {
             "specifier": "./types.d.ts",
             "type": {
               "specifier": "file:///a/types.d.ts",
+              "kind": "esm",
               "span": {
                 "start": {
                   "line": 4,
@@ -3761,6 +3771,7 @@ export function a(a) {
             "specifier": "./other.ts",
             "type": {
               "specifier": "file:///a/other.ts",
+              "kind": "esm",
               "span": {
                 "start": {
                   "line": 5,
@@ -3774,7 +3785,6 @@ export function a(a) {
             }
           }
         ],
-        "kind": "esm",
         "mediaType": "JavaScript",
         "size": 137,
         "specifier": "file:///a/test.js"
@@ -4422,6 +4432,7 @@ export function a(a: A): B {
                   "specifier": "./a",
                   "code": {
                     "specifier": "file:///a/a.js",
+                    "kind": "esm",
                     "span": {
                       "start": {
                         "line": 1,
@@ -4435,6 +4446,7 @@ export function a(a: A): B {
                   },
                   "type": {
                     "specifier": "file:///a/a.d.ts",
+                    "kind": "esm",
                     "span": {
                       "start": {
                         "line": 1,
@@ -4491,6 +4503,7 @@ export function a(a: A): B {
                   "specifier": "./a",
                   "code": {
                     "specifier": "file:///a/a.js",
+                    "kind": "esm",
                     "span": {
                       "start": {
                         "line": 1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -842,7 +842,7 @@ console.log(a);
                 "specifier": "./deno.json",
                 "code": {
                   "specifier": "file:///a/deno.json",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 0,
@@ -1359,7 +1359,7 @@ console.log(a);
               "specifier": "path",
               "code": {
                 "specifier": "node:path",
-                "mode": "import",
+                "resolutionMode": "import",
                 "span": {
                   "start": {
                     "line": 0,
@@ -1569,7 +1569,7 @@ console.log(a);
                 "specifier": "./b.ts",
                 "code": {
                   "specifier": "file:///b.ts",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 0,
@@ -1930,7 +1930,7 @@ export const foo = 'bar';"#,
               character: 36
             },
           },
-          mode: None,
+          resolution_mode: None,
         }
       }
     );
@@ -1987,7 +1987,7 @@ export const foo = 'bar';"#,
               character: 33
             },
           },
-          mode: None,
+          resolution_mode: None,
         }
       }
     );
@@ -2111,7 +2111,7 @@ export const foo = 'bar';"#,
           Some(Range {
             specifier: ModuleSpecifier::parse("file:///package.json").unwrap(),
             range: PositionRange::zeroed(),
-            mode: None,
+            resolution_mode: None,
           }),
         ),
       )],
@@ -2139,7 +2139,7 @@ export const foo = 'bar';"#,
         range: Range {
           specifier: ModuleSpecifier::parse("file:///package.json").unwrap(),
           range: PositionRange::zeroed(),
-          mode: None,
+          resolution_mode: None,
         }
       }
     );
@@ -2241,7 +2241,7 @@ export const foo = 'bar';"#,
                 "specifier": "./a.json",
                 "code": {
                   "specifier": "file:///a/a.json",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 1,
@@ -2259,7 +2259,7 @@ export const foo = 'bar';"#,
                 "specifier": "./b.json",
                 "code": {
                   "specifier": "file:///a/b.json",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 2,
@@ -2278,7 +2278,7 @@ export const foo = 'bar';"#,
                 "specifier": "./c.json",
                 "code": {
                   "specifier": "file:///a/c.json",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 3,
@@ -2296,7 +2296,7 @@ export const foo = 'bar';"#,
                 "specifier": "./d.json",
                 "code": {
                   "specifier": "file:///a/d.json",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 5,
@@ -2373,7 +2373,7 @@ export const foo = 'bar';"#,
                 "specifier": "./a.json",
                 "code": {
                   "specifier": "file:///a/a.json",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 1,
@@ -2501,7 +2501,7 @@ export const foo = 'bar';"#,
                 "specifier": "./a.json",
                 "code": {
                   "specifier": "file:///a/a.json",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 1,
@@ -2518,7 +2518,7 @@ export const foo = 'bar';"#,
                 "specifier": "./b.json",
                 "code": {
                   "specifier": "file:///a/b.json",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 2,
@@ -2536,7 +2536,7 @@ export const foo = 'bar';"#,
                 "specifier": "./c.js",
                 "code": {
                   "specifier": "file:///a/c.js",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 3,
@@ -2554,7 +2554,7 @@ export const foo = 'bar';"#,
                 "specifier": "./d.json",
                 "code": {
                   "specifier": "file:///a/d.json",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 4,
@@ -2572,7 +2572,7 @@ export const foo = 'bar';"#,
                 "specifier": "./e.wasm",
                 "code": {
                   "specifier": "file:///a/e.wasm",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 5,
@@ -2844,7 +2844,7 @@ export const foo = 'bar';"#,
                 "specifier": "./a.js",
                 "type": {
                   "specifier": "file:///a/a.d.ts",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 1,
@@ -2861,7 +2861,7 @@ export const foo = 'bar';"#,
                 "specifier": "./b.d.ts",
                 "type": {
                   "specifier": "file:///a/b.d.ts",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 3,
@@ -2878,7 +2878,7 @@ export const foo = 'bar';"#,
                 "specifier": "https://example.com/c",
                 "code": {
                   "specifier": "https://example.com/c",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 4,
@@ -2895,7 +2895,7 @@ export const foo = 'bar';"#,
                 "specifier": "./d.js",
                 "code": {
                   "specifier": "file:///a/d.js",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 5,
@@ -3073,7 +3073,7 @@ export const foo = 'bar';"#,
                 "specifier": "./a.js",
                 "code": {
                   "specifier": "file:///a/a.js",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 2,
@@ -3090,7 +3090,7 @@ export const foo = 'bar';"#,
                 "specifier": "https://example.com/c",
                 "code": {
                   "specifier": "https://example.com/c",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 4,
@@ -3107,7 +3107,7 @@ export const foo = 'bar';"#,
                 "specifier": "./d.js",
                 "code": {
                   "specifier": "file:///a/d.js",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 5,
@@ -3132,7 +3132,7 @@ export const foo = 'bar';"#,
                 "specifier": "./c.js",
                 "code": {
                   "specifier": "https://example.com/c.js",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 0,
@@ -3209,7 +3209,7 @@ export const foo = 'bar';"#,
                 "specifier": "builtin:fs",
                 "code": {
                   "specifier": "builtin:fs",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 1,
@@ -3226,7 +3226,7 @@ export const foo = 'bar';"#,
                 "specifier": "https://example.com/bundle",
                 "code": {
                   "specifier": "https://example.com/bundle",
-                  "mode": "import",
+                  "resolutionMode": "import",
                   "span": {
                     "start": {
                       "line": 2,
@@ -3337,7 +3337,7 @@ export const foo = 'bar';"#,
                 start: Position::new(2, 22),
                 end: Position::new(2, 30),
               },
-              mode: Some(ResolutionMode::Import),
+              resolution_mode: Some(ResolutionMode::Import),
             },
           })),
           maybe_type: Resolution::Ok(Box::new(ResolutionResolved {
@@ -3348,7 +3348,7 @@ export const foo = 'bar';"#,
                 start: Position::new(1, 19),
                 end: Position::new(1, 29),
               },
-              mode: Some(ResolutionMode::Import),
+              resolution_mode: Some(ResolutionMode::Import),
             },
           })),
           maybe_deno_types_specifier: Some("./a.d.ts".to_string()),
@@ -3361,7 +3361,7 @@ export const foo = 'bar';"#,
                 start: Position::new(2, 22),
                 end: Position::new(2, 30),
               },
-              mode: Some(ResolutionMode::Import),
+              resolution_mode: Some(ResolutionMode::Import),
             },
             is_dynamic: false,
             attributes: Default::default(),
@@ -3404,7 +3404,7 @@ export const foo = 'bar';"#,
             "specifier": "./a.json",
             "code": {
               "specifier": "file:///a/a.json",
-              "mode": "import",
+              "resolutionMode": "import",
               "span": {
                 "start": {
                   "line": 1,
@@ -3422,7 +3422,7 @@ export const foo = 'bar';"#,
             "specifier": "./b.json",
             "code": {
               "specifier": "file:///a/b.json",
-              "mode": "import",
+              "resolutionMode": "import",
               "span": {
                 "start": {
                   "line": 2,
@@ -4463,7 +4463,7 @@ export function a(a: A): B {
                   "specifier": "./a",
                   "code": {
                     "specifier": "file:///a/a.js",
-                    "mode": "import",
+                    "resolutionMode": "import",
                     "span": {
                       "start": {
                         "line": 1,
@@ -4477,7 +4477,7 @@ export function a(a: A): B {
                   },
                   "type": {
                     "specifier": "file:///a/a.d.ts",
-                    "mode": "import",
+                    "resolutionMode": "import",
                     "span": {
                       "start": {
                         "line": 1,
@@ -4534,7 +4534,7 @@ export function a(a: A): B {
                   "specifier": "./a",
                   "code": {
                     "specifier": "file:///a/a.js",
-                    "mode": "import",
+                    "resolutionMode": "import",
                     "span": {
                       "start": {
                         "line": 1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub use analyzer::DependencyDescriptor;
 pub use analyzer::DynamicArgument;
 pub use analyzer::DynamicDependencyDescriptor;
 pub use analyzer::DynamicTemplatePart;
+pub use analyzer::JsDocImportInfo;
 pub use analyzer::ModuleAnalyzer;
 pub use analyzer::ModuleInfo;
 pub use analyzer::PositionRange;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@ mod tests {
   use crate::graph::ImportKind;
   use crate::graph::ResolutionResolved;
   use crate::source::NullFileSystem;
-  use crate::source::ResolutionMode;
+  use crate::source::ResolutionKind;
 
   use super::*;
   use async_trait::async_trait;
@@ -197,7 +197,7 @@ mod tests {
   use source::CacheInfo;
   use source::MemoryLoader;
   use source::NpmResolvePkgReqsResult;
-  use source::ResolutionKind;
+  use source::ResolutionMode;
   use source::Source;
   use std::cell::RefCell;
   use std::collections::BTreeMap;
@@ -841,6 +841,7 @@ console.log(a);
                 "specifier": "./deno.json",
                 "code": {
                   "specifier": "file:///a/deno.json",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 0,
@@ -1321,7 +1322,7 @@ console.log(a);
       &self,
       specifier_text: &str,
       referrer_range: &Range,
-      _mode: ResolutionMode,
+      _kind: ResolutionKind,
     ) -> Result<deno_ast::ModuleSpecifier, source::ResolveError> {
       use import_map::ImportMapError;
       Err(source::ResolveError::Other(
@@ -1358,6 +1359,7 @@ console.log(a);
               "specifier": "path",
               "code": {
                 "specifier": "node:path",
+                "mode": "import",
                 "span": {
                   "start": {
                     "line": 0,
@@ -1567,6 +1569,7 @@ console.log(a);
                 "specifier": "./b.ts",
                 "code": {
                   "specifier": "file:///b.ts",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 0,
@@ -1925,7 +1928,7 @@ export const foo = 'bar';"#,
             line: 0,
             character: 36
           },
-          kind: None,
+          mode: None,
         }
       }
     );
@@ -1980,7 +1983,7 @@ export const foo = 'bar';"#,
             line: 0,
             character: 33
           },
-          kind: Some(ResolutionKind::Esm),
+          mode: None,
         }
       }
     );
@@ -2105,7 +2108,7 @@ export const foo = 'bar';"#,
             specifier: ModuleSpecifier::parse("file:///package.json").unwrap(),
             start: Position::zeroed(),
             end: Position::zeroed(),
-            kind: None,
+            mode: None,
           }),
         ),
       )],
@@ -2134,7 +2137,7 @@ export const foo = 'bar';"#,
           specifier: ModuleSpecifier::parse("file:///package.json").unwrap(),
           start: Position::zeroed(),
           end: Position::zeroed(),
-          kind: None,
+          mode: None,
         }
       }
     );
@@ -2236,6 +2239,7 @@ export const foo = 'bar';"#,
                 "specifier": "./a.json",
                 "code": {
                   "specifier": "file:///a/a.json",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 1,
@@ -2253,6 +2257,7 @@ export const foo = 'bar';"#,
                 "specifier": "./b.json",
                 "code": {
                   "specifier": "file:///a/b.json",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 2,
@@ -2271,6 +2276,7 @@ export const foo = 'bar';"#,
                 "specifier": "./c.json",
                 "code": {
                   "specifier": "file:///a/c.json",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 3,
@@ -2288,6 +2294,7 @@ export const foo = 'bar';"#,
                 "specifier": "./d.json",
                 "code": {
                   "specifier": "file:///a/d.json",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 5,
@@ -2364,6 +2371,7 @@ export const foo = 'bar';"#,
                 "specifier": "./a.json",
                 "code": {
                   "specifier": "file:///a/a.json",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 1,
@@ -2491,6 +2499,7 @@ export const foo = 'bar';"#,
                 "specifier": "./a.json",
                 "code": {
                   "specifier": "file:///a/a.json",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 1,
@@ -2507,6 +2516,7 @@ export const foo = 'bar';"#,
                 "specifier": "./b.json",
                 "code": {
                   "specifier": "file:///a/b.json",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 2,
@@ -2524,6 +2534,7 @@ export const foo = 'bar';"#,
                 "specifier": "./c.js",
                 "code": {
                   "specifier": "file:///a/c.js",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 3,
@@ -2541,6 +2552,7 @@ export const foo = 'bar';"#,
                 "specifier": "./d.json",
                 "code": {
                   "specifier": "file:///a/d.json",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 4,
@@ -2558,6 +2570,7 @@ export const foo = 'bar';"#,
                 "specifier": "./e.wasm",
                 "code": {
                   "specifier": "file:///a/e.wasm",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 5,
@@ -2829,6 +2842,7 @@ export const foo = 'bar';"#,
                 "specifier": "./a.js",
                 "type": {
                   "specifier": "file:///a/a.d.ts",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 1,
@@ -2845,6 +2859,7 @@ export const foo = 'bar';"#,
                 "specifier": "./b.d.ts",
                 "type": {
                   "specifier": "file:///a/b.d.ts",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 3,
@@ -2861,6 +2876,7 @@ export const foo = 'bar';"#,
                 "specifier": "https://example.com/c",
                 "code": {
                   "specifier": "https://example.com/c",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 4,
@@ -2877,6 +2893,7 @@ export const foo = 'bar';"#,
                 "specifier": "./d.js",
                 "code": {
                   "specifier": "file:///a/d.js",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 5,
@@ -3054,6 +3071,7 @@ export const foo = 'bar';"#,
                 "specifier": "./a.js",
                 "code": {
                   "specifier": "file:///a/a.js",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 2,
@@ -3070,6 +3088,7 @@ export const foo = 'bar';"#,
                 "specifier": "https://example.com/c",
                 "code": {
                   "specifier": "https://example.com/c",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 4,
@@ -3086,6 +3105,7 @@ export const foo = 'bar';"#,
                 "specifier": "./d.js",
                 "code": {
                   "specifier": "file:///a/d.js",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 5,
@@ -3110,6 +3130,7 @@ export const foo = 'bar';"#,
                 "specifier": "./c.js",
                 "code": {
                   "specifier": "https://example.com/c.js",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 0,
@@ -3186,6 +3207,7 @@ export const foo = 'bar';"#,
                 "specifier": "builtin:fs",
                 "code": {
                   "specifier": "builtin:fs",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 1,
@@ -3202,6 +3224,7 @@ export const foo = 'bar';"#,
                 "specifier": "https://example.com/bundle",
                 "code": {
                   "specifier": "https://example.com/bundle",
+                  "mode": "import",
                   "span": {
                     "start": {
                       "line": 2,
@@ -3310,7 +3333,7 @@ export const foo = 'bar';"#,
               specifier: specifier.clone(),
               start: Position::new(2, 22),
               end: Position::new(2, 30),
-              kind: Some(ResolutionKind::Esm),
+              mode: Some(ResolutionMode::Import),
             },
           })),
           maybe_type: Resolution::Ok(Box::new(ResolutionResolved {
@@ -3319,7 +3342,7 @@ export const foo = 'bar';"#,
               specifier: specifier.clone(),
               start: Position::new(1, 19),
               end: Position::new(1, 29),
-              kind: Some(ResolutionKind::Esm),
+              mode: Some(ResolutionMode::Import),
             },
           })),
           maybe_deno_types_specifier: Some("./a.d.ts".to_string()),
@@ -3330,7 +3353,7 @@ export const foo = 'bar';"#,
               specifier: specifier.clone(),
               start: Position::new(2, 22),
               end: Position::new(2, 30),
-              kind: Some(ResolutionKind::Esm),
+              mode: Some(ResolutionMode::Import),
             },
             is_dynamic: false,
             attributes: Default::default(),
@@ -3367,11 +3390,13 @@ export const foo = 'bar';"#,
     assert_eq!(
       json!(actual),
       json!({
+        "kind": "esm",
         "dependencies": [
           {
             "specifier": "./a.json",
             "code": {
               "specifier": "file:///a/a.json",
+              "mode": "import",
               "span": {
                 "start": {
                   "line": 1,
@@ -3389,6 +3414,7 @@ export const foo = 'bar';"#,
             "specifier": "./b.json",
             "code": {
               "specifier": "file:///a/b.json",
+              "mode": "import",
               "span": {
                 "start": {
                   "line": 2,
@@ -3404,7 +3430,6 @@ export const foo = 'bar';"#,
             "assertionType": "json"
           }
         ],
-        "kind": "esm",
         "mediaType": "TypeScript",
         "size": 119,
         "specifier": "file:///a/test01.ts"
@@ -3754,7 +3779,6 @@ export function a(a) {
             "specifier": "./types.d.ts",
             "type": {
               "specifier": "file:///a/types.d.ts",
-              "kind": "esm",
               "span": {
                 "start": {
                   "line": 4,
@@ -3771,7 +3795,6 @@ export function a(a) {
             "specifier": "./other.ts",
             "type": {
               "specifier": "file:///a/other.ts",
-              "kind": "esm",
               "span": {
                 "start": {
                   "line": 5,
@@ -4349,11 +4372,11 @@ export function a(a: A): B {
         &self,
         specifier_text: &str,
         referrer_range: &Range,
-        mode: ResolutionMode,
+        resolution_kind: ResolutionKind,
       ) -> Result<ModuleSpecifier, crate::source::ResolveError> {
-        let specifier_text = match mode {
-          ResolutionMode::Types => format!("{}.d.ts", specifier_text),
-          ResolutionMode::Execution => format!("{}.js", specifier_text),
+        let specifier_text = match resolution_kind {
+          ResolutionKind::Types => format!("{}.d.ts", specifier_text),
+          ResolutionKind::Execution => format!("{}.js", specifier_text),
         };
         Ok(resolve_import(&specifier_text, &referrer_range.specifier)?)
       }
@@ -4432,7 +4455,7 @@ export function a(a: A): B {
                   "specifier": "./a",
                   "code": {
                     "specifier": "file:///a/a.js",
-                    "kind": "esm",
+                    "mode": "import",
                     "span": {
                       "start": {
                         "line": 1,
@@ -4446,7 +4469,7 @@ export function a(a: A): B {
                   },
                   "type": {
                     "specifier": "file:///a/a.d.ts",
-                    "kind": "esm",
+                    "mode": "import",
                     "span": {
                       "start": {
                         "line": 1,
@@ -4503,7 +4526,7 @@ export function a(a: A): B {
                   "specifier": "./a",
                   "code": {
                     "specifier": "file:///a/a.js",
-                    "kind": "esm",
+                    "mode": "import",
                     "span": {
                       "start": {
                         "line": 1,
@@ -4539,13 +4562,13 @@ export function a(a: A): B {
         &self,
         specifier_text: &str,
         referrer_range: &Range,
-        mode: ResolutionMode,
+        resolution_kind: ResolutionKind,
       ) -> Result<ModuleSpecifier, crate::source::ResolveError> {
-        match mode {
-          ResolutionMode::Execution => {
+        match resolution_kind {
+          ResolutionKind::Execution => {
             Ok(resolve_import(specifier_text, &referrer_range.specifier)?)
           }
-          ResolutionMode::Types => Err(crate::source::ResolveError::Other(
+          ResolutionKind::Types => Err(crate::source::ResolveError::Other(
             anyhow::anyhow!("Failed."),
           )),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1283,9 +1283,8 @@ console.log(a);
       module_name: &str,
       range: &Range,
     ) {
-      let Range {
-        specifier, start, ..
-      } = range;
+      let specifier = &range.specifier;
+      let start = range.range.start;
       let line = start.line + 1;
       let column = start.character;
       log::warn!("Warning: Resolving \"{module_name}\" as \"node:{module_name}\" at {specifier}:{line}:{column}. If you want to use a built-in Node module, add a \"node:\" prefix.");
@@ -1921,13 +1920,15 @@ export const foo = 'bar';"#,
         specifier: ModuleSpecifier::parse("file:///test01.d.ts").unwrap(),
         range: Range {
           specifier: ModuleSpecifier::parse("file:///test01.js").unwrap(),
-          start: Position {
-            line: 0,
-            character: 21
-          },
-          end: Position {
-            line: 0,
-            character: 36
+          range: PositionRange {
+            start: Position {
+              line: 0,
+              character: 21
+            },
+            end: Position {
+              line: 0,
+              character: 36
+            },
           },
           mode: None,
         }
@@ -1976,13 +1977,15 @@ export const foo = 'bar';"#,
         specifier: ModuleSpecifier::parse("file:///test01.d.ts").unwrap(),
         range: Range {
           specifier: ModuleSpecifier::parse("file:///test01.js").unwrap(),
-          start: Position {
-            line: 0,
-            character: 18
-          },
-          end: Position {
-            line: 0,
-            character: 33
+          range: PositionRange {
+            start: Position {
+              line: 0,
+              character: 18
+            },
+            end: Position {
+              line: 0,
+              character: 33
+            },
           },
           mode: None,
         }
@@ -2107,8 +2110,7 @@ export const foo = 'bar';"#,
           "file:///a.d.ts",
           Some(Range {
             specifier: ModuleSpecifier::parse("file:///package.json").unwrap(),
-            start: Position::zeroed(),
-            end: Position::zeroed(),
+            range: PositionRange::zeroed(),
             mode: None,
           }),
         ),
@@ -2136,8 +2138,7 @@ export const foo = 'bar';"#,
         specifier: ModuleSpecifier::parse("file:///a.d.ts").unwrap(),
         range: Range {
           specifier: ModuleSpecifier::parse("file:///package.json").unwrap(),
-          start: Position::zeroed(),
-          end: Position::zeroed(),
+          range: PositionRange::zeroed(),
           mode: None,
         }
       }
@@ -3332,8 +3333,10 @@ export const foo = 'bar';"#,
             specifier: ModuleSpecifier::parse("file:///a/a.js").unwrap(),
             range: Range {
               specifier: specifier.clone(),
-              start: Position::new(2, 22),
-              end: Position::new(2, 30),
+              range: PositionRange {
+                start: Position::new(2, 22),
+                end: Position::new(2, 30),
+              },
               mode: Some(ResolutionMode::Import),
             },
           })),
@@ -3341,8 +3344,10 @@ export const foo = 'bar';"#,
             specifier: ModuleSpecifier::parse("file:///a/a.d.ts").unwrap(),
             range: Range {
               specifier: specifier.clone(),
-              start: Position::new(1, 19),
-              end: Position::new(1, 29),
+              range: PositionRange {
+                start: Position::new(1, 19),
+                end: Position::new(1, 29),
+              },
               mode: Some(ResolutionMode::Import),
             },
           })),
@@ -3352,8 +3357,10 @@ export const foo = 'bar';"#,
             kind: ImportKind::Es,
             specifier_range: Range {
               specifier: specifier.clone(),
-              start: Position::new(2, 22),
-              end: Position::new(2, 30),
+              range: PositionRange {
+                start: Position::new(2, 22),
+                end: Position::new(2, 30),
+              },
               mode: Some(ResolutionMode::Import),
             },
             is_dynamic: false,

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -367,26 +367,26 @@ pub enum ResolveError {
 
 /// The kind of resolution currently being done by deno_graph.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum ResolutionMode {
+pub enum ResolutionKind {
   /// Resolving for code that will be executed.
   Execution,
   /// Resolving for code that will be used for type information.
   Types,
 }
 
-impl ResolutionMode {
+impl ResolutionKind {
   pub fn is_types(&self) -> bool {
-    *self == ResolutionMode::Types
+    *self == ResolutionKind::Types
   }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub enum ResolutionKind {
+pub enum ResolutionMode {
   /// Resolving as an ES module.
-  Esm,
+  Import,
   /// Resolving as a CJS module.
-  Cjs,
+  Require,
 }
 
 /// A trait which allows the module graph to resolve specifiers and type only
@@ -421,7 +421,7 @@ pub trait Resolver: fmt::Debug {
     &self,
     specifier_text: &str,
     referrer_range: &Range,
-    _mode: ResolutionMode,
+    _kind: ResolutionKind,
   ) -> Result<ModuleSpecifier, ResolveError> {
     Ok(resolve_import(specifier_text, &referrer_range.specifier)?)
   }
@@ -926,7 +926,7 @@ pub mod tests {
       &self,
       specifier: &str,
       referrer_range: &Range,
-      _mode: ResolutionMode,
+      _resolution_kind: ResolutionKind,
     ) -> Result<ModuleSpecifier, ResolveError> {
       if let Some(map) = self.map.get(&referrer_range.specifier) {
         if let Some(resolved_specifier) = map.get(specifier) {

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -366,7 +366,7 @@ pub enum ResolveError {
 }
 
 /// The kind of resolution currently being done by deno_graph.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ResolutionMode {
   /// Resolving for code that will be executed.
   Execution,
@@ -378,6 +378,15 @@ impl ResolutionMode {
   pub fn is_types(&self) -> bool {
     *self == ResolutionMode::Types
   }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ResolutionKind {
+  /// Resolving as an ES module.
+  Esm,
+  /// Resolving as a CJS module.
+  Cjs,
 }
 
 /// A trait which allows the module graph to resolve specifiers and type only

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -606,7 +606,7 @@ impl deno_graph::source::Resolver for WorkspaceMemberResolver {
     &self,
     specifier_text: &str,
     referrer_range: &deno_graph::Range,
-    _mode: deno_graph::source::ResolutionMode,
+    _mode: deno_graph::source::ResolutionKind,
   ) -> Result<deno_ast::ModuleSpecifier, deno_graph::source::ResolveError> {
     if let Ok(package_ref) = JsrPackageReqReference::from_str(specifier_text) {
       for workspace_member in &self.members {

--- a/tests/specs/graph/checksums/invalid.txt
+++ b/tests/specs/graph/checksums/invalid.txt
@@ -22,6 +22,7 @@ import 'https://localhost/mod.ts'
           "specifier": "https://localhost/mod.ts",
           "code": {
             "specifier": "https://localhost/mod.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/checksums/invalid.txt
+++ b/tests/specs/graph/checksums/invalid.txt
@@ -22,7 +22,7 @@ import 'https://localhost/mod.ts'
           "specifier": "https://localhost/mod.ts",
           "code": {
             "specifier": "https://localhost/mod.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/checksums/jsr_pkg_fills.txt
+++ b/tests/specs/graph/checksums/jsr_pkg_fills.txt
@@ -34,7 +34,7 @@ console.log('HI');
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/checksums/jsr_pkg_fills.txt
+++ b/tests/specs/graph/checksums/jsr_pkg_fills.txt
@@ -34,6 +34,7 @@ console.log('HI');
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/checksums/jsr_pkg_invalid.txt
+++ b/tests/specs/graph/checksums/jsr_pkg_invalid.txt
@@ -36,6 +36,7 @@ console.log('HI');
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/checksums/jsr_pkg_invalid.txt
+++ b/tests/specs/graph/checksums/jsr_pkg_invalid.txt
@@ -36,7 +36,7 @@ console.log('HI');
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/checksums/jsr_pkg_valid.txt
+++ b/tests/specs/graph/checksums/jsr_pkg_valid.txt
@@ -36,6 +36,7 @@ console.log('HI');
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/checksums/jsr_pkg_valid.txt
+++ b/tests/specs/graph/checksums/jsr_pkg_valid.txt
@@ -36,7 +36,7 @@ console.log('HI');
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/checksums/redirect_with_checksum.txt
+++ b/tests/specs/graph/checksums/redirect_with_checksum.txt
@@ -25,7 +25,7 @@ import 'https://localhost/mod.ts'
           "specifier": "https://localhost/mod.ts",
           "code": {
             "specifier": "https://localhost/mod.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/checksums/redirect_with_checksum.txt
+++ b/tests/specs/graph/checksums/redirect_with_checksum.txt
@@ -25,6 +25,7 @@ import 'https://localhost/mod.ts'
           "specifier": "https://localhost/mod.ts",
           "code": {
             "specifier": "https://localhost/mod.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/checksums/redirected_to_invalid.txt
+++ b/tests/specs/graph/checksums/redirected_to_invalid.txt
@@ -25,7 +25,7 @@ import 'https://localhost/mod.ts'
           "specifier": "https://localhost/mod.ts",
           "code": {
             "specifier": "https://localhost/mod.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/checksums/redirected_to_invalid.txt
+++ b/tests/specs/graph/checksums/redirected_to_invalid.txt
@@ -25,6 +25,7 @@ import 'https://localhost/mod.ts'
           "specifier": "https://localhost/mod.ts",
           "code": {
             "specifier": "https://localhost/mod.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/checksums/valid.txt
+++ b/tests/specs/graph/checksums/valid.txt
@@ -22,6 +22,7 @@ import 'https://localhost/mod.ts'
           "specifier": "https://localhost/mod.ts",
           "code": {
             "specifier": "https://localhost/mod.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/checksums/valid.txt
+++ b/tests/specs/graph/checksums/valid.txt
@@ -22,7 +22,7 @@ import 'https://localhost/mod.ts'
           "specifier": "https://localhost/mod.ts",
           "code": {
             "specifier": "https://localhost/mod.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/cjs/basic.txt
+++ b/tests/specs/graph/cjs/basic.txt
@@ -35,7 +35,7 @@ module.exports = 5;
           "specifier": "./final.js",
           "code": {
             "specifier": "file:///final.js",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -52,7 +52,7 @@ module.exports = 5;
           "specifier": "node:module",
           "code": {
             "specifier": "node:module",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -69,7 +69,7 @@ module.exports = 5;
           "specifier": "./final_cjs.cjs",
           "code": {
             "specifier": "file:///final_cjs.cjs",
-            "mode": "require",
+            "resolutionMode": "require",
             "span": {
               "start": {
                 "line": 5,
@@ -95,7 +95,7 @@ module.exports = 5;
           "specifier": "./other.cjs",
           "code": {
             "specifier": "file:///other.cjs",
-            "mode": "require",
+            "resolutionMode": "require",
             "span": {
               "start": {
                 "line": 0,
@@ -133,7 +133,7 @@ module.exports = 5;
           "specifier": "./file.cjs",
           "code": {
             "specifier": "file:///file.cjs",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -158,7 +158,7 @@ module.exports = 5;
           "specifier": "./esm.js",
           "code": {
             "specifier": "file:///esm.js",
-            "mode": "require",
+            "resolutionMode": "require",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/cjs/basic.txt
+++ b/tests/specs/graph/cjs/basic.txt
@@ -35,6 +35,7 @@ module.exports = 5;
           "specifier": "./final.js",
           "code": {
             "specifier": "file:///final.js",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -51,6 +52,7 @@ module.exports = 5;
           "specifier": "node:module",
           "code": {
             "specifier": "node:module",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -67,6 +69,7 @@ module.exports = 5;
           "specifier": "./final_cjs.cjs",
           "code": {
             "specifier": "file:///final_cjs.cjs",
+            "mode": "require",
             "span": {
               "start": {
                 "line": 5,
@@ -92,6 +95,7 @@ module.exports = 5;
           "specifier": "./other.cjs",
           "code": {
             "specifier": "file:///other.cjs",
+            "mode": "require",
             "span": {
               "start": {
                 "line": 0,
@@ -129,6 +133,7 @@ module.exports = 5;
           "specifier": "./file.cjs",
           "code": {
             "specifier": "file:///file.cjs",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -153,6 +158,7 @@ module.exports = 5;
           "specifier": "./esm.js",
           "code": {
             "specifier": "file:///esm.js",
+            "mode": "require",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/cjs/file_export.txt
+++ b/tests/specs/graph/cjs/file_export.txt
@@ -21,7 +21,7 @@ export class Test {}
           "specifier": "./file.cjs",
           "code": {
             "specifier": "file:///file.cjs",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/cjs/file_export.txt
+++ b/tests/specs/graph/cjs/file_export.txt
@@ -21,6 +21,7 @@ export class Test {}
           "specifier": "./file.cjs",
           "code": {
             "specifier": "file:///file.cjs",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/cjs/remote.txt
+++ b/tests/specs/graph/cjs/remote.txt
@@ -18,6 +18,7 @@ module.exports.test = {};
           "specifier": "https://deno.land/file.cjs",
           "code": {
             "specifier": "https://deno.land/file.cjs",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/cjs/remote.txt
+++ b/tests/specs/graph/cjs/remote.txt
@@ -18,7 +18,7 @@ module.exports.test = {};
           "specifier": "https://deno.land/file.cjs",
           "code": {
             "specifier": "https://deno.land/file.cjs",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/dynamic_json_ignores_assert.txt
+++ b/tests/specs/graph/dynamic_json_ignores_assert.txt
@@ -23,6 +23,7 @@ const a = await import("./a.json");
           "specifier": "./a.json",
           "code": {
             "specifier": "file:///a.json",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/dynamic_json_ignores_assert.txt
+++ b/tests/specs/graph/dynamic_json_ignores_assert.txt
@@ -23,7 +23,7 @@ const a = await import("./a.json");
           "specifier": "./a.json",
           "code": {
             "specifier": "file:///a.json",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/auto_accessors.txt
+++ b/tests/specs/graph/fast_check/auto_accessors.txt
@@ -37,7 +37,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/auto_accessors.txt
+++ b/tests/specs/graph/fast_check/auto_accessors.txt
@@ -37,6 +37,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/basic.txt
+++ b/tests/specs/graph/fast_check/basic.txt
@@ -70,7 +70,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -95,7 +95,7 @@ import 'jsr:@scope/a'
           "specifier": "./a4.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a4.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 4,
@@ -112,7 +112,7 @@ import 'jsr:@scope/a'
           "specifier": "./a6.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a6.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 5,
@@ -149,7 +149,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -181,7 +181,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/a.ts:
     "./a4.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a4.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 4,
@@ -197,7 +197,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/a.ts:
     "./a6.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a6.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 5,
@@ -246,7 +246,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./a.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/basic.txt
+++ b/tests/specs/graph/fast_check/basic.txt
@@ -70,6 +70,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -94,6 +95,7 @@ import 'jsr:@scope/a'
           "specifier": "./a4.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a4.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 4,
@@ -110,6 +112,7 @@ import 'jsr:@scope/a'
           "specifier": "./a6.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a6.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 5,
@@ -146,6 +149,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -177,6 +181,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/a.ts:
     "./a4.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a4.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 4,
@@ -192,6 +197,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/a.ts:
     "./a6.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a6.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 5,
@@ -240,6 +246,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./a.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/cache__basic.txt
+++ b/tests/specs/graph/fast_check/cache__basic.txt
@@ -78,7 +78,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -103,7 +103,7 @@ import 'jsr:@scope/a'
           "specifier": "./a4.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a4.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 4,
@@ -120,7 +120,7 @@ import 'jsr:@scope/a'
           "specifier": "./a6.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a6.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 5,
@@ -137,7 +137,7 @@ import 'jsr:@scope/a'
           "specifier": "./not_in_output.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/not_in_output.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 7,
@@ -174,7 +174,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -212,7 +212,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/a.ts:
     "./a4.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a4.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 4,
@@ -228,7 +228,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/a.ts:
     "./a6.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a6.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 5,
@@ -264,7 +264,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./a.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/cache__basic.txt
+++ b/tests/specs/graph/fast_check/cache__basic.txt
@@ -78,6 +78,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -102,6 +103,7 @@ import 'jsr:@scope/a'
           "specifier": "./a4.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a4.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 4,
@@ -118,6 +120,7 @@ import 'jsr:@scope/a'
           "specifier": "./a6.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a6.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 5,
@@ -134,6 +137,7 @@ import 'jsr:@scope/a'
           "specifier": "./not_in_output.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/not_in_output.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 7,
@@ -170,6 +174,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -207,6 +212,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/a.ts:
     "./a4.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a4.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 4,
@@ -222,6 +228,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/a.ts:
     "./a6.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a6.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 5,
@@ -257,6 +264,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./a.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/cache__diagnostic.txt
+++ b/tests/specs/graph/fast_check/cache__diagnostic.txt
@@ -39,6 +39,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -81,6 +82,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -97,6 +99,7 @@ import 'jsr:@scope/a'
           "specifier": "./b.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -113,6 +116,7 @@ import 'jsr:@scope/a'
           "specifier": "./c.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/c.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 2,

--- a/tests/specs/graph/fast_check/cache__diagnostic.txt
+++ b/tests/specs/graph/fast_check/cache__diagnostic.txt
@@ -39,7 +39,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -82,7 +82,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -99,7 +99,7 @@ import 'jsr:@scope/a'
           "specifier": "./b.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -116,7 +116,7 @@ import 'jsr:@scope/a'
           "specifier": "./c.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/c.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 2,

--- a/tests/specs/graph/fast_check/cache__diagnostic_deep.txt
+++ b/tests/specs/graph/fast_check/cache__diagnostic_deep.txt
@@ -36,6 +36,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -60,6 +61,7 @@ import 'jsr:@scope/a'
           "specifier": "./b.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -84,6 +86,7 @@ import 'jsr:@scope/a'
           "specifier": "./c.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/c.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -114,6 +117,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/cache__diagnostic_deep.txt
+++ b/tests/specs/graph/fast_check/cache__diagnostic_deep.txt
@@ -36,7 +36,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -61,7 +61,7 @@ import 'jsr:@scope/a'
           "specifier": "./b.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -86,7 +86,7 @@ import 'jsr:@scope/a'
           "specifier": "./c.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/c.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -117,7 +117,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/cache__diagnostic_multiple_exports.txt
+++ b/tests/specs/graph/fast_check/cache__diagnostic_multiple_exports.txt
@@ -44,7 +44,7 @@ import 'jsr:@scope/a/c'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 4,
@@ -61,7 +61,7 @@ import 'jsr:@scope/a/c'
           "specifier": "jsr:@scope/a/c",
           "code": {
             "specifier": "jsr:@scope/a/c",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 5,
@@ -104,7 +104,7 @@ import 'jsr:@scope/a/c'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -121,7 +121,7 @@ import 'jsr:@scope/a/c'
           "specifier": "./b.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -138,7 +138,7 @@ import 'jsr:@scope/a/c'
           "specifier": "./c.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/c.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 2,

--- a/tests/specs/graph/fast_check/cache__diagnostic_multiple_exports.txt
+++ b/tests/specs/graph/fast_check/cache__diagnostic_multiple_exports.txt
@@ -44,6 +44,7 @@ import 'jsr:@scope/a/c'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 4,
@@ -60,6 +61,7 @@ import 'jsr:@scope/a/c'
           "specifier": "jsr:@scope/a/c",
           "code": {
             "specifier": "jsr:@scope/a/c",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 5,
@@ -102,6 +104,7 @@ import 'jsr:@scope/a/c'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -118,6 +121,7 @@ import 'jsr:@scope/a/c'
           "specifier": "./b.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -134,6 +138,7 @@ import 'jsr:@scope/a/c'
           "specifier": "./c.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/c.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 2,

--- a/tests/specs/graph/fast_check/cache__diagnostic_then_nested_dep.txt
+++ b/tests/specs/graph/fast_check/cache__diagnostic_then_nested_dep.txt
@@ -60,6 +60,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -84,6 +85,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/b@1",
           "code": {
             "specifier": "jsr:@scope/b@1",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -100,6 +102,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/c@1",
           "code": {
             "specifier": "jsr:@scope/c@1",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 6,
@@ -124,6 +127,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 4,

--- a/tests/specs/graph/fast_check/cache__diagnostic_then_nested_dep.txt
+++ b/tests/specs/graph/fast_check/cache__diagnostic_then_nested_dep.txt
@@ -60,7 +60,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -85,7 +85,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/b@1",
           "code": {
             "specifier": "jsr:@scope/b@1",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -102,7 +102,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/c@1",
           "code": {
             "specifier": "jsr:@scope/c@1",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 6,
@@ -127,7 +127,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 4,

--- a/tests/specs/graph/fast_check/class_ctors.txt
+++ b/tests/specs/graph/fast_check/class_ctors.txt
@@ -97,6 +97,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_ctors.txt
+++ b/tests/specs/graph/fast_check/class_ctors.txt
@@ -97,7 +97,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_getters_and_setters.txt
+++ b/tests/specs/graph/fast_check/class_getters_and_setters.txt
@@ -31,7 +31,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_getters_and_setters.txt
+++ b/tests/specs/graph/fast_check/class_getters_and_setters.txt
@@ -31,6 +31,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_member_ref_additional_prop_on_member.txt
+++ b/tests/specs/graph/fast_check/class_member_ref_additional_prop_on_member.txt
@@ -29,7 +29,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_member_ref_additional_prop_on_member.txt
+++ b/tests/specs/graph/fast_check/class_member_ref_additional_prop_on_member.txt
@@ -29,6 +29,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_member_ref_found.txt
+++ b/tests/specs/graph/fast_check/class_member_ref_found.txt
@@ -28,7 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_member_ref_found.txt
+++ b/tests/specs/graph/fast_check/class_member_ref_found.txt
@@ -28,6 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_member_ref_not_found.txt
+++ b/tests/specs/graph/fast_check/class_member_ref_not_found.txt
@@ -28,7 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_member_ref_not_found.txt
+++ b/tests/specs/graph/fast_check/class_member_ref_not_found.txt
@@ -28,6 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_methods_with_ts_private.txt
+++ b/tests/specs/graph/fast_check/class_methods_with_ts_private.txt
@@ -105,7 +105,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_methods_with_ts_private.txt
+++ b/tests/specs/graph/fast_check/class_methods_with_ts_private.txt
@@ -105,6 +105,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_optional_method.txt
+++ b/tests/specs/graph/fast_check/class_optional_method.txt
@@ -29,7 +29,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_optional_method.txt
+++ b/tests/specs/graph/fast_check/class_optional_method.txt
@@ -29,6 +29,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_overrides.txt
+++ b/tests/specs/graph/fast_check/class_overrides.txt
@@ -49,6 +49,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_overrides.txt
+++ b/tests/specs/graph/fast_check/class_overrides.txt
@@ -49,7 +49,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_params_initializers.txt
+++ b/tests/specs/graph/fast_check/class_params_initializers.txt
@@ -48,7 +48,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_params_initializers.txt
+++ b/tests/specs/graph/fast_check/class_params_initializers.txt
@@ -48,6 +48,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_properties.txt
+++ b/tests/specs/graph/fast_check/class_properties.txt
@@ -60,7 +60,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_properties.txt
+++ b/tests/specs/graph/fast_check/class_properties.txt
@@ -60,6 +60,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_properties_computed.txt
+++ b/tests/specs/graph/fast_check/class_properties_computed.txt
@@ -29,7 +29,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_properties_computed.txt
+++ b/tests/specs/graph/fast_check/class_properties_computed.txt
@@ -29,6 +29,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_properties_leavable.txt
+++ b/tests/specs/graph/fast_check/class_properties_leavable.txt
@@ -34,6 +34,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -64,6 +65,7 @@ import 'jsr:@scope/a'
           "specifier": "./b.ts",
           "type": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -103,6 +105,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./b.ts": {
       "type": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/class_properties_leavable.txt
+++ b/tests/specs/graph/fast_check/class_properties_leavable.txt
@@ -34,7 +34,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -65,7 +65,7 @@ import 'jsr:@scope/a'
           "specifier": "./b.ts",
           "type": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -105,7 +105,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./b.ts": {
       "type": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/class_properties_with_ts_private.txt
+++ b/tests/specs/graph/fast_check/class_properties_with_ts_private.txt
@@ -32,6 +32,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_properties_with_ts_private.txt
+++ b/tests/specs/graph/fast_check/class_properties_with_ts_private.txt
@@ -32,7 +32,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_static_member_ref_found.txt
+++ b/tests/specs/graph/fast_check/class_static_member_ref_found.txt
@@ -28,7 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_static_member_ref_found.txt
+++ b/tests/specs/graph/fast_check/class_static_member_ref_found.txt
@@ -28,6 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_static_member_ref_not_found.txt
+++ b/tests/specs/graph/fast_check/class_static_member_ref_not_found.txt
@@ -28,7 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_static_member_ref_not_found.txt
+++ b/tests/specs/graph/fast_check/class_static_member_ref_not_found.txt
@@ -28,6 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_super.txt
+++ b/tests/specs/graph/fast_check/class_super.txt
@@ -40,7 +40,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_super.txt
+++ b/tests/specs/graph/fast_check/class_super.txt
@@ -40,6 +40,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_super_unsupported.txt
+++ b/tests/specs/graph/fast_check/class_super_unsupported.txt
@@ -27,7 +27,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/class_super_unsupported.txt
+++ b/tests/specs/graph/fast_check/class_super_unsupported.txt
@@ -27,6 +27,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/comments.txt
+++ b/tests/specs/graph/fast_check/comments.txt
@@ -26,7 +26,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/comments.txt
+++ b/tests/specs/graph/fast_check/comments.txt
@@ -26,6 +26,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/const_infer_function_missing_return.txt
+++ b/tests/specs/graph/fast_check/const_infer_function_missing_return.txt
@@ -23,6 +23,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/const_infer_function_missing_return.txt
+++ b/tests/specs/graph/fast_check/const_infer_function_missing_return.txt
@@ -23,7 +23,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/cross_file_ref_aliased.txt
+++ b/tests/specs/graph/fast_check/cross_file_ref_aliased.txt
@@ -39,7 +39,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -70,7 +70,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -95,7 +95,7 @@ import 'jsr:@scope/a'
           "specifier": "./b.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -112,7 +112,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -154,7 +154,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/b.ts:
     "./a.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 0,
@@ -177,7 +177,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./b.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/cross_file_ref_aliased.txt
+++ b/tests/specs/graph/fast_check/cross_file_ref_aliased.txt
@@ -39,6 +39,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -69,6 +70,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -93,6 +95,7 @@ import 'jsr:@scope/a'
           "specifier": "./b.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -109,6 +112,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -150,6 +154,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/b.ts:
     "./a.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 0,
@@ -172,6 +177,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./b.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/cross_file_ref_import_type.txt
+++ b/tests/specs/graph/fast_check/cross_file_ref_import_type.txt
@@ -27,6 +27,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -57,6 +58,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "type": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -100,6 +102,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./a.ts": {
       "type": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/cross_file_ref_import_type.txt
+++ b/tests/specs/graph/fast_check/cross_file_ref_import_type.txt
@@ -27,7 +27,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -58,7 +58,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "type": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -102,7 +102,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./a.ts": {
       "type": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/cross_file_ref_import_type_qualified.txt
+++ b/tests/specs/graph/fast_check/cross_file_ref_import_type_qualified.txt
@@ -27,6 +27,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -57,6 +58,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "type": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -96,6 +98,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./a.ts": {
       "type": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/cross_file_ref_import_type_qualified.txt
+++ b/tests/specs/graph/fast_check/cross_file_ref_import_type_qualified.txt
@@ -27,7 +27,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -58,7 +58,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "type": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -98,7 +98,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./a.ts": {
       "type": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/cross_file_ref_module.txt
+++ b/tests/specs/graph/fast_check/cross_file_ref_module.txt
@@ -41,7 +41,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -72,7 +72,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -97,7 +97,7 @@ import 'jsr:@scope/a'
           "specifier": "./b.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -114,7 +114,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -158,7 +158,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/b.ts:
     "./a.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 0,
@@ -181,7 +181,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./b.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/cross_file_ref_module.txt
+++ b/tests/specs/graph/fast_check/cross_file_ref_module.txt
@@ -41,6 +41,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -71,6 +72,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -95,6 +97,7 @@ import 'jsr:@scope/a'
           "specifier": "./b.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -111,6 +114,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -154,6 +158,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/b.ts:
     "./a.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 0,
@@ -176,6 +181,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./b.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/cross_file_ref_module_not_found.txt
+++ b/tests/specs/graph/fast_check/cross_file_ref_module_not_found.txt
@@ -40,7 +40,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -71,7 +71,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -96,7 +96,7 @@ import 'jsr:@scope/a'
           "specifier": "./b.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -113,7 +113,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 1,

--- a/tests/specs/graph/fast_check/cross_file_ref_module_not_found.txt
+++ b/tests/specs/graph/fast_check/cross_file_ref_module_not_found.txt
@@ -40,6 +40,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -70,6 +71,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -94,6 +96,7 @@ import 'jsr:@scope/a'
           "specifier": "./b.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -110,6 +113,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 1,

--- a/tests/specs/graph/fast_check/default_export_expr_leavable.txt
+++ b/tests/specs/graph/fast_check/default_export_expr_leavable.txt
@@ -33,7 +33,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/default_export_expr_leavable.txt
+++ b/tests/specs/graph/fast_check/default_export_expr_leavable.txt
@@ -33,6 +33,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/default_export_expr_var.txt
+++ b/tests/specs/graph/fast_check/default_export_expr_var.txt
@@ -30,6 +30,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/default_export_expr_var.txt
+++ b/tests/specs/graph/fast_check/default_export_expr_var.txt
@@ -30,7 +30,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/diagnostic_tabs.txt
+++ b/tests/specs/graph/fast_check/diagnostic_tabs.txt
@@ -29,7 +29,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/diagnostic_tabs.txt
+++ b/tests/specs/graph/fast_check/diagnostic_tabs.txt
@@ -29,6 +29,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/dts.txt
+++ b/tests/specs/graph/fast_check/dts.txt
@@ -50,6 +50,7 @@ import 'jsr:@scope/a/foo'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -66,6 +67,7 @@ import 'jsr:@scope/a/foo'
           "specifier": "jsr:@scope/a/foo",
           "code": {
             "specifier": "jsr:@scope/a/foo",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 1,

--- a/tests/specs/graph/fast_check/dts.txt
+++ b/tests/specs/graph/fast_check/dts.txt
@@ -50,7 +50,7 @@ import 'jsr:@scope/a/foo'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -67,7 +67,7 @@ import 'jsr:@scope/a/foo'
           "specifier": "jsr:@scope/a/foo",
           "code": {
             "specifier": "jsr:@scope/a/foo",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 1,

--- a/tests/specs/graph/fast_check/entrypoint_js.txt
+++ b/tests/specs/graph/fast_check/entrypoint_js.txt
@@ -27,7 +27,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/entrypoint_js.txt
+++ b/tests/specs/graph/fast_check/entrypoint_js.txt
@@ -27,6 +27,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/entrypoint_js_with_ts_decl.txt
+++ b/tests/specs/graph/fast_check/entrypoint_js_with_ts_decl.txt
@@ -29,7 +29,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/entrypoint_js_with_ts_decl.txt
+++ b/tests/specs/graph/fast_check/entrypoint_js_with_ts_decl.txt
@@ -29,6 +29,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/enums.txt
+++ b/tests/specs/graph/fast_check/enums.txt
@@ -62,6 +62,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/enums.txt
+++ b/tests/specs/graph/fast_check/enums.txt
@@ -62,7 +62,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/expando_props/basic.txt
+++ b/tests/specs/graph/fast_check/expando_props/basic.txt
@@ -29,7 +29,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/expando_props/basic.txt
+++ b/tests/specs/graph/fast_check/expando_props/basic.txt
@@ -29,6 +29,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/expando_props/funcs_ref_private_name.txt
+++ b/tests/specs/graph/fast_check/expando_props/funcs_ref_private_name.txt
@@ -28,7 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/expando_props/funcs_ref_private_name.txt
+++ b/tests/specs/graph/fast_check/expando_props/funcs_ref_private_name.txt
@@ -28,6 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/expando_props/nested_func_same_name.txt
+++ b/tests/specs/graph/fast_check/expando_props/nested_func_same_name.txt
@@ -31,7 +31,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/expando_props/nested_func_same_name.txt
+++ b/tests/specs/graph/fast_check/expando_props/nested_func_same_name.txt
@@ -31,6 +31,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/expando_props/nested_namespace.txt
+++ b/tests/specs/graph/fast_check/expando_props/nested_namespace.txt
@@ -32,6 +32,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/expando_props/nested_namespace.txt
+++ b/tests/specs/graph/fast_check/expando_props/nested_namespace.txt
@@ -32,7 +32,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/expando_props/other_namespaces.txt
+++ b/tests/specs/graph/fast_check/expando_props/other_namespaces.txt
@@ -52,7 +52,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -89,7 +89,7 @@ import 'jsr:@scope/a'
           "specifier": "./b.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 10,
@@ -106,7 +106,7 @@ import 'jsr:@scope/a'
           "specifier": "./c.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/c.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 11,
@@ -166,7 +166,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./b.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 10,
@@ -182,7 +182,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./c.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/c.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 11,

--- a/tests/specs/graph/fast_check/expando_props/other_namespaces.txt
+++ b/tests/specs/graph/fast_check/expando_props/other_namespaces.txt
@@ -52,6 +52,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -88,6 +89,7 @@ import 'jsr:@scope/a'
           "specifier": "./b.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 10,
@@ -104,6 +106,7 @@ import 'jsr:@scope/a'
           "specifier": "./c.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/c.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 11,
@@ -163,6 +166,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./b.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 10,
@@ -178,6 +182,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./c.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/c.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 11,

--- a/tests/specs/graph/fast_check/expando_props/same_name_local_var_ref.txt
+++ b/tests/specs/graph/fast_check/expando_props/same_name_local_var_ref.txt
@@ -30,6 +30,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/expando_props/same_name_local_var_ref.txt
+++ b/tests/specs/graph/fast_check/expando_props/same_name_local_var_ref.txt
@@ -30,7 +30,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/expando_props/same_name_namespace_export.txt
+++ b/tests/specs/graph/fast_check/expando_props/same_name_namespace_export.txt
@@ -34,7 +34,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/expando_props/same_name_namespace_export.txt
+++ b/tests/specs/graph/fast_check/expando_props/same_name_namespace_export.txt
@@ -34,6 +34,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/expando_props/same_name_property_ok.txt
+++ b/tests/specs/graph/fast_check/expando_props/same_name_property_ok.txt
@@ -34,7 +34,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/expando_props/same_name_property_ok.txt
+++ b/tests/specs/graph/fast_check/expando_props/same_name_property_ok.txt
@@ -34,6 +34,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/expando_props/ts_assertion.txt
+++ b/tests/specs/graph/fast_check/expando_props/ts_assertion.txt
@@ -28,7 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/expando_props/ts_assertion.txt
+++ b/tests/specs/graph/fast_check/expando_props/ts_assertion.txt
@@ -28,6 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/export_equals.txt
+++ b/tests/specs/graph/fast_check/export_equals.txt
@@ -23,6 +23,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/export_equals.txt
+++ b/tests/specs/graph/fast_check/export_equals.txt
@@ -23,7 +23,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/function_default_before_required.txt
+++ b/tests/specs/graph/fast_check/function_default_before_required.txt
@@ -39,7 +39,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/function_default_before_required.txt
+++ b/tests/specs/graph/fast_check/function_default_before_required.txt
@@ -39,6 +39,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/functions.txt
+++ b/tests/specs/graph/fast_check/functions.txt
@@ -92,7 +92,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/functions.txt
+++ b/tests/specs/graph/fast_check/functions.txt
@@ -92,6 +92,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/global_module.txt
+++ b/tests/specs/graph/fast_check/global_module.txt
@@ -25,6 +25,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/global_module.txt
+++ b/tests/specs/graph/fast_check/global_module.txt
@@ -25,7 +25,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/import_equals.txt
+++ b/tests/specs/graph/fast_check/import_equals.txt
@@ -36,7 +36,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -67,7 +67,7 @@ import 'jsr:@scope/a'
           "specifier": "./inner.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/inner.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -105,7 +105,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./inner.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/inner.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/import_equals.txt
+++ b/tests/specs/graph/fast_check/import_equals.txt
@@ -36,6 +36,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -66,6 +67,7 @@ import 'jsr:@scope/a'
           "specifier": "./inner.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/inner.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -103,6 +105,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./inner.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/inner.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/inferred_unique_symbols.txt
+++ b/tests/specs/graph/fast_check/inferred_unique_symbols.txt
@@ -29,7 +29,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/inferred_unique_symbols.txt
+++ b/tests/specs/graph/fast_check/inferred_unique_symbols.txt
@@ -29,6 +29,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/inferred_unique_symbols__not_global.txt
+++ b/tests/specs/graph/fast_check/inferred_unique_symbols__not_global.txt
@@ -32,6 +32,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/inferred_unique_symbols__not_global.txt
+++ b/tests/specs/graph/fast_check/inferred_unique_symbols__not_global.txt
@@ -32,7 +32,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/init_idents_and_members.txt
+++ b/tests/specs/graph/fast_check/init_idents_and_members.txt
@@ -64,7 +64,7 @@ import 'jsr:@scope/b'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -81,7 +81,7 @@ import 'jsr:@scope/b'
           "specifier": "jsr:@scope/b",
           "code": {
             "specifier": "jsr:@scope/b",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 1,

--- a/tests/specs/graph/fast_check/init_idents_and_members.txt
+++ b/tests/specs/graph/fast_check/init_idents_and_members.txt
@@ -64,6 +64,7 @@ import 'jsr:@scope/b'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -80,6 +81,7 @@ import 'jsr:@scope/b'
           "specifier": "jsr:@scope/b",
           "code": {
             "specifier": "jsr:@scope/b",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 1,

--- a/tests/specs/graph/fast_check/interface_with_export.txt
+++ b/tests/specs/graph/fast_check/interface_with_export.txt
@@ -47,7 +47,7 @@ it.ignore();
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/interface_with_export.txt
+++ b/tests/specs/graph/fast_check/interface_with_export.txt
@@ -47,6 +47,7 @@ it.ignore();
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/issue_22544.txt
+++ b/tests/specs/graph/fast_check/issue_22544.txt
@@ -33,7 +33,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/issue_22544.txt
+++ b/tests/specs/graph/fast_check/issue_22544.txt
@@ -33,6 +33,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/issue_22829.txt
+++ b/tests/specs/graph/fast_check/issue_22829.txt
@@ -44,7 +44,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -75,7 +75,7 @@ import 'jsr:@scope/a'
           "specifier": "./functions.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/functions.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -136,7 +136,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./functions.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/functions.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/issue_22829.txt
+++ b/tests/specs/graph/fast_check/issue_22829.txt
@@ -44,6 +44,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -74,6 +75,7 @@ import 'jsr:@scope/a'
           "specifier": "./functions.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/functions.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -134,6 +136,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./functions.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/functions.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/issue_23658_1.txt
+++ b/tests/specs/graph/fast_check/issue_23658_1.txt
@@ -34,7 +34,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -65,7 +65,7 @@ import 'jsr:@scope/a'
           "specifier": "./base.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/base.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -105,7 +105,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./base.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/base.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/issue_23658_1.txt
+++ b/tests/specs/graph/fast_check/issue_23658_1.txt
@@ -34,6 +34,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -64,6 +65,7 @@ import 'jsr:@scope/a'
           "specifier": "./base.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/base.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -103,6 +105,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./base.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/base.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/issue_23658_2.txt
+++ b/tests/specs/graph/fast_check/issue_23658_2.txt
@@ -39,7 +39,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -76,7 +76,7 @@ import 'jsr:@scope/a'
           "specifier": "./base.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/base.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -93,7 +93,7 @@ import 'jsr:@scope/a'
           "specifier": "./interface.ts",
           "type": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/interface.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -141,7 +141,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./base.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/base.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 0,
@@ -157,7 +157,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./interface.ts": {
       "type": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/interface.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 1,

--- a/tests/specs/graph/fast_check/issue_23658_2.txt
+++ b/tests/specs/graph/fast_check/issue_23658_2.txt
@@ -39,6 +39,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -75,6 +76,7 @@ import 'jsr:@scope/a'
           "specifier": "./base.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/base.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -91,6 +93,7 @@ import 'jsr:@scope/a'
           "specifier": "./interface.ts",
           "type": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/interface.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -138,6 +141,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./base.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/base.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 0,
@@ -153,6 +157,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./interface.ts": {
       "type": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/interface.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 1,

--- a/tests/specs/graph/fast_check/issue_jsr_580.txt
+++ b/tests/specs/graph/fast_check/issue_jsr_580.txt
@@ -39,7 +39,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/issue_jsr_580.txt
+++ b/tests/specs/graph/fast_check/issue_jsr_580.txt
@@ -39,6 +39,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/js_with_ts_decl.txt
+++ b/tests/specs/graph/fast_check/js_with_ts_decl.txt
@@ -32,7 +32,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -57,7 +57,7 @@ import 'jsr:@scope/a'
           "specifier": "./random.js",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/random.js",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -117,7 +117,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./random.d.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/random.d.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/js_with_ts_decl.txt
+++ b/tests/specs/graph/fast_check/js_with_ts_decl.txt
@@ -32,6 +32,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -56,6 +57,7 @@ import 'jsr:@scope/a'
           "specifier": "./random.js",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/random.js",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -115,6 +117,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./random.d.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/random.d.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/mapped_type.txt
+++ b/tests/specs/graph/fast_check/mapped_type.txt
@@ -51,6 +51,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/mapped_type.txt
+++ b/tests/specs/graph/fast_check/mapped_type.txt
@@ -51,7 +51,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/methods.txt
+++ b/tests/specs/graph/fast_check/methods.txt
@@ -68,7 +68,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/methods.txt
+++ b/tests/specs/graph/fast_check/methods.txt
@@ -68,6 +68,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/missing_return_type.txt
+++ b/tests/specs/graph/fast_check/missing_return_type.txt
@@ -25,6 +25,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/missing_return_type.txt
+++ b/tests/specs/graph/fast_check/missing_return_type.txt
@@ -25,7 +25,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/missing_return_type_generator.txt
+++ b/tests/specs/graph/fast_check/missing_return_type_generator.txt
@@ -24,7 +24,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/missing_return_type_generator.txt
+++ b/tests/specs/graph/fast_check/missing_return_type_generator.txt
@@ -24,6 +24,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/nested_java_script.txt
+++ b/tests/specs/graph/fast_check/nested_java_script.txt
@@ -32,6 +32,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -62,6 +63,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.js",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.js",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/nested_java_script.txt
+++ b/tests/specs/graph/fast_check/nested_java_script.txt
@@ -32,7 +32,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -63,7 +63,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.js",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.js",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/nested_java_script_decl_file.txt
+++ b/tests/specs/graph/fast_check/nested_java_script_decl_file.txt
@@ -61,7 +61,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -126,7 +126,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.js",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.js",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -143,7 +143,7 @@ import 'jsr:@scope/a'
           "specifier": "./b.js",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.js",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 5,
@@ -157,7 +157,7 @@ import 'jsr:@scope/a'
           },
           "type": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.d.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 4,
@@ -217,7 +217,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./a.d.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a.d.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 0,
@@ -233,7 +233,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./b.d.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/b.d.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 5,

--- a/tests/specs/graph/fast_check/nested_java_script_decl_file.txt
+++ b/tests/specs/graph/fast_check/nested_java_script_decl_file.txt
@@ -61,6 +61,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -125,6 +126,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.js",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.js",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -141,6 +143,7 @@ import 'jsr:@scope/a'
           "specifier": "./b.js",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.js",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 5,
@@ -154,6 +157,7 @@ import 'jsr:@scope/a'
           },
           "type": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.d.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 4,
@@ -213,6 +217,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./a.d.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a.d.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 0,
@@ -228,6 +233,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./b.d.ts": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/b.d.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 5,

--- a/tests/specs/graph/fast_check/npm_types.txt
+++ b/tests/specs/graph/fast_check/npm_types.txt
@@ -28,7 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -75,7 +75,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.js",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.js",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -118,7 +118,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./a.js": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a.js",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/npm_types.txt
+++ b/tests/specs/graph/fast_check/npm_types.txt
@@ -28,6 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -74,6 +75,7 @@ import 'jsr:@scope/a'
           "specifier": "./a.js",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.js",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -116,6 +118,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./a.js": {
       "code": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a.js",
+        "mode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/overloads.txt
+++ b/tests/specs/graph/fast_check/overloads.txt
@@ -55,6 +55,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/overloads.txt
+++ b/tests/specs/graph/fast_check/overloads.txt
@@ -55,7 +55,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/properties.txt
+++ b/tests/specs/graph/fast_check/properties.txt
@@ -39,7 +39,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/properties.txt
+++ b/tests/specs/graph/fast_check/properties.txt
@@ -39,6 +39,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/ref_obj_type.txt
+++ b/tests/specs/graph/fast_check/ref_obj_type.txt
@@ -34,7 +34,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/ref_obj_type.txt
+++ b/tests/specs/graph/fast_check/ref_obj_type.txt
@@ -34,6 +34,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/ref_var_no_type.txt
+++ b/tests/specs/graph/fast_check/ref_var_no_type.txt
@@ -28,7 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/ref_var_no_type.txt
+++ b/tests/specs/graph/fast_check/ref_var_no_type.txt
@@ -28,6 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/ref_var_type.txt
+++ b/tests/specs/graph/fast_check/ref_var_type.txt
@@ -30,6 +30,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/ref_var_type.txt
+++ b/tests/specs/graph/fast_check/ref_var_type.txt
@@ -30,7 +30,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/require.txt
+++ b/tests/specs/graph/fast_check/require.txt
@@ -27,7 +27,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -52,7 +52,7 @@ import 'jsr:@scope/a'
           "specifier": "./other.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/other.ts",
-            "mode": "require",
+            "resolutionMode": "require",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/require.txt
+++ b/tests/specs/graph/fast_check/require.txt
@@ -27,6 +27,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -51,6 +52,7 @@ import 'jsr:@scope/a'
           "specifier": "./other.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/other.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/require.txt
+++ b/tests/specs/graph/fast_check/require.txt
@@ -52,7 +52,7 @@ import 'jsr:@scope/a'
           "specifier": "./other.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/other.ts",
-            "mode": "import",
+            "mode": "require",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/ts_as_const.txt
+++ b/tests/specs/graph/fast_check/ts_as_const.txt
@@ -36,6 +36,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/ts_as_const.txt
+++ b/tests/specs/graph/fast_check/ts_as_const.txt
@@ -36,7 +36,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/ts_const_assertion.txt
+++ b/tests/specs/graph/fast_check/ts_const_assertion.txt
@@ -28,7 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/ts_const_assertion.txt
+++ b/tests/specs/graph/fast_check/ts_const_assertion.txt
@@ -28,6 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/ts_module.txt
+++ b/tests/specs/graph/fast_check/ts_module.txt
@@ -35,6 +35,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/ts_module.txt
+++ b/tests/specs/graph/fast_check/ts_module.txt
@@ -35,7 +35,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/ts_namespace_export.txt
+++ b/tests/specs/graph/fast_check/ts_namespace_export.txt
@@ -25,6 +25,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/ts_namespace_export.txt
+++ b/tests/specs/graph/fast_check/ts_namespace_export.txt
@@ -25,7 +25,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/type_assertion.txt
+++ b/tests/specs/graph/fast_check/type_assertion.txt
@@ -57,7 +57,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/type_assertion.txt
+++ b/tests/specs/graph/fast_check/type_assertion.txt
@@ -57,6 +57,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/types.txt
+++ b/tests/specs/graph/fast_check/types.txt
@@ -28,7 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/types.txt
+++ b/tests/specs/graph/fast_check/types.txt
@@ -28,6 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/unsupported_ambient_decl.txt
+++ b/tests/specs/graph/fast_check/unsupported_ambient_decl.txt
@@ -25,6 +25,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/unsupported_ambient_decl.txt
+++ b/tests/specs/graph/fast_check/unsupported_ambient_decl.txt
@@ -25,7 +25,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/unsupported_default_export_expr.txt
+++ b/tests/specs/graph/fast_check/unsupported_default_export_expr.txt
@@ -27,7 +27,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/unsupported_default_export_expr.txt
+++ b/tests/specs/graph/fast_check/unsupported_default_export_expr.txt
@@ -27,6 +27,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/unsupported_destructuring.txt
+++ b/tests/specs/graph/fast_check/unsupported_destructuring.txt
@@ -28,7 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/unsupported_destructuring.txt
+++ b/tests/specs/graph/fast_check/unsupported_destructuring.txt
@@ -28,6 +28,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/unsupported_private_member_ref.txt
+++ b/tests/specs/graph/fast_check/unsupported_private_member_ref.txt
@@ -26,7 +26,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/unsupported_private_member_ref.txt
+++ b/tests/specs/graph/fast_check/unsupported_private_member_ref.txt
@@ -26,6 +26,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/unsupported_using_public_api.txt
+++ b/tests/specs/graph/fast_check/unsupported_using_public_api.txt
@@ -25,6 +25,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/unsupported_using_public_api.txt
+++ b/tests/specs/graph/fast_check/unsupported_using_public_api.txt
@@ -25,7 +25,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/var_arrow_expr_inferred.txt
+++ b/tests/specs/graph/fast_check/var_arrow_expr_inferred.txt
@@ -24,7 +24,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/var_arrow_expr_inferred.txt
+++ b/tests/specs/graph/fast_check/var_arrow_expr_inferred.txt
@@ -24,6 +24,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/var_arrow_leavable.txt
+++ b/tests/specs/graph/fast_check/var_arrow_leavable.txt
@@ -30,6 +30,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -60,6 +61,7 @@ import 'jsr:@scope/a'
           "specifier": "./b.ts",
           "type": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -101,6 +103,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./b.ts": {
       "type": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/var_arrow_leavable.txt
+++ b/tests/specs/graph/fast_check/var_arrow_leavable.txt
@@ -30,7 +30,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -61,7 +61,7 @@ import 'jsr:@scope/a'
           "specifier": "./b.ts",
           "type": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -103,7 +103,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./b.ts": {
       "type": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/var_declare_keyword.txt
+++ b/tests/specs/graph/fast_check/var_declare_keyword.txt
@@ -25,6 +25,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/var_declare_keyword.txt
+++ b/tests/specs/graph/fast_check/var_declare_keyword.txt
@@ -25,7 +25,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/var_function_leavable.txt
+++ b/tests/specs/graph/fast_check/var_function_leavable.txt
@@ -30,6 +30,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -60,6 +61,7 @@ import 'jsr:@scope/a'
           "specifier": "./b.ts",
           "type": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -101,6 +103,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./b.ts": {
       "type": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/var_function_leavable.txt
+++ b/tests/specs/graph/fast_check/var_function_leavable.txt
@@ -30,7 +30,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -61,7 +61,7 @@ import 'jsr:@scope/a'
           "specifier": "./b.ts",
           "type": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -103,7 +103,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./b.ts": {
       "type": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/fast_check/vars.txt
+++ b/tests/specs/graph/fast_check/vars.txt
@@ -75,7 +75,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/vars.txt
+++ b/tests/specs/graph/fast_check/vars.txt
@@ -75,6 +75,7 @@ import 'jsr:@scope/a'
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/fast_check/workspace_fast_check.txt
+++ b/tests/specs/graph/fast_check/workspace_fast_check.txt
@@ -57,7 +57,7 @@ class Private {
           "specifier": "jsr:@scope/b",
           "code": {
             "specifier": "file:///mod.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -74,7 +74,7 @@ class Private {
           "specifier": "jsr:@scope/c",
           "code": {
             "specifier": "jsr:@scope/c",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -112,7 +112,7 @@ Fast check file:///mod.ts:
     "jsr:@scope/c": {
       "code": {
         "specifier": "jsr:@scope/c",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 1,

--- a/tests/specs/graph/fast_check/workspace_fast_check.txt
+++ b/tests/specs/graph/fast_check/workspace_fast_check.txt
@@ -57,6 +57,7 @@ class Private {
           "specifier": "jsr:@scope/b",
           "code": {
             "specifier": "file:///mod.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -73,6 +74,7 @@ class Private {
           "specifier": "jsr:@scope/c",
           "code": {
             "specifier": "jsr:@scope/c",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -110,6 +112,7 @@ Fast check file:///mod.ts:
     "jsr:@scope/c": {
       "code": {
         "specifier": "jsr:@scope/c",
+        "mode": "import",
         "span": {
           "start": {
             "line": 1,

--- a/tests/specs/graph/fast_check/workspace_fast_check_no_version.txt
+++ b/tests/specs/graph/fast_check/workspace_fast_check_no_version.txt
@@ -56,6 +56,7 @@ class Private {
           "specifier": "jsr:@scope/b",
           "code": {
             "specifier": "file:///mod.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -72,6 +73,7 @@ class Private {
           "specifier": "jsr:@scope/c",
           "code": {
             "specifier": "jsr:@scope/c",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -109,6 +111,7 @@ Fast check file:///mod.ts:
     "jsr:@scope/c": {
       "code": {
         "specifier": "jsr:@scope/c",
+        "mode": "import",
         "span": {
           "start": {
             "line": 1,

--- a/tests/specs/graph/fast_check/workspace_fast_check_no_version.txt
+++ b/tests/specs/graph/fast_check/workspace_fast_check_no_version.txt
@@ -56,7 +56,7 @@ class Private {
           "specifier": "jsr:@scope/b",
           "code": {
             "specifier": "file:///mod.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -73,7 +73,7 @@ class Private {
           "specifier": "jsr:@scope/c",
           "code": {
             "specifier": "jsr:@scope/c",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -111,7 +111,7 @@ Fast check file:///mod.ts:
     "jsr:@scope/c": {
       "code": {
         "specifier": "jsr:@scope/c",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 1,

--- a/tests/specs/graph/jsr/Checksum_Mismatch.txt
+++ b/tests/specs/graph/jsr/Checksum_Mismatch.txt
@@ -37,7 +37,7 @@ console.log('HI');
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/Checksum_Mismatch.txt
+++ b/tests/specs/graph/jsr/Checksum_Mismatch.txt
@@ -37,6 +37,7 @@ console.log('HI');
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/Checksum_Unsupported.txt
+++ b/tests/specs/graph/jsr/Checksum_Unsupported.txt
@@ -37,7 +37,7 @@ console.log('HI');
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/Checksum_Unsupported.txt
+++ b/tests/specs/graph/jsr/Checksum_Unsupported.txt
@@ -37,6 +37,7 @@ console.log('HI');
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/Yanked.txt
+++ b/tests/specs/graph/jsr/Yanked.txt
@@ -35,7 +35,7 @@ import "jsr:@scope/a@^1.0";
           "specifier": "jsr:@scope/a@^1.0",
           "code": {
             "specifier": "jsr:@scope/a@^1.0",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/Yanked.txt
+++ b/tests/specs/graph/jsr/Yanked.txt
@@ -35,6 +35,7 @@ import "jsr:@scope/a@^1.0";
           "specifier": "jsr:@scope/a@^1.0",
           "code": {
             "specifier": "jsr:@scope/a@^1.0",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/dynamic_import.txt
+++ b/tests/specs/graph/jsr/dynamic_import.txt
@@ -30,7 +30,7 @@ import "jsr:@scope/a";
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -61,7 +61,7 @@ import "jsr:@scope/a";
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -75,7 +75,7 @@ import "jsr:@scope/a";
           },
           "type": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -116,7 +116,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./a.ts": {
       "type": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-        "mode": "import",
+        "resolutionMode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/jsr/dynamic_import.txt
+++ b/tests/specs/graph/jsr/dynamic_import.txt
@@ -30,6 +30,7 @@ import "jsr:@scope/a";
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -60,6 +61,7 @@ import "jsr:@scope/a";
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -73,6 +75,7 @@ import "jsr:@scope/a";
           },
           "type": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -113,6 +116,7 @@ Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
     "./a.ts": {
       "type": {
         "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+        "mode": "import",
         "span": {
           "start": {
             "line": 0,

--- a/tests/specs/graph/jsr/dynamic_import_invalid_checksum.txt
+++ b/tests/specs/graph/jsr/dynamic_import_invalid_checksum.txt
@@ -35,6 +35,7 @@ import "jsr:@scope/a";
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -63,6 +64,7 @@ import "jsr:@scope/a";
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/dynamic_import_invalid_checksum.txt
+++ b/tests/specs/graph/jsr/dynamic_import_invalid_checksum.txt
@@ -35,7 +35,7 @@ import "jsr:@scope/a";
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -64,7 +64,7 @@ import "jsr:@scope/a";
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/dynamic_import_of_jsr.txt
+++ b/tests/specs/graph/jsr/dynamic_import_of_jsr.txt
@@ -26,7 +26,7 @@ await import("jsr:@scope/a");
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/dynamic_import_of_jsr.txt
+++ b/tests/specs/graph/jsr/dynamic_import_of_jsr.txt
@@ -26,6 +26,7 @@ await import("jsr:@scope/a");
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/https_redirect_to_jsr_invalid_checksum.txt
+++ b/tests/specs/graph/jsr/https_redirect_to_jsr_invalid_checksum.txt
@@ -35,6 +35,7 @@ import "https://deno.land/example.ts";
           "specifier": "https://deno.land/example.ts",
           "code": {
             "specifier": "https://deno.land/example.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/https_redirect_to_jsr_invalid_checksum.txt
+++ b/tests/specs/graph/jsr/https_redirect_to_jsr_invalid_checksum.txt
@@ -35,7 +35,7 @@ import "https://deno.land/example.ts";
           "specifier": "https://deno.land/example.ts",
           "code": {
             "specifier": "https://deno.land/example.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/https_redirect_to_jsr_valid_checksum.txt
+++ b/tests/specs/graph/jsr/https_redirect_to_jsr_valid_checksum.txt
@@ -29,7 +29,7 @@ import "https://deno.land/example.ts";
           "specifier": "https://deno.land/example.ts",
           "code": {
             "specifier": "https://deno.land/example.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/https_redirect_to_jsr_valid_checksum.txt
+++ b/tests/specs/graph/jsr/https_redirect_to_jsr_valid_checksum.txt
@@ -29,6 +29,7 @@ import "https://deno.land/example.ts";
           "specifier": "https://deno.land/example.ts",
           "code": {
             "specifier": "https://deno.land/example.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/import_via_https_invalid_checksum.txt
+++ b/tests/specs/graph/jsr/import_via_https_invalid_checksum.txt
@@ -33,6 +33,7 @@ console.log(Test);
           "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -46,6 +47,7 @@ console.log(Test);
           },
           "type": {
             "error": "Importing JSR packages via HTTPS specifiers for type checking is not supported for performance reasons. If you would like types, import via a `jsr:` specifier instead or else use a non-statically analyzable dynamic import.\n  Importing: https://jsr.io/@scope/a/1.0.0/mod.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/import_via_https_invalid_checksum.txt
+++ b/tests/specs/graph/jsr/import_via_https_invalid_checksum.txt
@@ -33,7 +33,7 @@ console.log(Test);
           "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -47,7 +47,7 @@ console.log(Test);
           },
           "type": {
             "error": "Importing JSR packages via HTTPS specifiers for type checking is not supported for performance reasons. If you would like types, import via a `jsr:` specifier instead or else use a non-statically analyzable dynamic import.\n  Importing: https://jsr.io/@scope/a/1.0.0/mod.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/import_via_https_valid_checksum.txt
+++ b/tests/specs/graph/jsr/import_via_https_valid_checksum.txt
@@ -34,7 +34,7 @@ console.log(Test);
           "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -48,7 +48,7 @@ console.log(Test);
           },
           "type": {
             "error": "Importing JSR packages via HTTPS specifiers for type checking is not supported for performance reasons. If you would like types, import via a `jsr:` specifier instead or else use a non-statically analyzable dynamic import.\n  Importing: https://jsr.io/@scope/a/1.0.0/mod.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/import_via_https_valid_checksum.txt
+++ b/tests/specs/graph/jsr/import_via_https_valid_checksum.txt
@@ -34,6 +34,7 @@ console.log(Test);
           "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -47,6 +48,7 @@ console.log(Test);
           },
           "type": {
             "error": "Importing JSR packages via HTTPS specifiers for type checking is not supported for performance reasons. If you would like types, import via a `jsr:` specifier instead or else use a non-statically analyzable dynamic import.\n  Importing: https://jsr.io/@scope/a/1.0.0/mod.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/import_via_https_with_deps.txt
+++ b/tests/specs/graph/jsr/import_via_https_with_deps.txt
@@ -42,7 +42,7 @@ console.log(Test);
           "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -56,7 +56,7 @@ console.log(Test);
           },
           "type": {
             "error": "Importing JSR packages via HTTPS specifiers for type checking is not supported for performance reasons. If you would like types, import via a `jsr:` specifier instead or else use a non-statically analyzable dynamic import.\n  Importing: https://jsr.io/@scope/a/1.0.0/mod.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -81,7 +81,7 @@ console.log(Test);
           "specifier": "jsr:@scope/b",
           "code": {
             "specifier": "jsr:@scope/b",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/import_via_https_with_deps.txt
+++ b/tests/specs/graph/jsr/import_via_https_with_deps.txt
@@ -42,6 +42,7 @@ console.log(Test);
           "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -55,6 +56,7 @@ console.log(Test);
           },
           "type": {
             "error": "Importing JSR packages via HTTPS specifiers for type checking is not supported for performance reasons. If you would like types, import via a `jsr:` specifier instead or else use a non-statically analyzable dynamic import.\n  Importing: https://jsr.io/@scope/a/1.0.0/mod.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -79,6 +81,7 @@ console.log(Test);
           "specifier": "jsr:@scope/b",
           "code": {
             "specifier": "jsr:@scope/b",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/imported_multiple_packages.txt
+++ b/tests/specs/graph/jsr/imported_multiple_packages.txt
@@ -54,6 +54,7 @@ import "jsr:@scope/c";
           "specifier": "jsr:@scope/c",
           "code": {
             "specifier": "jsr:@scope/c",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -84,6 +85,7 @@ import "jsr:@scope/c";
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -108,6 +110,7 @@ import "jsr:@scope/c";
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -124,6 +127,7 @@ import "jsr:@scope/c";
           "specifier": "jsr:@scope/b",
           "code": {
             "specifier": "jsr:@scope/b",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 1,

--- a/tests/specs/graph/jsr/imported_multiple_packages.txt
+++ b/tests/specs/graph/jsr/imported_multiple_packages.txt
@@ -54,7 +54,7 @@ import "jsr:@scope/c";
           "specifier": "jsr:@scope/c",
           "code": {
             "specifier": "jsr:@scope/c",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -85,7 +85,7 @@ import "jsr:@scope/c";
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -110,7 +110,7 @@ import "jsr:@scope/c";
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -127,7 +127,7 @@ import "jsr:@scope/c";
           "specifier": "jsr:@scope/b",
           "code": {
             "specifier": "jsr:@scope/b",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 1,

--- a/tests/specs/graph/jsr/invalid_export.txt
+++ b/tests/specs/graph/jsr/invalid_export.txt
@@ -31,6 +31,7 @@ import 'jsr:@scope/a/non_existent' // invalid export
           "specifier": "jsr:@scope/a/non_existent",
           "code": {
             "specifier": "jsr:@scope/a/non_existent",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/invalid_export.txt
+++ b/tests/specs/graph/jsr/invalid_export.txt
@@ -31,7 +31,7 @@ import 'jsr:@scope/a/non_existent' // invalid export
           "specifier": "jsr:@scope/a/non_existent",
           "code": {
             "specifier": "jsr:@scope/a/non_existent",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/json_entrypoint.txt
+++ b/tests/specs/graph/jsr/json_entrypoint.txt
@@ -36,7 +36,7 @@ console.log(test);
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/json_entrypoint.txt
+++ b/tests/specs/graph/jsr/json_entrypoint.txt
@@ -36,6 +36,7 @@ console.log(test);
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/module_graph_info_1.txt
+++ b/tests/specs/graph/jsr/module_graph_info_1.txt
@@ -97,6 +97,7 @@ import './c.ts';
           "specifier": "jsr:@scope/a@^1.0",
           "code": {
             "specifier": "jsr:@scope/a@^1.0",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -121,6 +122,7 @@ import './c.ts';
           "specifier": "./b.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 13,
@@ -137,6 +139,7 @@ import './c.ts';
           "specifier": "jsr:@scope/b/export",
           "code": {
             "specifier": "jsr:@scope/b/export",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 5,
@@ -161,6 +164,7 @@ import './c.ts';
           "specifier": "./c.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/c.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -191,6 +195,7 @@ import './c.ts';
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 5,
@@ -221,6 +226,7 @@ import './c.ts';
           "specifier": "./inner.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/b/9.0.0/inner.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 5,

--- a/tests/specs/graph/jsr/module_graph_info_1.txt
+++ b/tests/specs/graph/jsr/module_graph_info_1.txt
@@ -97,7 +97,7 @@ import './c.ts';
           "specifier": "jsr:@scope/a@^1.0",
           "code": {
             "specifier": "jsr:@scope/a@^1.0",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -122,7 +122,7 @@ import './c.ts';
           "specifier": "./b.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 13,
@@ -139,7 +139,7 @@ import './c.ts';
           "specifier": "jsr:@scope/b/export",
           "code": {
             "specifier": "jsr:@scope/b/export",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 5,
@@ -164,7 +164,7 @@ import './c.ts';
           "specifier": "./c.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/c.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -195,7 +195,7 @@ import './c.ts';
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 5,
@@ -226,7 +226,7 @@ import './c.ts';
           "specifier": "./inner.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/b/9.0.0/inner.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 5,

--- a/tests/specs/graph/jsr/module_graph_info_1_leading_comments.txt
+++ b/tests/specs/graph/jsr/module_graph_info_1_leading_comments.txt
@@ -54,6 +54,7 @@ import 'jsr:@scope/a@^1.0';
           "specifier": "jsr:@scope/a@^1.0",
           "code": {
             "specifier": "jsr:@scope/a@^1.0",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -90,6 +91,7 @@ import 'jsr:@scope/a@^1.0';
           "specifier": "./a.js",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.js",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 5,
@@ -103,6 +105,7 @@ import 'jsr:@scope/a@^1.0';
           },
           "type": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.d.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/module_graph_info_1_leading_comments.txt
+++ b/tests/specs/graph/jsr/module_graph_info_1_leading_comments.txt
@@ -54,7 +54,7 @@ import 'jsr:@scope/a@^1.0';
           "specifier": "jsr:@scope/a@^1.0",
           "code": {
             "specifier": "jsr:@scope/a@^1.0",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -91,7 +91,7 @@ import 'jsr:@scope/a@^1.0';
           "specifier": "./a.js",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.js",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 5,
@@ -105,7 +105,7 @@ import 'jsr:@scope/a@^1.0';
           },
           "type": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.d.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/module_graph_info_2.txt
+++ b/tests/specs/graph/jsr/module_graph_info_2.txt
@@ -97,6 +97,7 @@ import './c.ts';
           "specifier": "jsr:@scope/a@^1.0",
           "code": {
             "specifier": "jsr:@scope/a@^1.0",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -121,6 +122,7 @@ import './c.ts';
           "specifier": "./b.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 13,
@@ -137,6 +139,7 @@ import './c.ts';
           "specifier": "jsr:@scope/b/export",
           "code": {
             "specifier": "jsr:@scope/b/export",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 5,
@@ -161,6 +164,7 @@ import './c.ts';
           "specifier": "./c.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/c.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -191,6 +195,7 @@ import './c.ts';
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 5,
@@ -221,6 +226,7 @@ import './c.ts';
           "specifier": "./inner.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/b/9.0.0/inner.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 5,

--- a/tests/specs/graph/jsr/module_graph_info_2.txt
+++ b/tests/specs/graph/jsr/module_graph_info_2.txt
@@ -97,7 +97,7 @@ import './c.ts';
           "specifier": "jsr:@scope/a@^1.0",
           "code": {
             "specifier": "jsr:@scope/a@^1.0",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -122,7 +122,7 @@ import './c.ts';
           "specifier": "./b.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 13,
@@ -139,7 +139,7 @@ import './c.ts';
           "specifier": "jsr:@scope/b/export",
           "code": {
             "specifier": "jsr:@scope/b/export",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 5,
@@ -164,7 +164,7 @@ import './c.ts';
           "specifier": "./c.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/c.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -195,7 +195,7 @@ import './c.ts';
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 5,
@@ -226,7 +226,7 @@ import './c.ts';
           "specifier": "./inner.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/b/9.0.0/inner.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 5,

--- a/tests/specs/graph/jsr/module_graph_info_modified_cached_files.txt
+++ b/tests/specs/graph/jsr/module_graph_info_modified_cached_files.txt
@@ -104,6 +104,7 @@ import 'jsr:@scope/b';
           "specifier": "jsr:@scope/a@^1.0",
           "code": {
             "specifier": "jsr:@scope/a@^1.0",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -128,6 +129,7 @@ import 'jsr:@scope/b';
           "specifier": "./b.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -152,6 +154,7 @@ import 'jsr:@scope/b';
           "specifier": "./c.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/c.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 13,
@@ -176,6 +179,7 @@ import 'jsr:@scope/b';
           "specifier": "jsr:@scope/b",
           "code": {
             "specifier": "jsr:@scope/b",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -200,6 +204,7 @@ import 'jsr:@scope/b';
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/module_graph_info_modified_cached_files.txt
+++ b/tests/specs/graph/jsr/module_graph_info_modified_cached_files.txt
@@ -104,7 +104,7 @@ import 'jsr:@scope/b';
           "specifier": "jsr:@scope/a@^1.0",
           "code": {
             "specifier": "jsr:@scope/a@^1.0",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -129,7 +129,7 @@ import 'jsr:@scope/b';
           "specifier": "./b.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/b.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -154,7 +154,7 @@ import 'jsr:@scope/b';
           "specifier": "./c.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/c.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 13,
@@ -179,7 +179,7 @@ import 'jsr:@scope/b';
           "specifier": "jsr:@scope/b",
           "code": {
             "specifier": "jsr:@scope/b",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -204,7 +204,7 @@ import 'jsr:@scope/b';
           "specifier": "./a.ts",
           "code": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/a.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/no_module_graph_info.txt
+++ b/tests/specs/graph/jsr/no_module_graph_info.txt
@@ -76,7 +76,7 @@ console.log(1);
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -93,7 +93,7 @@ console.log(1);
           "specifier": "jsr:@scope/c@3.0.0",
           "code": {
             "specifier": "jsr:@scope/c@3.0.0",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -118,7 +118,7 @@ console.log(1);
           "specifier": "jsr:@scope/b@2/sub",
           "code": {
             "specifier": "jsr:@scope/b@2/sub",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -143,7 +143,7 @@ console.log(1);
           "specifier": "jsr:@scope/c@3",
           "code": {
             "specifier": "jsr:@scope/c@3",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 1,

--- a/tests/specs/graph/jsr/no_module_graph_info.txt
+++ b/tests/specs/graph/jsr/no_module_graph_info.txt
@@ -76,6 +76,7 @@ console.log(1);
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -92,6 +93,7 @@ console.log(1);
           "specifier": "jsr:@scope/c@3.0.0",
           "code": {
             "specifier": "jsr:@scope/c@3.0.0",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -116,6 +118,7 @@ console.log(1);
           "specifier": "jsr:@scope/b@2/sub",
           "code": {
             "specifier": "jsr:@scope/b@2/sub",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -140,6 +143,7 @@ console.log(1);
           "specifier": "jsr:@scope/c@3",
           "code": {
             "specifier": "jsr:@scope/c@3",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 1,

--- a/tests/specs/graph/jsr/package_not_exist.txt
+++ b/tests/specs/graph/jsr/package_not_exist.txt
@@ -14,6 +14,7 @@ import 'jsr:@scope/a/mod.ts';
           "specifier": "jsr:@scope/a/mod.ts",
           "code": {
             "specifier": "jsr:@scope/a/mod.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/package_not_exist.txt
+++ b/tests/specs/graph/jsr/package_not_exist.txt
@@ -14,7 +14,7 @@ import 'jsr:@scope/a/mod.ts';
           "specifier": "jsr:@scope/a/mod.ts",
           "code": {
             "specifier": "jsr:@scope/a/mod.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/redirect_content.txt
+++ b/tests/specs/graph/jsr/redirect_content.txt
@@ -39,7 +39,7 @@ import 'jsr:@scope/a';
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/redirect_content.txt
+++ b/tests/specs/graph/jsr/redirect_content.txt
@@ -39,6 +39,7 @@ import 'jsr:@scope/a';
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/redirect_package_metadata.txt
+++ b/tests/specs/graph/jsr/redirect_package_metadata.txt
@@ -33,7 +33,7 @@ import 'jsr:@scope/a';
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/redirect_package_metadata.txt
+++ b/tests/specs/graph/jsr/redirect_package_metadata.txt
@@ -33,6 +33,7 @@ import 'jsr:@scope/a';
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/redirect_version_metadata.txt
+++ b/tests/specs/graph/jsr/redirect_version_metadata.txt
@@ -33,7 +33,7 @@ import 'jsr:@scope/a';
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/redirect_version_metadata.txt
+++ b/tests/specs/graph/jsr/redirect_version_metadata.txt
@@ -33,6 +33,7 @@ import 'jsr:@scope/a';
           "specifier": "jsr:@scope/a",
           "code": {
             "specifier": "jsr:@scope/a",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/same_package_multiple_times.txt
+++ b/tests/specs/graph/jsr/same_package_multiple_times.txt
@@ -69,6 +69,7 @@ import "jsr:@scope/b@1.1";
           "specifier": "jsr:@scope/a@^1.0",
           "code": {
             "specifier": "jsr:@scope/a@^1.0",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -85,6 +86,7 @@ import "jsr:@scope/b@1.1";
           "specifier": "jsr:@scope/b@1.1",
           "code": {
             "specifier": "jsr:@scope/b@1.1",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -109,6 +111,7 @@ import "jsr:@scope/b@1.1";
           "specifier": "jsr:@scope/b@1",
           "code": {
             "specifier": "jsr:@scope/b@1",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 5,

--- a/tests/specs/graph/jsr/same_package_multiple_times.txt
+++ b/tests/specs/graph/jsr/same_package_multiple_times.txt
@@ -69,7 +69,7 @@ import "jsr:@scope/b@1.1";
           "specifier": "jsr:@scope/a@^1.0",
           "code": {
             "specifier": "jsr:@scope/a@^1.0",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -86,7 +86,7 @@ import "jsr:@scope/b@1.1";
           "specifier": "jsr:@scope/b@1.1",
           "code": {
             "specifier": "jsr:@scope/b@1.1",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 1,
@@ -111,7 +111,7 @@ import "jsr:@scope/b@1.1";
           "specifier": "jsr:@scope/b@1",
           "code": {
             "specifier": "jsr:@scope/b@1",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 5,

--- a/tests/specs/graph/jsr/version_not_exist.txt
+++ b/tests/specs/graph/jsr/version_not_exist.txt
@@ -21,6 +21,7 @@ import 'jsr:@scope/a@1.0.1/mod.ts';
           "specifier": "jsr:@scope/a@1.0.1/mod.ts",
           "code": {
             "specifier": "jsr:@scope/a@1.0.1/mod.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/version_not_exist.txt
+++ b/tests/specs/graph/jsr/version_not_exist.txt
@@ -21,7 +21,7 @@ import 'jsr:@scope/a@1.0.1/mod.ts';
           "specifier": "jsr:@scope/a@1.0.1/mod.ts",
           "code": {
             "specifier": "jsr:@scope/a@1.0.1/mod.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/version_tag_not_supported.txt
+++ b/tests/specs/graph/jsr/version_tag_not_supported.txt
@@ -21,6 +21,7 @@ import 'jsr:@scope/a@tag';
           "specifier": "jsr:@scope/a@tag",
           "code": {
             "specifier": "jsr:@scope/a@tag",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/version_tag_not_supported.txt
+++ b/tests/specs/graph/jsr/version_tag_not_supported.txt
@@ -21,7 +21,7 @@ import 'jsr:@scope/a@tag';
           "specifier": "jsr:@scope/a@tag",
           "code": {
             "specifier": "jsr:@scope/a@tag",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/yanked_fallback.txt
+++ b/tests/specs/graph/jsr/yanked_fallback.txt
@@ -34,7 +34,7 @@ import "jsr:@scope/a@^1.0";
           "specifier": "jsr:@scope/a@^1.0",
           "code": {
             "specifier": "jsr:@scope/a@^1.0",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/yanked_fallback.txt
+++ b/tests/specs/graph/jsr/yanked_fallback.txt
@@ -34,6 +34,7 @@ import "jsr:@scope/a@^1.0";
           "specifier": "jsr:@scope/a@^1.0",
           "code": {
             "specifier": "jsr:@scope/a@^1.0",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/yanked_lockfile.txt
+++ b/tests/specs/graph/jsr/yanked_lockfile.txt
@@ -35,7 +35,7 @@ import "jsr:@scope/a@^1.0";
           "specifier": "jsr:@scope/a@^1.0",
           "code": {
             "specifier": "jsr:@scope/a@^1.0",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/jsr/yanked_lockfile.txt
+++ b/tests/specs/graph/jsr/yanked_lockfile.txt
@@ -35,6 +35,7 @@ import "jsr:@scope/a@^1.0";
           "specifier": "jsr:@scope/a@^1.0",
           "code": {
             "specifier": "jsr:@scope/a@^1.0",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/redirects_circular.txt
+++ b/tests/specs/graph/redirects_circular.txt
@@ -20,6 +20,7 @@ HEADERS: {"location":"./redirect.ts"}
           "specifier": "https://localhost/redirect.ts",
           "code": {
             "specifier": "https://localhost/redirect.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/redirects_circular.txt
+++ b/tests/specs/graph/redirects_circular.txt
@@ -20,7 +20,7 @@ HEADERS: {"location":"./redirect.ts"}
           "specifier": "https://localhost/redirect.ts",
           "code": {
             "specifier": "https://localhost/redirect.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/redirects_max.txt
+++ b/tests/specs/graph/redirects_max.txt
@@ -50,7 +50,7 @@ console.log('hi');
           "specifier": "https://localhost/redirect.ts",
           "code": {
             "specifier": "https://localhost/redirect.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/redirects_max.txt
+++ b/tests/specs/graph/redirects_max.txt
@@ -50,6 +50,7 @@ console.log('hi');
           "specifier": "https://localhost/redirect.ts",
           "code": {
             "specifier": "https://localhost/redirect.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,

--- a/tests/specs/graph/redirects_multiple.txt
+++ b/tests/specs/graph/redirects_multiple.txt
@@ -30,7 +30,7 @@ console.log('hi');
           "specifier": "https://localhost/redirect.ts",
           "code": {
             "specifier": "https://localhost/redirect.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -47,7 +47,7 @@ console.log('hi');
           "specifier": "https://localhost/other_redirect.ts",
           "code": {
             "specifier": "https://localhost/other_redirect.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 1,

--- a/tests/specs/graph/redirects_multiple.txt
+++ b/tests/specs/graph/redirects_multiple.txt
@@ -30,6 +30,7 @@ console.log('hi');
           "specifier": "https://localhost/redirect.ts",
           "code": {
             "specifier": "https://localhost/redirect.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -46,6 +47,7 @@ console.log('hi');
           "specifier": "https://localhost/other_redirect.ts",
           "code": {
             "specifier": "https://localhost/other_redirect.ts",
+            "mode": "import",
             "span": {
               "start": {
                 "line": 1,

--- a/tests/specs/graph/resolution_mode.txt
+++ b/tests/specs/graph/resolution_mode.txt
@@ -1,0 +1,133 @@
+# mod.ts
+export type * from "./declarations.d.ts";
+
+# declarations.d.ts
+import type { Test } from "./a.d.ts" with {
+  "resolution-mode": "import"
+};
+export type { Test };
+export type { Test2 } from "./b.d.ts" with {
+  "resolution-mode": "require"
+};
+// this one won't have a resolution mode because we're in a .d.ts file
+export type { Test3 } from "./c.d.ts";
+
+# a.d.ts
+export class Test {}
+
+# b.d.ts
+export class Test2 {}
+
+# c.d.ts
+export class Test3 {}
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "size": 21,
+      "mediaType": "Dts",
+      "specifier": "file:///a.d.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 22,
+      "mediaType": "Dts",
+      "specifier": "file:///b.d.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 22,
+      "mediaType": "Dts",
+      "specifier": "file:///c.d.ts"
+    },
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "./a.d.ts",
+          "type": {
+            "specifier": "file:///a.d.ts",
+            "mode": "import",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 26
+              },
+              "end": {
+                "line": 0,
+                "character": 36
+              }
+            }
+          }
+        },
+        {
+          "specifier": "./b.d.ts",
+          "type": {
+            "specifier": "file:///b.d.ts",
+            "mode": "require",
+            "span": {
+              "start": {
+                "line": 4,
+                "character": 27
+              },
+              "end": {
+                "line": 4,
+                "character": 37
+              }
+            }
+          }
+        },
+        {
+          "specifier": "./c.d.ts",
+          "type": {
+            "specifier": "file:///c.d.ts",
+            "span": {
+              "start": {
+                "line": 8,
+                "character": 27
+              },
+              "end": {
+                "line": 8,
+                "character": 37
+              }
+            }
+          }
+        }
+      ],
+      "size": 288,
+      "mediaType": "Dts",
+      "specifier": "file:///declarations.d.ts"
+    },
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "./declarations.d.ts",
+          "type": {
+            "specifier": "file:///declarations.d.ts",
+            "mode": "import",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 19
+              },
+              "end": {
+                "line": 0,
+                "character": 40
+              }
+            }
+          }
+        }
+      ],
+      "size": 42,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    }
+  ],
+  "redirects": {}
+}

--- a/tests/specs/graph/resolution_mode.txt
+++ b/tests/specs/graph/resolution_mode.txt
@@ -52,7 +52,7 @@ export class Test3 {}
           "specifier": "./a.d.ts",
           "type": {
             "specifier": "file:///a.d.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,
@@ -69,7 +69,7 @@ export class Test3 {}
           "specifier": "./b.d.ts",
           "type": {
             "specifier": "file:///b.d.ts",
-            "mode": "require",
+            "resolutionMode": "require",
             "span": {
               "start": {
                 "line": 4,
@@ -110,7 +110,7 @@ export class Test3 {}
           "specifier": "./declarations.d.ts",
           "type": {
             "specifier": "file:///declarations.d.ts",
-            "mode": "import",
+            "resolutionMode": "import",
             "span": {
               "start": {
                 "line": 0,


### PR DESCRIPTION
We now say if a specific import or export resolution should definitely use ESM or CJS along with supporting "resolution-mode" in TypeScript (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-3.html#stable-support-resolution-mode-in-import-types). This information is stored in the referrer range.

It's important to know this for importing npm packages (ex. dynamic imports in cjs should load using ESM and not CJS resolution).

For https://github.com/denoland/deno/issues/27059

CLI PR: https://github.com/denoland/deno/pull/27071