### PR TITLE
feat: ability to reload certain specifiers and store mtime in graph

### DIFF
--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -306,6 +306,7 @@ pub async fn js_create_graph(
   graph
     .build(
       roots,
+      imports,
       &loader,
       BuildOptions {
         is_dynamic: false,
@@ -321,7 +322,6 @@ pub async fn js_create_graph(
         locker: None,
         passthrough_jsr_specifiers: false,
         module_analyzer: Default::default(),
-        imports,
         reporter: None,
         executor: Default::default(),
       },
@@ -370,6 +370,7 @@ pub async fn js_parse_module(
     graph_kind: GraphKind::All,
     specifier,
     maybe_headers,
+    mtime: None,
     content: content.into(),
     file_system: &NullFileSystem,
     jsr_url_provider: Default::default(),

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -101,7 +101,7 @@ impl Loader for JsLoader {
       let context = JsValue::null();
       let arg1 = JsValue::from(specifier.to_string());
       let arg2 = serde_wasm_bindgen::to_value(&JsLoadOptions {
-        is_dynamic: options.is_dynamic,
+        is_dynamic: options.in_dynamic_branch,
         cache_setting: options.cache_setting.as_js_str(),
         checksum: options.maybe_checksum.map(|c| c.into_string()),
       })

--- a/src/fast_check/transform_dts.rs
+++ b/src/fast_check/transform_dts.rs
@@ -1088,6 +1088,7 @@ mod tests {
     graph
       .build(
         vec![specifier.clone()],
+        Default::default(),
         &loader,
         BuildOptions {
           module_analyzer: &analyzer,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1010,6 +1010,17 @@ impl Module {
       Module::Npm(_) | Module::External(_) => MediaType::Unknown,
     }
   }
+  
+  pub fn mtime(&self) -> Option<SystemTime> {
+    match self {
+        Module::Js(m) => m.mtime,
+        Module::Json(m) => m.mtime,
+        Module::Wasm(m) => m.mtime,
+        Module::Npm(_) |
+        Module::Node(_) |
+        Module::External(_) => None,
+    }
+  }
 
   pub fn json(&self) -> Option<&JsonModule> {
     if let Module::Json(module) = &self {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -285,6 +285,8 @@ pub enum ModuleLoadError {
 #[derive(Debug, JsError)]
 #[class(inherit)]
 pub struct DecodeError {
+  /// Modified time of the underlying file. Used to tell whether
+  /// the file should be reloaded.
   pub mtime: Option<SystemTime>,
   #[inherit]
   pub err: std::io::Error,
@@ -324,6 +326,8 @@ pub enum ModuleError {
   #[class(inherit)]
   Parse {
     specifier: ModuleSpecifier,
+    /// Modified time of the underlying file. Used to tell whether
+    /// the file should be reloaded.
     mtime: Option<SystemTime>,
     #[inherit]
     diagnostic: ParseDiagnostic,
@@ -331,6 +335,8 @@ pub enum ModuleError {
   #[class(inherit)]
   WasmParse {
     specifier: ModuleSpecifier,
+    /// Modified time of the underlying file. Used to tell whether
+    /// the file should be reloaded.
     mtime: Option<SystemTime>,
     #[inherit]
     err: wasm_dep_analyzer::ParseError,
@@ -385,24 +391,24 @@ impl ModuleError {
     }
   }
 
-  /// Gets the mtime of the loaded file that caused this error.
+  /// Gets the mtime (if able) of the loaded file that caused this error.
   pub fn mtime(&self) -> Option<SystemTime> {
     match self {
-        ModuleError::Parse { mtime, .. } |
-        ModuleError::WasmParse { mtime, .. } => *mtime,
-        ModuleError::Load { err, .. } => match err {
-            ModuleLoadError::Decode(decode_error) => decode_error.mtime,
-            ModuleLoadError::HttpsChecksumIntegrity { .. } |
-            ModuleLoadError::Loader { .. } |
-            ModuleLoadError::Jsr { .. } |
-            ModuleLoadError::Npm { .. } |
-            ModuleLoadError::TooManyRedirects => None,
-        },
-        ModuleError::Missing { .. } |
-        ModuleError::MissingDynamic { .. } |
-        ModuleError::UnsupportedMediaType { .. } |
-        ModuleError::InvalidTypeAssertion { .. } |
-        ModuleError::UnsupportedImportAttributeType { .. } => None,
+      ModuleError::Parse { mtime, .. }
+      | ModuleError::WasmParse { mtime, .. } => *mtime,
+      ModuleError::Load { err, .. } => match err {
+        ModuleLoadError::Decode(decode_error) => decode_error.mtime,
+        ModuleLoadError::HttpsChecksumIntegrity { .. }
+        | ModuleLoadError::Loader { .. }
+        | ModuleLoadError::Jsr { .. }
+        | ModuleLoadError::Npm { .. }
+        | ModuleLoadError::TooManyRedirects => None,
+      },
+      ModuleError::Missing { .. }
+      | ModuleError::MissingDynamic { .. }
+      | ModuleError::UnsupportedMediaType { .. }
+      | ModuleError::InvalidTypeAssertion { .. }
+      | ModuleError::UnsupportedImportAttributeType { .. } => None,
     }
   }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -385,6 +385,27 @@ impl ModuleError {
     }
   }
 
+  /// Gets the mtime of the loaded file that caused this error.
+  pub fn mtime(&self) -> Option<SystemTime> {
+    match self {
+        ModuleError::Parse { mtime, .. } |
+        ModuleError::WasmParse { mtime, .. } => *mtime,
+        ModuleError::Load { err, .. } => match err {
+            ModuleLoadError::Decode(decode_error) => decode_error.mtime,
+            ModuleLoadError::HttpsChecksumIntegrity { .. } |
+            ModuleLoadError::Loader { .. } |
+            ModuleLoadError::Jsr { .. } |
+            ModuleLoadError::Npm { .. } |
+            ModuleLoadError::TooManyRedirects => None,
+        },
+        ModuleError::Missing { .. } |
+        ModuleError::MissingDynamic { .. } |
+        ModuleError::UnsupportedMediaType { .. } |
+        ModuleError::InvalidTypeAssertion { .. } |
+        ModuleError::UnsupportedImportAttributeType { .. } => None,
+    }
+  }
+
   /// Converts the error into a string along with the range related to the error.
   pub fn to_string_with_range(&self) -> String {
     if let Some(range) = self.maybe_referrer() {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1010,15 +1010,13 @@ impl Module {
       Module::Npm(_) | Module::External(_) => MediaType::Unknown,
     }
   }
-  
+
   pub fn mtime(&self) -> Option<SystemTime> {
     match self {
-        Module::Js(m) => m.mtime,
-        Module::Json(m) => m.mtime,
-        Module::Wasm(m) => m.mtime,
-        Module::Npm(_) |
-        Module::Node(_) |
-        Module::External(_) => None,
+      Module::Js(m) => m.mtime,
+      Module::Json(m) => m.mtime,
+      Module::Wasm(m) => m.mtime,
+      Module::Npm(_) | Module::Node(_) | Module::External(_) => None,
     }
   }
 

--- a/src/jsr.rs
+++ b/src/jsr.rs
@@ -194,7 +194,7 @@ impl JsrMetadataStore {
     let fut = services.loader.load(
       &specifier,
       LoadOptions {
-        is_dynamic: false,
+        in_dynamic_branch: false,
         was_dynamic_root: false,
         cache_setting,
         maybe_checksum: maybe_expected_checksum,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,10 @@ pub use deno_ast::dep::ImportAttribute;
 pub use deno_ast::dep::ImportAttributes;
 pub use deno_ast::dep::StaticDependencyKind;
 
+/// Additional import that should be brought into the scope of
+/// the module graph to add to the graph's "imports". This may
+/// be extra modules such as TypeScript's "types" option or JSX
+/// runtime types.
 #[derive(Debug, Clone)]
 pub struct ReferrerImports {
   /// The referrer to resolve the imports from.
@@ -241,7 +245,12 @@ mod tests {
       ModuleSpecifier::parse("file:///a/test01.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert_eq!(graph.module_slots.len(), 2);
     assert_eq!(graph.roots, IndexSet::from([root_specifier.clone()]));
@@ -318,7 +327,12 @@ mod tests {
     ]);
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(roots.iter().cloned().collect(), &loader, Default::default())
+      .build(
+        roots.iter().cloned().collect(),
+        Vec::new(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert_eq!(graph.module_slots.len(), 4);
     assert_eq!(graph.roots, roots);
@@ -388,14 +402,24 @@ mod tests {
       ModuleSpecifier::parse("https://example.com/d.ts").unwrap();
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![first_root.clone()], &loader, Default::default())
+      .build(
+        vec![first_root.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert_eq!(graph.module_slots.len(), 4);
     assert_eq!(graph.roots, IndexSet::from([first_root.clone()]));
 
     // now build with the second root
     graph
-      .build(vec![second_root.clone()], &loader, Default::default())
+      .build(
+        vec![second_root.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     let mut roots = IndexSet::from([first_root, second_root]);
     assert_eq!(graph.module_slots.len(), 5);
@@ -415,7 +439,12 @@ mod tests {
 
     // now try making one of the already existing modules a root
     graph
-      .build(vec![third_root.clone()], &loader, Default::default())
+      .build(
+        vec![third_root.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     roots.insert(third_root);
     assert_eq!(graph.module_slots.len(), 5);
@@ -440,6 +469,7 @@ mod tests {
     graph
       .build(
         roots.clone(),
+        Default::default(),
         &loader,
         BuildOptions {
           is_dynamic: true,
@@ -497,7 +527,12 @@ console.log(a);
       ModuleSpecifier::parse("file:///a/test01.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert!(graph.valid().is_ok());
   }
@@ -521,7 +556,12 @@ console.log(a);
     let root_specifier = ModuleSpecifier::parse("file:///a/test01.ts").unwrap();
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert!(graph.valid().is_err());
     assert_eq!(
@@ -550,7 +590,12 @@ console.log(a);
       ModuleSpecifier::parse("https://deno.land/main.ts").unwrap();
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert!(graph.valid().is_ok());
   }
@@ -587,7 +632,12 @@ console.log(a);
       );
       let mut graph = ModuleGraph::new(GraphKind::All);
       graph
-        .build(vec![root_specifier], &loader, Default::default())
+        .build(
+          vec![root_specifier],
+          Default::default(),
+          &loader,
+          Default::default(),
+        )
         .await;
       assert!(matches!(
         graph.valid().err().unwrap(),
@@ -639,6 +689,7 @@ console.log(a);
       graph
         .build(
           vec![root_specifier.clone()],
+          Default::default(),
           &loader,
           BuildOptions {
             resolver: maybe_resolver,
@@ -692,11 +743,9 @@ console.log(a);
     graph
       .build(
         vec![root_specifier],
+        imports,
         &loader,
-        BuildOptions {
-          imports,
-          ..Default::default()
-        },
+        BuildOptions::default(),
       )
       .await;
     assert_eq!(
@@ -820,11 +869,9 @@ console.log(a);
     graph
       .build(
         vec![root_specifier],
+        imports,
         &loader,
-        BuildOptions {
-          imports,
-          ..Default::default()
-        },
+        BuildOptions::default(),
       )
       .await;
     assert_eq!(
@@ -947,11 +994,9 @@ console.log(a);
     graph
       .build(
         vec![root_specifier],
+        imports,
         &loader,
-        BuildOptions {
-          imports,
-          ..Default::default()
-        },
+        BuildOptions::default(),
       )
       .await;
     assert_eq!(
@@ -1019,7 +1064,12 @@ console.log(a);
       ModuleSpecifier::parse("https://example.com/a").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert_eq!(graph.module_slots.len(), 1);
     assert_eq!(graph.roots, IndexSet::from([root_specifier.clone()]));
@@ -1069,7 +1119,12 @@ console.log(a);
       ModuleSpecifier::parse("file:///a/test01.tsx").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert_eq!(
       json!(graph),
@@ -1164,7 +1219,12 @@ console.log(a);
       ModuleSpecifier::parse("file:///a/test01.tsx").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert_eq!(
       json!(graph),
@@ -1248,7 +1308,12 @@ console.log(a);
       ModuleSpecifier::parse("file:///a/test.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     let result = graph.valid();
     assert!(result.is_err());
@@ -1317,7 +1382,12 @@ console.log(a);
       ModuleSpecifier::parse("file:///a/test.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     graph.valid().unwrap();
     assert_eq!(json!(graph), expectation);
@@ -1350,7 +1420,12 @@ console.log(a);
       ModuleSpecifier::parse("file:///a/test.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     let result = graph.valid();
     assert!(result.is_err());
@@ -1392,7 +1467,12 @@ console.log(a);
       ModuleSpecifier::parse("file:///a/test01").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert!(graph.valid().is_ok());
   }
@@ -1424,7 +1504,12 @@ console.log(a);
       ModuleSpecifier::parse("file:///a.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert_eq!(
       json!(graph),
@@ -1515,7 +1600,12 @@ export function a(a) {
     let root = ModuleSpecifier::parse("file:///a/test.js").unwrap();
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root.clone()], &loader, Default::default())
+      .build(
+        vec![root.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert_eq!(
       json!(graph),
@@ -1615,7 +1705,12 @@ export function a(a) {
       ModuleSpecifier::parse("https://example.com/a").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert_eq!(
       graph.roots,
@@ -1680,7 +1775,12 @@ export function a(a) {
       ModuleSpecifier::parse("https://example.com/a").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert_eq!(
       graph.roots,
@@ -1738,7 +1838,12 @@ export function a(a) {
       ModuleSpecifier::parse("file:///a/test01.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert_eq!(graph.module_slots.len(), 3);
     let data_specifier = ModuleSpecifier::parse("data:application/typescript,export%20*%20from%20%22https://example.com/c.ts%22;").unwrap();
@@ -1777,7 +1882,12 @@ export const foo = 'bar';"#,
       ModuleSpecifier::parse("file:///test01.js").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert_eq!(graph.module_slots.len(), 2);
     let module = graph.get(&root_specifier).unwrap().js().unwrap();
@@ -1834,7 +1944,12 @@ export const foo = 'bar';"#,
       ModuleSpecifier::parse("file:///test01.js").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert_eq!(graph.module_slots.len(), 2);
     let module = graph.get(&root_specifier).unwrap().js().unwrap();
@@ -1891,7 +2006,12 @@ export const foo = 'bar';"#,
       ModuleSpecifier::parse("file:///test01.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert_eq!(graph.module_slots.len(), 1);
     let module = graph.get(&root_specifier).unwrap().js().unwrap();
@@ -1932,6 +2052,7 @@ export const foo = 'bar';"#,
     graph
       .build(
         vec![root_specifier.clone()],
+        Default::default(),
         &loader,
         BuildOptions {
           resolver: maybe_resolver,
@@ -1992,6 +2113,7 @@ export const foo = 'bar';"#,
     graph
       .build(
         vec![root_specifier.clone()],
+        Default::default(),
         &loader,
         BuildOptions {
           resolver: maybe_resolver,
@@ -2072,7 +2194,12 @@ export const foo = 'bar';"#,
       ModuleSpecifier::parse("file:///a/test01.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert_eq!(
       json!(graph),
@@ -2222,7 +2349,12 @@ export const foo = 'bar';"#,
       ModuleSpecifier::parse("file:///a/test01.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert_eq!(
       json!(graph),
@@ -2334,7 +2466,12 @@ export const foo = 'bar';"#,
       ModuleSpecifier::parse("file:///a/test01.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert_eq!(
       json!(graph),
@@ -2545,6 +2682,7 @@ export const foo = 'bar';"#,
     graph
       .build(
         vec![root_specifier.clone()],
+        Default::default(),
         &loader,
         BuildOptions {
           reporter: Some(&reporter),
@@ -2681,7 +2819,12 @@ export const foo = 'bar';"#,
       ModuleSpecifier::parse("file:///a/test01.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::TypesOnly);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert_eq!(
       json!(graph),
@@ -2916,7 +3059,12 @@ export const foo = 'bar';"#,
       ModuleSpecifier::parse("file:///a/test01.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::CodeOnly);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert_eq!(
       json!(graph),
@@ -3060,7 +3208,12 @@ export const foo = 'bar';"#,
       ModuleSpecifier::parse("file:///a/test01.ts").expect("bad url");
     let mut graph = ModuleGraph::new(GraphKind::All);
     graph
-      .build(vec![root_specifier.clone()], &loader, Default::default())
+      .build(
+        vec![root_specifier.clone()],
+        Default::default(),
+        &loader,
+        Default::default(),
+      )
       .await;
     assert_eq!(
       json!(graph),
@@ -3849,11 +4002,9 @@ export function a(a: A): B {
     graph
       .build(
         roots.clone(),
+        imports.clone(),
         &loader,
-        BuildOptions {
-          imports: imports.clone(),
-          ..Default::default()
-        },
+        BuildOptions::default(),
       )
       .await;
     assert!(graph.valid().is_ok());
@@ -4007,11 +4158,9 @@ export function a(a: A): B {
     graph
       .build(
         vec![root.clone()],
+        imports.clone(),
         &loader,
-        BuildOptions {
-          imports: imports.clone(),
-          ..Default::default()
-        },
+        BuildOptions::default(),
       )
       .await;
     assert!(graph.valid().is_ok());
@@ -4322,6 +4471,7 @@ export function a(a: A): B {
       graph
         .build(
           vec![root_specifier.clone()],
+          Default::default(),
           &loader,
           BuildOptions {
             resolver: Some(&resolver),
@@ -4399,6 +4549,7 @@ export function a(a: A): B {
       graph
         .build(
           vec![root_specifier.clone()],
+          Default::default(),
           &loader,
           BuildOptions {
             resolver: Some(&resolver),
@@ -4510,6 +4661,7 @@ export function a(a: A): B {
     graph
       .build(
         vec![root_specifier.clone()],
+        Default::default(),
         &loader,
         BuildOptions {
           resolver: Some(&resolver),
@@ -4558,6 +4710,7 @@ export function a(a: A): B {
     graph
       .build(
         vec![root_specifier.clone()],
+        Default::default(),
         &loader,
         BuildOptions {
           passthrough_jsr_specifiers: true,

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use async_trait::async_trait;
 use deno_ast::data_url::RawDataUrl;
@@ -89,6 +90,8 @@ pub enum LoadResponse {
   Module {
     /// The content of the remote module.
     content: Arc<[u8]>,
+    /// Last modified time if a file specifier.
+    mtime: Option<SystemTime>,
     /// The final specifier of the module.
     specifier: ModuleSpecifier,
     /// If the module is a remote module, the headers should be returned as a
@@ -527,6 +530,7 @@ pub fn load_data_url(
   Ok(Some(LoadResponse::Module {
     specifier: specifier.clone(),
     maybe_headers: Some(headers),
+    mtime: None,
     content: Arc::from(bytes),
   }))
 }
@@ -560,6 +564,7 @@ impl<S: AsRef<str>> Source<S> {
         content,
       } => Ok(LoadResponse::Module {
         specifier: ModuleSpecifier::parse(specifier.as_ref()).unwrap(),
+        mtime: None,
         maybe_headers: maybe_headers.map(|h| {
           h.into_iter()
             .map(|(k, v)| (k.as_ref().to_string(), v.as_ref().to_string()))
@@ -612,6 +617,7 @@ impl MemoryLoader {
       ModuleSpecifier::parse(specifier.as_ref()).unwrap(),
       Ok(LoadResponse::Module {
         specifier: ModuleSpecifier::parse(specifier.as_ref()).unwrap(),
+        mtime: None,
         maybe_headers: None,
         content: Arc::from(content),
       }),

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -281,11 +281,12 @@ impl Locker for HashMapLocker {
 
 #[derive(Debug, Clone)]
 pub struct LoadOptions {
-  pub is_dynamic: bool,
+  /// If the specifier being loaded is part of a dynamic branch.
+  pub in_dynamic_branch: bool,
   /// If the root specifier building the graph was in a dynamic branch.
   ///
   /// This can be useful for telling if a dynamic load is statically analyzable
-  /// where `is_dynamic` is `true`` and `was_dynamic_root` is `false`.
+  /// where `is_dynamic_branch` is `true`` and `was_dynamic_root` is `false`.
   pub was_dynamic_root: bool,
   pub cache_setting: CacheSetting,
   /// It is the loader's responsibility to verify the provided checksum if it

--- a/tests/ecosystem_test.rs
+++ b/tests/ecosystem_test.rs
@@ -187,6 +187,7 @@ impl deno_graph::source::Loader for Loader<'_> {
           Ok(source_code) => Ok(Some(LoadResponse::Module {
             content: source_code.into_bytes().into(),
             maybe_headers: None,
+            mtime: None,
             specifier: specifier.clone(),
           })),
           Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
@@ -307,11 +308,10 @@ async fn test_version(
   if let Err(err) = graph.valid() {
     match err {
       deno_graph::ModuleGraphError::ModuleError(
-        deno_graph::ModuleError::UnsupportedMediaType(
-          _,
-          MediaType::Cjs | MediaType::Cts,
-          _,
-        ),
+        deno_graph::ModuleError::UnsupportedMediaType {
+          media_type: MediaType::Cjs | MediaType::Cts,
+          ..
+        },
       ) => {
         // ignore, old packages with cjs and cts
         return;

--- a/tests/ecosystem_test.rs
+++ b/tests/ecosystem_test.rs
@@ -287,6 +287,7 @@ async fn test_version(
   graph
     .build(
       roots.clone(),
+      Vec::new(),
       &loader,
       BuildOptions {
         is_dynamic: false,
@@ -300,7 +301,6 @@ async fn test_version(
         jsr_url_provider: &PassthroughJsrUrlProvider,
         passthrough_jsr_specifiers: true,
         executor: Default::default(),
-        imports: vec![],
       },
     )
     .await;

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -284,6 +284,7 @@ impl TestBuilder {
     graph
       .build(
         roots.clone(),
+        Vec::new(),
         &self.loader,
         deno_graph::BuildOptions {
           module_analyzer: &capturing_analyzer,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -170,6 +170,7 @@ async fn test_jsr_version_not_found_then_found() {
           Ok(Some(LoadResponse::Module {
             specifier: specifier.clone(),
             maybe_headers: None,
+            mtime: None,
             content: b"import 'jsr:@scope/a@1.2".to_vec().into(),
           }))
         }),
@@ -177,6 +178,7 @@ async fn test_jsr_version_not_found_then_found() {
           Ok(Some(LoadResponse::Module {
             specifier: specifier.clone(),
             maybe_headers: None,
+            mtime: None,
             content: Default::default(),
           }))
         }),
@@ -185,6 +187,7 @@ async fn test_jsr_version_not_found_then_found() {
             Ok(Some(LoadResponse::Module {
               specifier: specifier.clone(),
               maybe_headers: None,
+              mtime: None,
               content: match options.cache_setting {
                 CacheSetting::Only | CacheSetting::Use => {
                   // first time it won't have the version
@@ -202,6 +205,7 @@ async fn test_jsr_version_not_found_then_found() {
           Ok(Some(LoadResponse::Module {
             specifier: specifier.clone(),
             maybe_headers: None,
+            mtime: None,
             content: br#"{
                 "exports": { ".": "./mod.ts" },
                 "manifest": {
@@ -219,6 +223,7 @@ async fn test_jsr_version_not_found_then_found() {
           Ok(Some(LoadResponse::Module {
             specifier: specifier.clone(),
             maybe_headers: None,
+            mtime: None,
             content: b"console.log('Hello, world!')".to_vec().into(),
           }))
         }),
@@ -333,6 +338,7 @@ async fn test_jsr_wasm_module() {
           Ok(Some(LoadResponse::Module {
             specifier: specifier.clone(),
             maybe_headers: None,
+            mtime: None,
             content: b"import 'jsr:@scope/a@1".to_vec().into(),
           }))
         }),
@@ -340,6 +346,7 @@ async fn test_jsr_wasm_module() {
           Ok(Some(LoadResponse::Module {
             specifier: specifier.clone(),
             maybe_headers: None,
+            mtime: None,
             content: br#"{ "versions": { "1.0.0": {} } }"#.to_vec().into(),
           }))
         }),
@@ -347,6 +354,7 @@ async fn test_jsr_wasm_module() {
           Ok(Some(LoadResponse::Module {
             specifier: specifier.clone(),
             maybe_headers: None,
+            mtime: None,
             content: br#"{
                 "exports": { ".": "./math.wasm" },
                 "manifest": {
@@ -372,6 +380,7 @@ async fn test_jsr_wasm_module() {
             Ok(Some(LoadResponse::Module {
               specifier: specifier.clone(),
               maybe_headers: None,
+              mtime: None,
               content: std::fs::read("./tests/testdata/math.wasm")
                 .unwrap()
                 .into(),
@@ -429,6 +438,7 @@ async fn test_checksum_error_force_refresh() {
             CacheSetting::Reload => Ok(Some(LoadResponse::Module {
               specifier: specifier.clone(),
               maybe_headers: None,
+              mtime: None,
               content: b"import './other.js';".to_vec().into(),
             })),
           }
@@ -445,6 +455,7 @@ async fn test_checksum_error_force_refresh() {
             CacheSetting::Reload => Ok(Some(LoadResponse::Module {
               specifier: specifier.clone(),
               maybe_headers: None,
+              mtime: None,
               content: b"console.log(1);".to_vec().into(),
             })),
           }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -159,7 +159,7 @@ async fn test_jsr_version_not_found_then_found() {
       specifier: &ModuleSpecifier,
       options: LoadOptions,
     ) -> LoadFuture {
-      assert!(!options.is_dynamic);
+      assert!(!options.in_dynamic_branch);
       self
         .requests
         .borrow_mut()
@@ -331,7 +331,7 @@ async fn test_jsr_wasm_module() {
       specifier: &ModuleSpecifier,
       options: LoadOptions,
     ) -> LoadFuture {
-      assert!(!options.is_dynamic);
+      assert!(!options.in_dynamic_branch);
       let specifier = specifier.clone();
       match specifier.as_str() {
         "file:///main.ts" => Box::pin(async move {
@@ -1118,6 +1118,114 @@ await import("https://example.com/main.ts");
       "redirects": {
         "npm:chalk@1.0.0": "npm:/chalk@1.0.0"
       }
+    })
+  );
+}
+
+#[tokio::test]
+async fn test_reload() {
+  let mut graph = ModuleGraph::new(GraphKind::All);
+  let mut loader = MemoryLoader::default();
+  loader.add_source_with_text("file:///project/mod.ts", r#"import "./a.ts";"#);
+  loader.add_source_with_text("file:///project/a.ts", "");
+
+  graph
+    .build(
+      vec![Url::parse("file:///project/mod.ts").unwrap()],
+      Vec::new(),
+      &loader,
+      BuildOptions {
+        npm_resolver: Some(&TestNpmResolver),
+        ..Default::default()
+      },
+    )
+    .await;
+
+  loader.add_source_with_text("file:///project/a.ts", "await import('./b.ts')");
+  loader
+    .add_source_with_text("file:///project/b.ts", "import 'npm:chalk@1.0.0';");
+  graph
+    .reload(
+      vec![Url::parse("file:///project/a.ts").unwrap()],
+      &loader,
+      BuildOptions {
+        npm_resolver: Some(&TestNpmResolver),
+        ..Default::default()
+      },
+    )
+    .await;
+
+  graph.valid().unwrap();
+  assert_eq!(
+    graph.npm_packages,
+    IndexSet::from([PackageNv::from_str("chalk@1.0.0").unwrap()])
+  );
+  assert_eq!(
+    json!(graph),
+    json!({
+      "roots": ["file:///project/mod.ts"],
+      "modules": [
+        {
+          "kind": "esm",
+          "dependencies": [
+            {
+              "specifier": "./b.ts",
+              "code": {
+                "specifier": "file:///project/b.ts",
+                "resolutionMode": "import",
+                "span": {
+                  "start": { "line": 0, "character": 13 },
+                  "end": { "line": 0, "character": 21 }
+                }
+              },
+              "isDynamic": true
+            }
+          ],
+          "size": 22,
+          "mediaType": "TypeScript",
+          "specifier": "file:///project/a.ts"
+        },
+        {
+          "kind": "esm",
+          "dependencies": [
+            {
+              "specifier": "npm:chalk@1.0.0",
+              "code": {
+                "specifier": "npm:chalk@1.0.0",
+                "resolutionMode": "import",
+                "span": {
+                  "start": { "line": 0, "character": 7 },
+                  "end": { "line": 0, "character": 24 }
+                }
+              }
+            }
+          ],
+          "size": 25,
+          "mediaType": "TypeScript",
+          "specifier": "file:///project/b.ts"
+        },
+        {
+          "kind": "esm",
+          "dependencies": [
+            {
+              "specifier": "./a.ts",
+              "code": {
+                "specifier": "file:///project/a.ts",
+                "resolutionMode": "import",
+                "span": {
+                  "start": { "line": 0, "character": 7 },
+                  "end": { "line": 0, "character": 15 }
+                }
+              }
+            }
+          ],
+          "size": 16,
+          "mediaType": "TypeScript",
+          "specifier": "file:///project/mod.ts"
+        },
+        { "kind": "npm", "specifier": "npm:/chalk@1.0.0" }
+      ],
+      "redirects": { "npm:chalk@1.0.0": "npm:/chalk@1.0.0" }
     })
   );
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -233,6 +233,7 @@ async fn test_jsr_version_not_found_then_found() {
     graph
       .build(
         vec![Url::parse("file:///main.ts").unwrap()],
+        Vec::new(),
         &loader,
         Default::default(),
       )
@@ -270,6 +271,7 @@ async fn test_jsr_version_not_found_then_found() {
     graph
       .build(
         vec![Url::parse("file:///empty.ts").unwrap()],
+        Vec::new(),
         &loader,
         Default::default(),
       )
@@ -282,6 +284,7 @@ async fn test_jsr_version_not_found_then_found() {
     graph
       .build(
         vec![Url::parse("file:///main.ts").unwrap()],
+        Vec::new(),
         &loader,
         Default::default(),
       )
@@ -386,6 +389,7 @@ async fn test_jsr_wasm_module() {
     graph
       .build(
         vec![Url::parse("file:///main.ts").unwrap()],
+        Vec::new(),
         &loader,
         Default::default(),
       )
@@ -455,6 +459,7 @@ async fn test_checksum_error_force_refresh() {
   graph
     .build(
       vec![Url::parse("https://deno.land/mod.ts").unwrap()],
+      Vec::new(),
       &loader,
       Default::default(),
     )
@@ -506,6 +511,7 @@ async fn test_dynamic_imports_with_template_arg() {
     graph
       .build(
         vec![Url::parse(entrypoint).unwrap()],
+        Vec::new(),
         &loader,
         BuildOptions {
           file_system: &sys,
@@ -778,6 +784,7 @@ async fn test_fill_from_lockfile() {
     .build(
       // This should match 1.0.0 due to the first entry in the lockfile.
       vec![Url::parse("jsr:/@scope/example").unwrap()],
+      Vec::new(),
       &loader,
       Default::default(),
     )
@@ -839,6 +846,7 @@ async fn test_json_root() {
   graph
     .build(
       vec![Url::parse("jsr:/@scope/example@^1.0.0/json-export").unwrap()],
+      Vec::new(),
       &loader,
       Default::default(),
     )
@@ -847,6 +855,7 @@ async fn test_json_root() {
   graph
     .build(
       vec![Url::parse("https://deno.land/x/redirect").unwrap()],
+      Vec::new(),
       &loader,
       Default::default(),
     )
@@ -855,6 +864,7 @@ async fn test_json_root() {
   graph
     .build(
       vec![Url::parse("https://deno.land/x/redirect3").unwrap()],
+      Vec::new(),
       &loader,
       Default::default(),
     )
@@ -888,6 +898,7 @@ async fn test_wasm_math() {
   graph
     .build(
       vec![Url::parse("file:///project/main.ts").unwrap()],
+      Vec::new(),
       &loader,
       Default::default(),
     )
@@ -935,6 +946,7 @@ async fn test_wasm_math_with_import() {
   graph
     .build(
       vec![Url::parse("file:///project/main.ts").unwrap()],
+      Vec::new(),
       &loader,
       Default::default(),
     )
@@ -993,6 +1005,7 @@ await import("https://example.com/main.ts");
   graph
     .build(
       vec![Url::parse("file:///project/mod.ts").unwrap()],
+      Vec::new(),
       &loader,
       BuildOptions {
         npm_resolver: Some(&TestNpmResolver),


### PR DESCRIPTION
Somewhat of a naive remove and reload because it does not update the graph in anyway to remove dependencies of the reloaded specifiers.