### PR TITLE
feat: custom check_js resolver when walking graph

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -6834,11 +6834,7 @@ mod tests {
 
     impl CheckJsResolver for CustomResolver {
       fn resolve(&self, specifier: &ModuleSpecifier) -> bool {
-        if specifier.as_str() == "file:///true.js" {
-          true
-        } else {
-          false
-        }
+        specifier.as_str() == "file:///true.js"
       }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,8 @@ mod tests {
   use crate::source::NullFileSystem;
   use crate::source::ResolutionKind;
 
+  use self::graph::CheckJsOption;
+
   use super::*;
   use async_trait::async_trait;
   use deno_error::JsErrorBox;
@@ -4171,7 +4173,7 @@ export function a(a: A): B {
     let result = graph.walk(
       roots.iter(),
       WalkOptions {
-        check_js: true,
+        check_js: CheckJsOption::True,
         follow_dynamic: true,
         kind: GraphKind::All,
         prefer_fast_check_graph: true,
@@ -4200,7 +4202,7 @@ export function a(a: A): B {
     let result = graph.walk(
       roots.iter(),
       WalkOptions {
-        check_js: false,
+        check_js: CheckJsOption::False,
         follow_dynamic: false,
         kind: GraphKind::CodeOnly,
         prefer_fast_check_graph: true,
@@ -4224,7 +4226,7 @@ export function a(a: A): B {
     let result = graph.walk(
       roots.iter(),
       WalkOptions {
-        check_js: false,
+        check_js: CheckJsOption::False,
         follow_dynamic: true,
         kind: GraphKind::CodeOnly,
         prefer_fast_check_graph: true,
@@ -4250,7 +4252,7 @@ export function a(a: A): B {
     let result = graph.walk(
       roots.iter(),
       WalkOptions {
-        check_js: true,
+        check_js: CheckJsOption::True,
         follow_dynamic: false,
         kind: GraphKind::CodeOnly,
         prefer_fast_check_graph: true,
@@ -4275,7 +4277,7 @@ export function a(a: A): B {
     let result = graph.walk(
       roots.iter(),
       WalkOptions {
-        check_js: false,
+        check_js: CheckJsOption::False,
         follow_dynamic: false,
         kind: GraphKind::All,
         prefer_fast_check_graph: true,
@@ -4303,7 +4305,7 @@ export function a(a: A): B {
     let result = graph.walk(
       roots.iter(),
       WalkOptions {
-        check_js: false,
+        check_js: CheckJsOption::False,
         follow_dynamic: false,
         kind: GraphKind::TypesOnly,
         prefer_fast_check_graph: true,
@@ -4328,7 +4330,7 @@ export function a(a: A): B {
     let result = graph.walk(
       roots.iter(),
       WalkOptions {
-        check_js: true,
+        check_js: CheckJsOption::True,
         follow_dynamic: false,
         kind: GraphKind::TypesOnly,
         prefer_fast_check_graph: true,
@@ -4356,7 +4358,7 @@ export function a(a: A): B {
       let mut iterator = graph.walk(
         roots.iter(),
         WalkOptions {
-          check_js: true,
+          check_js: CheckJsOption::True,
           follow_dynamic: false,
           kind: GraphKind::All,
           prefer_fast_check_graph: false,
@@ -4380,7 +4382,7 @@ export function a(a: A): B {
       let mut iterator = graph.walk(
         roots.iter(),
         WalkOptions {
-          check_js: true,
+          check_js: CheckJsOption::True,
           follow_dynamic: false,
           kind: GraphKind::All,
           prefer_fast_check_graph: false,
@@ -4671,7 +4673,7 @@ export function a(a: A): B {
       .walk(
         graph.roots.iter(),
         WalkOptions {
-          check_js: true,
+          check_js: CheckJsOption::True,
           kind: GraphKind::TypesOnly,
           follow_dynamic: false,
           prefer_fast_check_graph: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,8 @@ pub use fast_check::FastCheckModule;
 #[cfg(feature = "fast_check")]
 pub use graph::BuildFastCheckTypeGraphOptions;
 pub use graph::BuildOptions;
+pub use graph::CheckJsOption;
+pub use graph::CheckJsResolver;
 pub use graph::Dependency;
 pub use graph::ExternalModule;
 pub use graph::FastCheckTypeModule;

--- a/tests/specs/ecosystem/mrii/rocket_io/0_1_3.test
+++ b/tests/specs/ecosystem/mrii/rocket_io/0_1_3.test
@@ -73,7 +73,7 @@ mrii/rocket-io/0.1.3
 
 -- stderr --
 error: Error: [ERR_PACKAGE_PATH_NOT_EXPORTED] Package subpath './build/esm/socket' is not defined for types by "exports" in '<global_npm_dir>/socket.io-client/4.7.5/package.json' imported from 'file://<tmpdir>/src/types/socket-reserved-events.ts'
-    at Object.resolveModuleNameLiterals (ext:deno_tsc/99_main_compiler.js:794:28)
+    at Object.resolveModuleNameLiterals (ext:deno_tsc/97_ts_host.js:611:26)
     at resolveModuleNamesWorker (ext:deno_tsc/00_typescript.js:125466:20)
     at resolveNamesReusingOldState (ext:deno_tsc/00_typescript.js:125608:14)
     at resolveModuleNamesReusingOldState (ext:deno_tsc/00_typescript.js:125564:12)


### PR DESCRIPTION
Provides the ability to walk the graph resolving the check_js value based on the specifier.

This is required for having multiple tsconfig options in a workspace.