### PR TITLE
refactor: split off cache_module_info from the Loader trait

### DIFF
--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -322,6 +322,7 @@ pub async fn js_create_graph(
         locker: None,
         passthrough_jsr_specifiers: false,
         module_analyzer: Default::default(),
+        module_info_cacher: Default::default(),
         reporter: None,
         executor: Default::default(),
       },

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1379,6 +1379,7 @@ pub struct BuildOptions<'a> {
   /// specifiers as external.
   pub passthrough_jsr_specifiers: bool,
   pub module_analyzer: &'a dyn ModuleAnalyzer,
+  pub module_info_cacher: &'a dyn ModuleInfoCacher,
   pub npm_resolver: Option<&'a dyn NpmResolver>,
   pub reporter: Option<&'a dyn Reporter>,
   pub resolver: Option<&'a dyn Resolver>,
@@ -1395,6 +1396,7 @@ impl Default for BuildOptions<'_> {
       jsr_url_provider: Default::default(),
       passthrough_jsr_specifiers: false,
       module_analyzer: Default::default(),
+      module_info_cacher: Default::default(),
       npm_resolver: None,
       reporter: None,
       resolver: None,
@@ -3801,6 +3803,7 @@ struct Builder<'a, 'graph> {
   resolver: Option<&'a dyn Resolver>,
   npm_resolver: Option<&'a dyn NpmResolver>,
   module_analyzer: &'a dyn ModuleAnalyzer,
+  module_info_cacher: &'a dyn ModuleInfoCacher,
   reporter: Option<&'a dyn Reporter>,
   graph: &'graph mut ModuleGraph,
   state: PendingState<'a>,
@@ -3831,6 +3834,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
       resolver: options.resolver,
       npm_resolver: options.npm_resolver,
       module_analyzer: options.module_analyzer,
+      module_info_cacher: options.module_info_cacher,
       reporter: options.reporter,
       graph,
       state: PendingState::default(),
@@ -4240,7 +4244,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
                 ModuleSlot::Module(module) => {
                   match module {
                     Module::Js(module) => {
-                      self.loader.cache_module_info(
+                      self.module_info_cacher.cache_module_info(
                         &specifier,
                         module.media_type,
                         &content,

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -323,9 +323,23 @@ pub trait Loader {
     specifier: &ModuleSpecifier,
     options: LoadOptions,
   ) -> LoadFuture;
+}
 
+pub trait ModuleInfoCacher {
   /// Cache the module info for the provided specifier if the loader
   /// supports caching this information.
+  fn cache_module_info(
+    &self,
+    specifier: &ModuleSpecifier,
+    media_type: MediaType,
+    source: &Arc<[u8]>,
+    module_info: &ModuleInfo,
+  );
+}
+
+pub struct NullModuleInfoCacher;
+
+impl ModuleInfoCacher for NullModuleInfoCacher {
   fn cache_module_info(
     &self,
     _specifier: &ModuleSpecifier,
@@ -333,6 +347,12 @@ pub trait Loader {
     _source: &Arc<[u8]>,
     _module_info: &ModuleInfo,
   ) {
+  }
+}
+
+impl Default for &dyn ModuleInfoCacher {
+  fn default() -> Self {
+    &NullModuleInfoCacher
   }
 }
 

--- a/tests/ecosystem_test.rs
+++ b/tests/ecosystem_test.rs
@@ -294,6 +294,7 @@ async fn test_version(
         is_dynamic: false,
         skip_dynamic_deps: false,
         module_analyzer: &module_analyzer,
+        module_info_cacher: Default::default(),
         file_system: &NullFileSystem,
         locker: None,
         resolver: None,


### PR DESCRIPTION
Makes it easier for me to move out the loader trait completely from the CLI crate and this is more SRP anyway.