### PR TITLE
chore: bump deno_semver to 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,7 +486,7 @@ dependencies = [
  "futures",
  "indexmap",
  "log",
- "monch 0.6.0",
+ "monch",
  "once_cell",
  "parking_lot",
  "pretty_assertions",
@@ -550,15 +550,15 @@ dependencies = [
 
 [[package]]
 name = "deno_semver"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2625b7107cc3f61a462886d5fa77c23e063c1fd15b90e3d5ee2646e9f6178d55"
+checksum = "147261611819fb4dfe339b53e3b45d6704c7e32c86ce33a88511d5bcebebaaa3"
 dependencies = [
  "capacity_builder",
  "deno_error",
  "ecow",
  "hipstr",
- "monch 0.5.0",
+ "monch",
  "once_cell",
  "serde",
  "thiserror",
@@ -1330,12 +1330,6 @@ dependencies = [
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "monch"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b52c1b33ff98142aecea13138bd399b68aa7ab5d9546c300988c345004001eea"
 
 [[package]]
 name = "monch"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ deno_ast = { version = "0.53.2", features = ["emit"], optional = true }
 deno_error.workspace = true
 deno_media_type = { version = "0.4.0", features = ["decoding", "data_url", "module_specifier"] }
 deno_path_util = "0.6.4"
-deno_semver = "0.9.0"
+deno_semver = "0.10.0"
 deno_unsync.workspace = true
 futures = "0.3.26"
 indexmap = { version = "2", features = ["serde"] }


### PR DESCRIPTION
Bump deno_semver to 0.10.0 for monch 0.6.0 perf improvements.