### PR TITLE
Revert "feat: allow source of modules to be removed from the graph (#579)"

### DIFF
--- a/src/fast_check/mod.rs
+++ b/src/fast_check/mod.rs
@@ -533,7 +533,7 @@ pub fn build_fast_check_type_graph<'a>(
           let source_hash = graph
             .get(specifier)
             .and_then(|m| m.source())
-            .map(|s| fast_insecure_hash(s.get().unwrap().as_bytes()))
+            .map(|s| fast_insecure_hash(s.as_bytes()))
             .unwrap_or(0);
           if errors.is_empty() {
             let module = module_result.as_ref().ok().unwrap();
@@ -561,7 +561,7 @@ pub fn build_fast_check_type_graph<'a>(
           let source_hash = graph
             .get(specifier)
             .and_then(|m| m.source())
-            .map(|s| fast_insecure_hash(s.get().unwrap().as_bytes()))
+            .map(|s| fast_insecure_hash(s.as_bytes()))
             .unwrap_or(0);
           package_cache_items.push((
             specifier.clone(),

--- a/src/fast_check/range_finder.rs
+++ b/src/fast_check/range_finder.rs
@@ -520,7 +520,7 @@ impl<'a> PublicRangeFinder<'a> {
         .graph
         .get(specifier)
         .and_then(|m| m.source())
-        .map(|s| fast_insecure_hash(s.get().unwrap().as_bytes()))
+        .map(|s| fast_insecure_hash(s.as_bytes()))
         .unwrap_or(0);
       if hash != module_item.source_hash() {
         return false;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -63,7 +63,6 @@ use futures::stream::StreamExt;
 use futures::FutureExt;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
-use parking_lot::Mutex;
 use serde::ser::SerializeSeq;
 use serde::ser::SerializeStruct;
 use serde::Deserialize;
@@ -978,7 +977,7 @@ impl Module {
     }
   }
 
-  pub fn source(&self) -> Option<&SourceCell<str>> {
+  pub fn source(&self) -> Option<&Arc<str>> {
     match self {
       crate::Module::Js(m) => Some(&m.source),
       crate::Module::Json(m) => Some(&m.source),
@@ -1025,55 +1024,6 @@ impl Module {
   }
 }
 
-#[derive(Debug, Error)]
-#[error("Value in text source cell was taken. This is a bug in the use of deno_graph. Please report this as an issue.")]
-pub struct SourceCellValueNotExistsError;
-
-#[derive(Debug)]
-pub struct SourceCell<T: ?Sized>(Mutex<Option<Arc<T>>>);
-
-impl Serialize for SourceCell<str> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let len = match &*self.0.lock() {
-      Some(arc_str) => arc_str.len() as u32,
-      None => 0,
-    };
-    serializer.serialize_u32(len)
-  }
-}
-
-impl Serialize for SourceCell<[u8]> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let len = match &*self.0.lock() {
-      Some(bytes) => bytes.len() as u32,
-      None => 0,
-    };
-    serializer.serialize_u32(len)
-  }
-}
-
-impl<T: ?Sized> SourceCell<T> {
-  pub fn new(value: Arc<T>) -> Self {
-    Self(Mutex::new(Some(value)))
-  }
-
-  /// Gets the value found in the cell.
-  pub fn get(&self) -> Result<Arc<T>, SourceCellValueNotExistsError> {
-    self.0.lock().clone().ok_or(SourceCellValueNotExistsError)
-  }
-
-  /// Takes the value out of the cell.
-  pub fn take(&self) -> Result<Arc<T>, SourceCellValueNotExistsError> {
-    self.0.lock().take().ok_or(SourceCellValueNotExistsError)
-  }
-}
-
 static EMPTY_DEPS: std::sync::OnceLock<IndexMap<String, Dependency>> =
   std::sync::OnceLock::new();
 
@@ -1111,8 +1061,8 @@ pub struct JsonModule {
   pub specifier: ModuleSpecifier,
   #[serde(flatten, skip_serializing_if = "Option::is_none")]
   pub maybe_cache_info: Option<CacheInfo>,
-  #[serde(rename = "size")]
-  pub source: Arc<SourceCell<str>>,
+  #[serde(rename = "size", serialize_with = "serialize_source")]
+  pub source: Arc<str>,
   // todo(#240): This will always be MediaType::Json, but it's currently
   // used in the --json output. It's redundant though.
   pub media_type: MediaType,
@@ -1120,8 +1070,8 @@ pub struct JsonModule {
 
 impl JsonModule {
   /// Return the size in bytes of the content of the JSON module.
-  pub fn size(&self) -> Result<usize, SourceCellValueNotExistsError> {
-    self.source.get().map(|v| v.len())
+  pub fn size(&self) -> usize {
+    self.source.len()
   }
 }
 
@@ -1152,8 +1102,8 @@ pub struct JsModule {
   pub dependencies: IndexMap<String, Dependency>,
   #[serde(flatten, skip_serializing_if = "Option::is_none")]
   pub maybe_cache_info: Option<CacheInfo>,
-  #[serde(rename = "size")]
-  pub source: Arc<SourceCell<str>>,
+  #[serde(rename = "size", serialize_with = "serialize_source")]
+  pub source: Arc<str>,
   #[serde(rename = "typesDependency", skip_serializing_if = "Option::is_none")]
   pub maybe_types_dependency: Option<TypesDependency>,
   #[serde(skip_serializing_if = "is_media_type_unknown")]
@@ -1169,7 +1119,7 @@ impl JsModule {
       is_script: false,
       dependencies: Default::default(),
       maybe_cache_info: None,
-      source: Arc::new(SourceCell::new(source)),
+      source,
       maybe_types_dependency: None,
       media_type: MediaType::Unknown,
       specifier,
@@ -1178,8 +1128,8 @@ impl JsModule {
   }
 
   /// Return the size in bytes of the content of the module.
-  pub fn size(&self) -> Result<usize, SourceCellValueNotExistsError> {
-    self.source.get().map(|v| v.len())
+  pub fn size(&self) -> usize {
+    self.source.len()
   }
 
   pub fn fast_check_diagnostics(&self) -> Option<&Vec<FastCheckDiagnostic>> {
@@ -1217,8 +1167,8 @@ pub struct WasmModule {
     serialize_with = "serialize_dependencies"
   )]
   pub dependencies: IndexMap<String, Dependency>,
-  #[serde(rename = "size")]
-  pub source: Arc<SourceCell<[u8]>>,
+  #[serde(rename = "size", serialize_with = "serialize_source_bytes")]
+  pub source: Arc<[u8]>,
   #[serde(skip_serializing)]
   pub source_dts: Arc<str>,
   #[serde(flatten, skip_serializing_if = "Option::is_none")]
@@ -1227,8 +1177,8 @@ pub struct WasmModule {
 
 impl WasmModule {
   /// Return the size in bytes of the content of the module.
-  pub fn size(&self) -> Result<usize, SourceCellValueNotExistsError> {
-    self.source.get().map(|s| s.len())
+  pub fn size(&self) -> usize {
+    self.source.len()
   }
 }
 
@@ -2604,7 +2554,7 @@ pub(crate) fn parse_module(
     ModuleSourceAndInfo::Json { specifier, source } => {
       Module::Json(JsonModule {
         maybe_cache_info: None,
-        source: Arc::new(SourceCell::new(source)),
+        source,
         media_type: MediaType::Json,
         specifier,
       })
@@ -3003,7 +2953,7 @@ fn parse_wasm_module_from_module_info(
   let mut module = WasmModule {
     specifier,
     dependencies: Default::default(),
-    source: Arc::new(SourceCell::new(source)),
+    source,
     source_dts,
     maybe_cache_info: None,
   };
@@ -4066,7 +4016,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
                         None, // no charset for JSR
                       ) {
                         Ok(source) => {
-                          module.source = Arc::new(SourceCell::new(source));
+                          module.source = source;
                         }
                         Err(err) => *slot = ModuleSlot::Err(*err),
                       }
@@ -4078,7 +4028,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
                         None, // no charset for JSR
                       ) {
                         Ok(source) => {
-                          module.source = Arc::new(SourceCell::new(source));
+                          module.source = source;
                         }
                         Err(err) => *slot = ModuleSlot::Err(*err),
                       }
@@ -4086,8 +4036,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
                     Module::Wasm(module) => {
                       match wasm_module_to_dts(&content) {
                         Ok(source_dts) => {
-                          module.source =
-                            Arc::new(SourceCell::new(content.clone()));
+                          module.source = content.clone();
                           module.source_dts = source_dts.into();
                         }
                         Err(err) => {
@@ -5582,6 +5531,26 @@ where
   seq.end()
 }
 
+fn serialize_source<S>(
+  source: &Arc<str>,
+  serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+  S: Serializer,
+{
+  serializer.serialize_u32(source.len() as u32)
+}
+
+fn serialize_source_bytes<S>(
+  source: &Arc<[u8]>,
+  serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+  S: Serializer,
+{
+  serializer.serialize_u32(source.len() as u32)
+}
+
 #[cfg(test)]
 mod tests {
   use crate::packages::JsrPackageInfoVersion;
@@ -6826,10 +6795,8 @@ mod tests {
       unreachable!();
     };
     let dts = fsm.dts.unwrap();
-    let source_map = SourceMap::single(
-      module.specifier.clone(),
-      module.source.get().unwrap().to_string(),
-    );
+    let source_map =
+      SourceMap::single(module.specifier.clone(), module.source.to_string());
     let EmittedSourceText { text, .. } = emit(
       (&dts.program).into(),
       &dts.comments.as_single_threaded(),
@@ -6914,7 +6881,7 @@ mod tests {
       let dts = fsm.dts.unwrap();
       let source_map = SourceMap::single(
         module.specifier().clone(),
-        module.source().unwrap().get().unwrap().to_string(),
+        module.source().unwrap().to_string(),
       );
       let EmittedSourceText { text, .. } = emit(
         (&dts.program).into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1743,7 +1743,7 @@ export function a(a) {
     let data_specifier = ModuleSpecifier::parse("data:application/typescript,export%20*%20from%20%22https://example.com/c.ts%22;").unwrap();
     let module = graph.get(&data_specifier).unwrap().js().unwrap();
     assert_eq!(
-      module.source.as_ref().get().unwrap().to_string(),
+      module.source.as_ref(),
       r#"export * from "https://example.com/c.ts";"#,
     );
   }

--- a/src/symbols/analyzer.rs
+++ b/src/symbols/analyzer.rs
@@ -175,8 +175,7 @@ impl<'a> RootSymbol<'a> {
     let specifier = &json_module.specifier;
     // it's not ideal having to use SourceTextInfo here, but it makes
     // it easier to interop with ParsedSource
-    let source_text_info =
-      SourceTextInfo::new(json_module.source.get().unwrap().clone());
+    let source_text_info = SourceTextInfo::new(json_module.source.clone());
     let range = source_text_info.range();
     let module_id = ModuleId(self.ids_to_modules.len() as u32);
     let decls = {
@@ -281,7 +280,7 @@ impl<'a> RootSymbol<'a> {
   ) -> Result<ParsedSource, deno_ast::ParseDiagnostic> {
     self.parser.parse_program(ParseOptions {
       specifier: &graph_module.specifier,
-      source: graph_module.source.get().unwrap().clone(),
+      source: graph_module.source.clone(),
       media_type: graph_module.media_type,
       scope_analysis: true,
     })

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -783,7 +783,7 @@ async fn test_fill_from_lockfile() {
   assert_eq!(modules.len(), 1);
   let module = modules.into_iter().next().unwrap().js().unwrap();
   assert_eq!(
-    module.source.as_ref().get().unwrap().to_string(),
+    module.source.as_ref(),
     "// This is version 1.0.0 of this package."
   );
 }

--- a/tests/specs_test.rs
+++ b/tests/specs_test.rs
@@ -181,7 +181,7 @@ fn run_graph_test(test: &CollectedTest) {
         if let Some(dts) = &fast_check.dts {
           let source_map = SourceMap::single(
             module.specifier.clone(),
-            module.source.get().unwrap().to_string(),
+            module.source.to_string(),
           );
           let EmittedSourceText { text, .. } = emit(
             (&dts.program).into(),


### PR DESCRIPTION
This reverts commit 6429114237dd9c49d59bde7c6663a4b89444d954.

I think it's too complicated because we need to keep most of this around for doing stuff like getting the original source text when displaying errors: https://github.com/denoland/deno/blob/8687526f947fbaeafd3f0dd0652d30ab95585170/cli/module_loader.rs#L1197-L1201

Additionally, it brings some complications around how this would work once we have the ability to import bytes and text as we need the original bytes around. I think we should revist this in the future once we land `{ type: "bytes" }` and `"text"`.