### PR TITLE
fix: do not do execution resolution for declaration file dependencies

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -3589,25 +3589,25 @@ fn fill_module_dependencies(
             maybe_resolver,
           );
         }
-      } else if media_type.is_declaration() {
-        // ignore
-      } else if dep.maybe_code.is_none() {
-        // This is a code import, the first one of that specifier in this module.
-        // Resolve and determine the initial `is_dynamic` value from it.
-        dep.maybe_code = resolve(
-          &import.specifier,
-          import.specifier_range.clone(),
-          ResolutionKind::Execution,
-          jsr_url_provider,
-          maybe_resolver,
-        );
-        dep.is_dynamic = import.is_dynamic;
-      } else {
-        // This is a code import, but not the first one of that specifier in this
-        // module. Maybe update the `is_dynamic` value. Static imports take
-        // precedence. Note that `@jsxImportSource` and `/// <reference path />`
-        // count as static imports for this purpose.
-        dep.is_dynamic = dep.is_dynamic && import.is_dynamic;
+      } else if !media_type.is_declaration() {
+        if dep.maybe_code.is_none() {
+          // This is a code import, the first one of that specifier in this module.
+          // Resolve and determine the initial `is_dynamic` value from it.
+          dep.maybe_code = resolve(
+            &import.specifier,
+            import.specifier_range.clone(),
+            ResolutionKind::Execution,
+            jsr_url_provider,
+            maybe_resolver,
+          );
+          dep.is_dynamic = import.is_dynamic;
+        } else {
+          // This is a code import, but not the first one of that specifier in this
+          // module. Maybe update the `is_dynamic` value. Static imports take
+          // precedence. Note that `@jsxImportSource` and `/// <reference path />`
+          // count as static imports for this purpose.
+          dep.is_dynamic = dep.is_dynamic && import.is_dynamic;
+        }
       }
       if graph_kind.include_types() && dep.maybe_type.is_none() {
         let maybe_type = resolve(

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -3589,6 +3589,8 @@ fn fill_module_dependencies(
             maybe_resolver,
           );
         }
+      } else if media_type.is_declaration() {
+        // ignore
       } else if dep.maybe_code.is_none() {
         // This is a code import, the first one of that specifier in this module.
         // Resolve and determine the initial `is_dynamic` value from it.

--- a/tests/specs/graph/dts_files.txt
+++ b/tests/specs/graph/dts_files.txt
@@ -1,0 +1,75 @@
+# mod.ts
+export type * from "./declarations.d.ts";
+
+# declarations.d.ts
+import { Test } from "./a.d.ts";
+
+export { Test }
+
+# a.d.ts
+export class Test {}
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "size": 21,
+      "mediaType": "Dts",
+      "specifier": "file:///a.d.ts"
+    },
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "./a.d.ts",
+          "type": {
+            "specifier": "file:///a.d.ts",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 21
+              },
+              "end": {
+                "line": 0,
+                "character": 31
+              }
+            }
+          }
+        }
+      ],
+      "size": 50,
+      "mediaType": "Dts",
+      "specifier": "file:///declarations.d.ts"
+    },
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "./declarations.d.ts",
+          "type": {
+            "specifier": "file:///declarations.d.ts",
+            "resolutionMode": "import",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 19
+              },
+              "end": {
+                "line": 0,
+                "character": 40
+              }
+            }
+          }
+        }
+      ],
+      "size": 42,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    }
+  ],
+  "redirects": {}
+}

--- a/tests/specs/graph/fast_check/dts.txt
+++ b/tests/specs/graph/fast_check/dts.txt
@@ -118,7 +118,7 @@ import 'jsr:@scope/a/foo'
       "dependencies": [
         {
           "specifier": "./other.d.ts",
-          "code": {
+          "type": {
             "specifier": "https://jsr.io/@scope/a/1.0.0/other.d.ts",
             "span": {
               "start": {


### PR DESCRIPTION
We were doing code resolution and types resolution for specifiers in dts files, which doesn't make sense.