### PR TITLE
feat: support import defer in module graph

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -98,6 +98,7 @@ impl ImportAttributes {
 pub enum DynamicDependencyKind {
   #[default]
   Import,
+  ImportDefer,
   ImportSource,
   Require,
 }
@@ -106,6 +107,7 @@ pub enum DynamicDependencyKind {
 #[serde(rename_all = "camelCase")]
 pub enum StaticDependencyKind {
   Import,
+  ImportDefer,
   ImportSource,
   ImportType,
   ImportEquals,

--- a/src/ast/dep.rs
+++ b/src/ast/dep.rs
@@ -150,7 +150,7 @@ impl Visit for DependencyCollector<'_> {
       (true, _) => StaticDependencyKind::ImportType,
       (false, ImportPhase::Evaluation) => StaticDependencyKind::Import,
       (false, ImportPhase::Source) => StaticDependencyKind::ImportSource,
-      (false, ImportPhase::Defer) => return,
+      (false, ImportPhase::Defer) => StaticDependencyKind::ImportDefer,
     };
     self.items.push(
       StaticDependencyDescriptor {
@@ -247,7 +247,7 @@ impl Visit for DependencyCollector<'_> {
       Callee::Import(import) => match import.phase {
         ImportPhase::Evaluation => DynamicDependencyKind::Import,
         ImportPhase::Source => DynamicDependencyKind::ImportSource,
-        ImportPhase::Defer => return,
+        ImportPhase::Defer => DynamicDependencyKind::ImportDefer,
       },
       _ if self.is_require(&node.callee) => DynamicDependencyKind::Require,
       _ => return,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -3892,6 +3892,7 @@ fn fill_module_dependencies(
           }
           StaticDependencyKind::ImportSource => ImportKind::EsSource,
           StaticDependencyKind::Import
+          | StaticDependencyKind::ImportDefer
           | StaticDependencyKind::ImportEquals
           | StaticDependencyKind::Export
           | StaticDependencyKind::ExportEquals => ImportKind::Es,
@@ -3904,6 +3905,7 @@ fn fill_module_dependencies(
           range: desc.specifier_range,
           resolution_mode: match desc.kind {
             StaticDependencyKind::Import
+            | StaticDependencyKind::ImportDefer
             | StaticDependencyKind::ImportSource
             | StaticDependencyKind::Export
             | StaticDependencyKind::ImportType
@@ -3970,6 +3972,7 @@ fn fill_module_dependencies(
           range: desc.argument_range,
           resolution_mode: match desc.kind {
             DynamicDependencyKind::Import
+            | DynamicDependencyKind::ImportDefer
             | DynamicDependencyKind::ImportSource => {
               if media_type.is_declaration() {
                 None
@@ -3986,7 +3989,8 @@ fn fill_module_dependencies(
             .map(|specifier| Import {
               specifier,
               kind: match desc.kind {
-                DynamicDependencyKind::Import => ImportKind::Es,
+                DynamicDependencyKind::Import
+                | DynamicDependencyKind::ImportDefer => ImportKind::Es,
                 DynamicDependencyKind::ImportSource => ImportKind::EsSource,
                 DynamicDependencyKind::Require => ImportKind::Require,
               },


### PR DESCRIPTION
## Summary

Include `import defer` and `import.defer()` dependencies in the module graph instead of skipping them.

Previously, deferred imports were returned from (`return`) in the dependency collector, meaning they were completely excluded from the module graph. This caused `Loading unprepared module` errors at runtime because the deferred module was never fetched or compiled.

Deferred imports need to be in the graph so they are fetched and compiled (prepared), even though evaluation is deferred until first namespace access at runtime.

### Changes

- Added `ImportDefer` variant to `StaticDependencyKind` and `DynamicDependencyKind`
- Deferred imports are treated as ES module imports for graph building (same `ImportKind::Es`, same resolution mode)

Needed by denoland/deno#32360 (TC39 import defer proposal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)