### PR TITLE
fix: use lockfileChecksum property for locker if set on jsr version metadata

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -7127,6 +7127,7 @@ mod tests {
         module_graph_1: None,
         module_graph_2: None,
         manifest: Default::default(),
+        lockfile_checksum: None,
       },
     );
     test_loader.add_external_source("https://jsr.io/@package/foo/1.0.0/mod.ts");

--- a/src/jsr.rs
+++ b/src/jsr.rs
@@ -139,13 +139,19 @@ impl JsrMetadataStore {
       // we won't have a checksum when not using a lockfile
       maybe_expected_checksum,
       move |content| {
-        let checksum_for_locker = if should_compute_checksum {
-          Some(LoaderChecksum::new(LoaderChecksum::gen(content)))
-        } else {
-          None
-        };
         let version_info: JsrPackageVersionInfo =
           serde_json::from_slice(content)?;
+        let checksum_for_locker = version_info
+          .lockfile_checksum
+          .clone()
+          .or_else(|| {
+            if should_compute_checksum {
+              Some(LoaderChecksum::gen(content))
+            } else {
+              None
+            }
+          })
+          .map(LoaderChecksum::new);
         Ok(PendingJsrPackageVersionInfoLoadItem {
           checksum_for_locker,
           info: Arc::new(version_info),

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -47,6 +47,14 @@ pub struct JsrPackageVersionInfo {
   #[serde(rename = "moduleGraph2")]
   pub module_graph_2: Option<serde_json::Value>,
   pub manifest: HashMap<String, JsrPackageVersionManifestEntry>,
+  /// This is a property that deno_cache_dir sets when copying from
+  /// the global to the local cache. If it's set, put this in the lockfile
+  /// instead of computing the checksum from the file bytes. This is necessary
+  /// because we store less data in the metadata files found in the vendor
+  /// directory than in the global cache and also someone may modify the vendored
+  /// files then regenerate the lockfile.
+  #[serde(rename = "lockfileChecksum")]
+  pub lockfile_checksum: Option<String>,
 }
 
 impl JsrPackageVersionInfo {

--- a/tests/specs/graph/checksums/uses_lockfile_checksum.txt
+++ b/tests/specs/graph/checksums/uses_lockfile_checksum.txt
@@ -43,18 +43,18 @@ console.log('HI');
             "resolutionMode": "import",
             "span": {
               "start": {
-                "line": 0,
+                "line": 5,
                 "character": 7
               },
               "end": {
-                "line": 0,
+                "line": 5,
                 "character": 21
               }
             }
           }
         }
       ],
-      "size": 22,
+      "size": 433,
       "mediaType": "TypeScript",
       "specifier": "file:///mod.ts"
     },

--- a/tests/specs/graph/checksums/uses_lockfile_checksum.txt
+++ b/tests/specs/graph/checksums/uses_lockfile_checksum.txt
@@ -1,0 +1,83 @@
+~~ {
+  "pkgChecksums": {}
+} ~~
+# https://jsr.io/@scope/a/meta.json
+{
+  "versions": {
+    "1.0.0": {}
+  }
+}
+
+# https://jsr.io/@scope/a/1.0.0_meta.json
+{
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "lockfileChecksum": "thisCodeShouldUseThisInTheLockfileInsteadOfComputingFromTheBytes"
+}
+
+# mod.ts
+// What's happening here is the 1.0.0_meta.json file has the lockfileChecksum property
+// set. This will be set when the metadata file is copied from the global to the local
+// cache. When that's the case, ensure the code uses the lockfileChecksum property because
+// it will contain the original checksum of the metadata found in the global cache rather
+// than the checksum that's found in the vendor folder.
+import 'jsr:@scope/a'
+
+# https://jsr.io/@scope/a/1.0.0/mod.ts
+console.log('HI');
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "jsr:@scope/a",
+          "code": {
+            "specifier": "jsr:@scope/a",
+            "resolutionMode": "import",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 7
+              },
+              "end": {
+                "line": 0,
+                "character": 21
+              }
+            }
+          }
+        }
+      ],
+      "size": 22,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 19,
+      "mediaType": "TypeScript",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+    }
+  ],
+  "redirects": {
+    "jsr:@scope/a": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+  },
+  "packages": {
+    "@scope/a@*": "@scope/a@1.0.0"
+  }
+}
+
+pkg manifest checksums:
+{
+  "@scope/a@1.0.0": "thisCodeShouldUseThisInTheLockfileInsteadOfComputingFromTheBytes"
+}
+
+Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
+  {}
+  <empty>


### PR DESCRIPTION
Part of https://github.com/denoland/deno/issues/29432

Corresponding fix and more details in https://github.com/denoland/deno_cache_dir/pull/82