### PR TITLE
chore: update string_capacity to capacity_builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
+name = "capacity_builder"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2c0f637033edd76ceb881faaee372868a383f0ed7a4a59e8fdf90db2502f3d3"
+dependencies = [
+ "itoa",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +432,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
+ "capacity_builder",
  "data-url",
  "deno_ast",
  "deno_semver",
@@ -444,7 +454,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "string_capacity",
  "tempfile",
  "thiserror 2.0.3",
  "tokio",
@@ -1957,15 +1966,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "string_capacity"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e7fad11dbd0a122b9b88d805c9cf0a420c6628773c6f4d738e6e49664b5a582"
-dependencies = [
- "itoa",
-]
 
 [[package]]
 name = "string_enum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ harness = false
 [dependencies]
 anyhow = "1.0.43"
 async-trait = "0.1.68"
-string_capacity = "0.1.3"
+capacity_builder = "0.1.0"
 data-url = "0.3.0"
 deno_ast = { version = "0.44.0", features = ["dep_analysis", "emit"] }
 deno_unsync.workspace = true

--- a/src/source/wasm.rs
+++ b/src/source/wasm.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
+use capacity_builder::StringBuilder;
 use indexmap::IndexSet;
-use string_capacity::StringBuilder;
 use wasm_dep_analyzer::ValueType;
 
 pub fn wasm_module_to_dts(


### PR DESCRIPTION
I updated the crate name to be more general and not apply to just strings.