### PR TITLE
refactor: remove bare node builtin resolution from deno graph

### DIFF
--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -375,7 +375,6 @@ pub async fn js_parse_module(
     jsr_url_provider: Default::default(),
     maybe_resolver: maybe_resolver.as_ref().map(|r| r as &dyn Resolver),
     module_analyzer: Default::default(),
-    maybe_npm_resolver: None,
   })
   .await
   {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -274,9 +274,6 @@ pub enum ModuleLoadError {
   Jsr(#[from] JsrLoadError),
   #[class(inherit)]
   #[error(transparent)]
-  NodeUnknownBuiltinModule(#[from] UnknownBuiltInNodeModuleError),
-  #[class(inherit)]
-  #[error(transparent)]
   Npm(#[from] NpmLoadError),
   #[class(generic)]
   #[error("Too many redirects.")]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -802,7 +802,6 @@ impl Dependency {
     specifier: &str,
     jsr_url_provider: &dyn JsrUrlProvider,
     maybe_resolver: Option<&dyn Resolver>,
-    maybe_npm_resolver: Option<&dyn NpmResolver>,
   ) -> Self {
     let maybe_code = self
       .maybe_code
@@ -814,7 +813,6 @@ impl Dependency {
           ResolutionKind::Execution,
           jsr_url_provider,
           maybe_resolver,
-          maybe_npm_resolver,
         )
       })
       .unwrap_or_default();
@@ -831,7 +829,6 @@ impl Dependency {
           ResolutionKind::Types,
           jsr_url_provider,
           maybe_resolver,
-          maybe_npm_resolver,
         )
       })
       .unwrap_or_default();
@@ -858,7 +855,6 @@ impl TypesDependency {
     &self,
     jsr_url_provider: &dyn JsrUrlProvider,
     maybe_resolver: Option<&dyn Resolver>,
-    maybe_npm_resolver: Option<&dyn NpmResolver>,
   ) -> Self {
     let dependency = self
       .dependency
@@ -870,7 +866,6 @@ impl TypesDependency {
           ResolutionKind::Types,
           jsr_url_provider,
           maybe_resolver,
-          maybe_npm_resolver,
         )
       })
       .unwrap_or_default();
@@ -1245,7 +1240,6 @@ impl GraphImport {
     imports: Vec<String>,
     jsr_url_provider: &dyn JsrUrlProvider,
     maybe_resolver: Option<&dyn Resolver>,
-    maybe_npm_resolver: Option<&dyn NpmResolver>,
   ) -> Self {
     let dependencies = imports
       .into_iter()
@@ -1261,7 +1255,6 @@ impl GraphImport {
           ResolutionKind::Types,
           jsr_url_provider,
           maybe_resolver,
-          maybe_npm_resolver,
         );
         (
           import,
@@ -1296,7 +1289,6 @@ pub struct BuildFastCheckTypeGraphOptions<'a> {
   pub jsr_url_provider: &'a dyn JsrUrlProvider,
   pub es_parser: Option<&'a dyn crate::EsParser>,
   pub resolver: Option<&'a dyn Resolver>,
-  pub npm_resolver: Option<&'a dyn NpmResolver>,
   /// Whether to fill workspace members with fast check TypeScript data.
   pub workspace_fast_check: WorkspaceFastCheckOption<'a>,
 }
@@ -1943,7 +1935,6 @@ impl ModuleGraph {
             &NullFileSystem,
             options.jsr_url_provider,
             options.resolver,
-            options.npm_resolver,
           );
           FastCheckTypeModuleSlot::Module(Box::new(FastCheckTypeModule {
             dependencies,
@@ -2270,7 +2261,6 @@ fn resolve(
   resolution_kind: ResolutionKind,
   jsr_url_provider: &dyn JsrUrlProvider,
   maybe_resolver: Option<&dyn Resolver>,
-  maybe_npm_resolver: Option<&dyn NpmResolver>,
 ) -> Resolution {
   let response = if let Some(resolver) = maybe_resolver {
     resolver.resolve(specifier_text, &referrer_range, resolution_kind)
@@ -2291,39 +2281,6 @@ fn resolve(
               range: referrer_range.clone(),
             },
           ));
-        }
-      }
-    }
-  }
-  if let Some(npm_resolver) = maybe_npm_resolver {
-    if npm_resolver.enables_bare_builtin_node_module() {
-      use import_map::ImportMapErrorKind;
-      use ResolveError::*;
-      use SpecifierError::*;
-      let res_ref = response.as_ref();
-      if matches!(res_ref, Err(Specifier(ImportPrefixMissing { .. })))
-        || matches!(
-          res_ref,
-          Err(ImportMap(error)) if matches!(
-            error.as_kind(),
-            ImportMapErrorKind::UnmappedBareSpecifier(_, _)
-          )
-        )
-      {
-        if let Ok(specifier) =
-          ModuleSpecifier::parse(&format!("node:{}", specifier_text))
-        {
-          if npm_resolver.resolve_builtin_node_module(&specifier).is_ok() {
-            npm_resolver.on_resolve_bare_builtin_node_module(
-              specifier_text,
-              &referrer_range,
-            );
-            return Resolution::from_resolve_result(
-              Ok(specifier),
-              specifier_text,
-              referrer_range,
-            );
-          }
         }
       }
     }
@@ -2594,7 +2551,6 @@ pub(crate) fn parse_module(
   file_system: &FileSystem,
   jsr_url_provider: &dyn JsrUrlProvider,
   maybe_resolver: Option<&dyn Resolver>,
-  maybe_npm_resolver: Option<&dyn NpmResolver>,
   options: ParseModuleOptions,
 ) -> Module {
   match options.module_source_and_info {
@@ -2622,7 +2578,6 @@ pub(crate) fn parse_module(
       file_system,
       jsr_url_provider,
       maybe_resolver,
-      maybe_npm_resolver,
     )),
     ModuleSourceAndInfo::Wasm {
       specifier,
@@ -2638,7 +2593,6 @@ pub(crate) fn parse_module(
       file_system,
       jsr_url_provider,
       maybe_resolver,
-      maybe_npm_resolver,
     )),
   }
 }
