### PR TITLE
feat: add `JsrVersionResolver` trait to allow more control over version resolution

### DIFF
--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -282,6 +282,7 @@ pub async fn js_create_graph(
         imports,
         reporter: None,
         executor: Default::default(),
+        jsr_version_resolver: None,
       },
     )
     .await;

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -16,6 +16,16 @@ use serde::Serialize;
 use crate::analyzer::module_graph_1_to_2;
 use crate::ModuleInfo;
 
+pub trait JsrVersionResolver {
+  fn resolve_package_version<'a>(
+    &self,
+    package_info: &'a JsrPackageInfo,
+    package_req: &PackageReq,
+  ) -> Option<&'a Version>;
+
+  fn force_fetch_metadata<'a>(&self, package_name: &str) -> bool;
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct JsrPackageInfo {
   pub versions: HashMap<Version, JsrPackageInfoVersion>,

--- a/tests/ecosystem_test.rs
+++ b/tests/ecosystem_test.rs
@@ -287,6 +287,7 @@ async fn test_version(
         passthrough_jsr_specifiers: true,
         executor: Default::default(),
         imports: vec![],
+        jsr_version_resolver: None,
       },
     )
     .await;


### PR DESCRIPTION
this is to support specifying versions to use for jsr packages that are not roots (for `deno outdated --update`). Currently, as a user of deno_graph there isn't a way to influence the version resolution for non-roots, and there also isn't a way to selectively invalidate cached metadata for packages.