### PR TITLE
fix: update deno_media_type to 0.2.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ast"
-version = "0.46.0"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd3b6e14e5b1235dd613d9f5d955d7a80dec6de0fc00fa34b5d0ef5ca0a9ddb"
+checksum = "b5700894f83f8d6a7507ed0667b27b812afbfe9bfdfd4d574191023a9c8c3a11"
 dependencies = [
  "base64 0.21.7",
  "deno_error",
@@ -542,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "deno_media_type"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "480223262efd08f96b3be5f0457c82bac7296e70dc4e7ef7350751f66293812c"
+checksum = "3d9080fcfcea53bcd6eea1916217bd5611c896f3a0db4c001a859722a1258a47"
 dependencies = [
  "data-url",
  "encoding_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ harness = false
 async-trait = "0.1.68"
 capacity_builder = "0.5.0"
 data-url = "0.3.0"
-deno_ast = { version = "0.46.0", features = ["dep_analysis", "emit"] }
-deno_media_type = { version = "0.2.4", features = ["decoding", "data_url", "module_specifier"] }
+deno_ast = { version = "0.46.2", features = ["dep_analysis", "emit"] }
+deno_media_type = { version = "0.2.8", features = ["decoding", "data_url", "module_specifier"] }
 deno_unsync.workspace = true
 deno_path_util = "0.3.0"
 deno_semver = "0.7.1"

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1443,7 +1443,11 @@ impl<'a, 'options> ModuleEntryIterator<'a, 'options> {
       | MediaType::Tsx
       | MediaType::Json
       | MediaType::Wasm => true,
-      MediaType::Css | MediaType::SourceMap | MediaType::Unknown => false,
+      MediaType::Css
+      | MediaType::SourceMap
+      | MediaType::Html
+      | MediaType::Sql
+      | MediaType::Unknown => false,
       MediaType::JavaScript
       | MediaType::Jsx
       | MediaType::Mjs
@@ -2525,6 +2529,8 @@ pub(crate) async fn parse_module_source_and_info(
     MediaType::Css
     | MediaType::Json
     | MediaType::SourceMap
+    | MediaType::Html
+    | MediaType::Sql
     | MediaType::Unknown => Err(ModuleError::UnsupportedMediaType(
       opts.specifier,
       media_type,
@@ -2730,7 +2736,7 @@ pub(crate) fn parse_js_module_from_module_info(
   // import source was set by the @jsxImportSource pragma. This is done to
   // prevent a default import source types from being injected when the user
   // has explicitly overridden the import source in the file.
-  if matches!(media_type, MediaType::Jsx | MediaType::Tsx) {
+  if media_type.is_jsx() {
     let has_jsx_import_source_pragma = module_info.jsx_import_source.is_some();
     let res = module_info.jsx_import_source.or_else(|| {
       maybe_resolver.and_then(|r| {

--- a/tests/specs/ecosystem/sxzz/ast_kit/0_12_0.test
+++ b/tests/specs/ecosystem/sxzz/ast_kit/0_12_0.test
@@ -41,17 +41,4 @@ sxzz/ast-kit/0.12.0
 
 == FAST CHECK EMIT PASSED ==
 
-== TYPE CHECK FAILED ==
--- stdout --
-
--- stderr --
-TS2694 [ERROR]: Namespace '"file:<global_npm_dir>/@babel/types/7.24.5/lib/index-legacy.d.ts"' has no exported member 'ParentMaps'.
-    at file://<tmpdir>/src/walk.ts:16:124
-
-TS2694 [ERROR]: Namespace '"file:<global_npm_dir>/@babel/types/7.24.5/lib/index-legacy.d.ts"' has no exported member 'ParentMaps'.
-    at file://<tmpdir>/src/walk.ts:16:139
-
-Found 2 errors.
-
-error: Type checking failed.
-
+== TYPE CHECK PASSED ==

--- a/tests/specs/ecosystem/sxzz/ast_kit/0_12_1.test
+++ b/tests/specs/ecosystem/sxzz/ast_kit/0_12_1.test
@@ -41,17 +41,4 @@ sxzz/ast-kit/0.12.1
 
 == FAST CHECK EMIT PASSED ==
 
-== TYPE CHECK FAILED ==
--- stdout --
-
--- stderr --
-TS2694 [ERROR]: Namespace '"file:<global_npm_dir>/@babel/types/7.24.5/lib/index-legacy.d.ts"' has no exported member 'ParentMaps'.
-    at file://<tmpdir>/src/walk.ts:31:124
-
-TS2694 [ERROR]: Namespace '"file:<global_npm_dir>/@babel/types/7.24.5/lib/index-legacy.d.ts"' has no exported member 'ParentMaps'.
-    at file://<tmpdir>/src/walk.ts:31:139
-
-Found 2 errors.
-
-error: Type checking failed.
-
+== TYPE CHECK PASSED ==


### PR DESCRIPTION
`deno_media_type` should have been released with a minor version because of the inbetween crate breakage.