@@ -2654,7 +2608,6 @@ pub(crate) fn parse_js_module_from_module_info(
   file_system: &FileSystem,
   jsr_url_provider: &dyn JsrUrlProvider,
   maybe_resolver: Option<&dyn Resolver>,
-  maybe_npm_resolver: Option<&dyn NpmResolver>,
 ) -> JsModule {
   let mut module = JsModule::new(specifier, source);
   module.is_script = module_info.is_script;
@@ -2676,7 +2629,6 @@ pub(crate) fn parse_js_module_from_module_info(
           ResolutionKind::Types,
           jsr_url_provider,
           maybe_resolver,
-          maybe_npm_resolver,
         ),
       });
     }
@@ -2700,7 +2652,6 @@ pub(crate) fn parse_js_module_from_module_info(
               ResolutionKind::Types,
               jsr_url_provider,
               maybe_resolver,
-              maybe_npm_resolver,
             );
           }
           dep.imports.push(Import {
@@ -2730,7 +2681,6 @@ pub(crate) fn parse_js_module_from_module_info(
             ResolutionKind::Types,
             jsr_url_provider,
             maybe_resolver,
-            maybe_npm_resolver,
           );
           if is_untyped {
             module.maybe_types_dependency = Some(TypesDependency {
@@ -2816,7 +2766,6 @@ pub(crate) fn parse_js_module_from_module_info(
           ResolutionKind::Execution,
           jsr_url_provider,
           maybe_resolver,
-          maybe_npm_resolver,
         );
       }
       if graph_kind.include_types() && dep.maybe_type.is_none() {
@@ -2850,7 +2799,6 @@ pub(crate) fn parse_js_module_from_module_info(
             ResolutionKind::Types,
             jsr_url_provider,
             maybe_resolver,
-            maybe_npm_resolver,
           );
           dep.maybe_deno_types_specifier = Some(specifier_text);
         } else {
@@ -2860,7 +2808,6 @@ pub(crate) fn parse_js_module_from_module_info(
             ResolutionKind::Types,
             jsr_url_provider,
             maybe_resolver,
-            maybe_npm_resolver,
           );
           if types_resolution.maybe_specifier()
             != dep.maybe_code.maybe_specifier()
@@ -2901,7 +2848,6 @@ pub(crate) fn parse_js_module_from_module_info(
           ResolutionKind::Types,
           jsr_url_provider,
           maybe_resolver,
-          maybe_npm_resolver,
         );
       }
       dep.imports.push(Import {
@@ -2931,7 +2877,6 @@ pub(crate) fn parse_js_module_from_module_info(
             ResolutionKind::Types,
             jsr_url_provider,
             maybe_resolver,
-            maybe_npm_resolver,
           ),
         });
       }
@@ -2991,7 +2936,6 @@ pub(crate) fn parse_js_module_from_module_info(
     file_system,
     jsr_url_provider,
     maybe_resolver,
-    maybe_npm_resolver,
   );
 
   // Return the module as a valid module
@@ -3008,7 +2952,6 @@ fn parse_wasm_module_from_module_info(
   file_system: &FileSystem,
   jsr_url_provider: &dyn JsrUrlProvider,
   maybe_resolver: Option<&dyn Resolver>,
-  maybe_npm_resolver: Option<&dyn NpmResolver>,
 ) -> WasmModule {
   let mut module = WasmModule {
     specifier,
@@ -3026,7 +2969,6 @@ fn parse_wasm_module_from_module_info(
     file_system,
     jsr_url_provider,
     maybe_resolver,
-    maybe_npm_resolver,
   );
   module
 }
@@ -3041,7 +2983,6 @@ fn fill_module_dependencies(
   file_system: &FileSystem,
   jsr_url_provider: &dyn JsrUrlProvider,
   maybe_resolver: Option<&dyn Resolver>,
-  maybe_npm_resolver: Option<&dyn NpmResolver>,
 ) {
   for desc in dependencies {
     let (imports, types_specifier) = match desc {
@@ -3178,7 +3119,6 @@ fn fill_module_dependencies(
             ResolutionKind::Types,
             jsr_url_provider,
             maybe_resolver,
-            maybe_npm_resolver,
           );
         }
       }
@@ -3190,7 +3130,6 @@ fn fill_module_dependencies(
             ResolutionKind::Types,
             jsr_url_provider,
             maybe_resolver,
-            maybe_npm_resolver,
           );
         }
       } else if dep.maybe_code.is_none() {
@@ -3202,7 +3141,6 @@ fn fill_module_dependencies(
           ResolutionKind::Execution,
           jsr_url_provider,
           maybe_resolver,
-          maybe_npm_resolver,
         );
         dep.is_dynamic = import.is_dynamic;
       } else {
@@ -3219,7 +3157,6 @@ fn fill_module_dependencies(
           ResolutionKind::Types,
           jsr_url_provider,
           maybe_resolver,
-          maybe_npm_resolver,
         );
         // only bother setting if the resolved specifier
         // does not match the code specifier
@@ -3813,7 +3750,6 @@ impl<'a, 'graph> Builder<'a, 'graph> {
         imports,
         self.jsr_url_provider,
         self.resolver,
-        self.npm_resolver,
       );
       for dep in graph_import.dependencies.values() {
         if let Resolution::Ok(resolved) = &dep.maybe_type {
@@ -4682,25 +4618,8 @@ impl<'a, 'graph> Builder<'a, 'graph> {
             NpmLoadError::PackageReqReferenceParse(err).into(),
           ))
         }),
-      _ => {
-        if let Some(npm_resolver) = self.npm_resolver {
-          match npm_resolver.resolve_builtin_node_module(specifier) {
-            Ok(Some(builtin_module)) => {
-              return Ok(LoadSpecifierKind::Node(builtin_module))
-            }
-            Ok(None) => {}
-            Err(err) => {
-              return Err(Box::new(ModuleError::LoadingErr(
-                specifier.clone(),
-                maybe_range.cloned(),
-                err.into(),
-              )))
-            }
-          }
-        }
-
-        Ok(LoadSpecifierKind::Url)
-      }
+      "node" => Ok(LoadSpecifierKind::Node(specifier.path().to_string())),
+      _ => Ok(LoadSpecifierKind::Url),
     }
   }
 
@@ -5174,7 +5093,6 @@ impl<'a, 'graph> Builder<'a, 'graph> {
       self.file_system,
       self.jsr_url_provider,
       self.resolver,
-      self.npm_resolver,
       ParseModuleOptions {
         graph_kind: self.graph.graph_kind,
         module_source_and_info,
@@ -5843,7 +5761,7 @@ mod tests {
       ..Default::default()
     };
     let new_dependency =
-      dependency.with_new_resolver("./b.ts", Default::default(), None, None);
+      dependency.with_new_resolver("./b.ts", Default::default(), None);
     assert_eq!(
       new_dependency,
       Dependency {
@@ -5884,7 +5802,7 @@ mod tests {
       })),
     };
     let new_types_dependency =
-      types_dependency.with_new_resolver(Default::default(), None, None);
+      types_dependency.with_new_resolver(Default::default(), None);
     assert_eq!(
       new_types_dependency,
       TypesDependency {

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -489,14 +489,6 @@ pub trait Resolver: fmt::Debug {
   }
 }
 
-#[derive(Error, Debug, Clone, deno_error::JsError)]
-#[class("NotFound")]
-#[error("Unknown built-in \"node:\" module: {module_name}")]
-pub struct UnknownBuiltInNodeModuleError {
-  /// Name of the invalid module.
-  pub module_name: String,
-}
-
 #[derive(Debug)]
 pub struct NpmResolvePkgReqsResult {
   /// The individual results of resolving the package requirements.

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -512,20 +512,6 @@ pub struct NpmResolvePkgReqsResult {
 
 #[async_trait(?Send)]
 pub trait NpmResolver: fmt::Debug {
-  /// Gets the builtin node module name from the specifier (ex. "node:fs" -> "fs").
-  fn resolve_builtin_node_module(
-    &self,
-    specifier: &ModuleSpecifier,
-  ) -> Result<Option<String>, UnknownBuiltInNodeModuleError>;
-
-  /// The callback when a bare specifier is resolved to a builtin node module.
-  /// (Note: used for printing warnings to discourage that usage of bare specifiers)
-  fn on_resolve_bare_builtin_node_module(
-    &self,
-    module_name: &str,
-    range: &Range,
-  );
-
   /// This is an optimization for the implementation to start loading and caching
   /// the npm registry package information ahead of time.
   fn load_and_cache_npm_package_info(&self, package_name: &str);
@@ -538,11 +524,6 @@ pub trait NpmResolver: fmt::Debug {
     &self,
     package_req: &[PackageReq],
   ) -> NpmResolvePkgReqsResult;
-
-  /// Returns true when bare node specifier resoluion is enabled
-  fn enables_bare_builtin_node_module(&self) -> bool {
-    false
-  }
 }
 
 pub fn load_data_url(

--- a/tests/ecosystem_test.rs
+++ b/tests/ecosystem_test.rs
@@ -325,7 +325,6 @@ async fn test_version(
     jsr_url_provider: &PassthroughJsrUrlProvider,
     es_parser: Some(&module_analyzer),
     resolver: None,
-    npm_resolver: None,
     workspace_fast_check: WorkspaceFastCheckOption::Enabled(&workspace_members),
   });
 

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -99,21 +99,6 @@ struct TestNpmResolver;
 
 #[async_trait(?Send)]
 impl NpmResolver for TestNpmResolver {
-  fn resolve_builtin_node_module(
-    &self,
-    _specifier: &ModuleSpecifier,
-  ) -> Result<Option<String>, deno_graph::source::UnknownBuiltInNodeModuleError>
-  {
-    Ok(None)
-  }
-
-  fn on_resolve_bare_builtin_node_module(
-    &self,
-    _module_name: &str,
-    _range: &deno_graph::Range,
-  ) {
-  }
-
   fn load_and_cache_npm_package_info(&self, _package_name: &str) {}
 
   async fn resolve_pkg_reqs(
@@ -323,7 +308,6 @@ impl TestBuilder {
           jsr_url_provider: Default::default(),
           es_parser: Some(&capturing_analyzer),
           resolver: None,
-          npm_resolver: None,
           workspace_fast_check: if self.workspace_fast_check {
             WorkspaceFastCheckOption::Enabled(&self.workspace_members)
           } else {

--- a/tests/specs/ecosystem/mrii/rocket_io/0_1_3.test
+++ b/tests/specs/ecosystem/mrii/rocket_io/0_1_3.test
@@ -73,10 +73,10 @@ mrii/rocket-io/0.1.3
 
 -- stderr --
 error: Error: [ERR_PACKAGE_PATH_NOT_EXPORTED] Package subpath './build/esm/socket' is not defined for types by "exports" in '<global_npm_dir>/socket.io-client/4.7.5/package.json' imported from 'file://<tmpdir>/src/types/socket-reserved-events.ts'
-    at Object.resolveModuleNameLiterals (ext:deno_cli_tsc/97_ts_host.js:623:26)
-    at ext:deno_cli_tsc/97_ts_host.js:758:49
+    at Object.resolveModuleNameLiterals (ext:deno_cli_tsc/97_ts_host.js:633:26)
+    at ext:deno_cli_tsc/97_ts_host.js:775:49
     at spanned (ext:deno_cli_tsc/97_ts_host.js:16:12)
-    at Object.host.<computed> [as resolveModuleNameLiterals] (ext:deno_cli_tsc/97_ts_host.js:758:14)
+    at Object.host.<computed> [as resolveModuleNameLiterals] (ext:deno_cli_tsc/97_ts_host.js:775:14)
     at resolveModuleNamesWorker (ext:deno_cli_tsc/00_typescript.js:126315:20)
     at resolveNamesReusingOldState (ext:deno_cli_tsc/00_typescript.js:126457:14)
     at resolveModuleNamesReusingOldState (ext:deno_cli_tsc/00_typescript.js:126413:12)

--- a/tests/specs/graph/cjs/basic.txt
+++ b/tests/specs/graph/cjs/basic.txt
@@ -178,8 +178,9 @@ module.exports = 5;
       "specifier": "file:///other.cjs"
     },
     {
+      "kind": "node",
       "specifier": "node:module",
-      "error": "Module not found \"node:module\"."
+      "moduleName": "module"
     }
   ],
   "redirects": {}


### PR DESCRIPTION
We should have this in deno_resolver instead.

CLI PR:

* https://github.com/denoland/deno/pull/29000