### PR TITLE
chore: update ecosystem test expectations for TS2580 -> TS2591

### DIFF
--- a/tests/specs/ecosystem/hampus/itsdangerous/1_1_0.test
+++ b/tests/specs/ecosystem/hampus/itsdangerous/1_1_0.test
@@ -29,27 +29,27 @@ export function wantBuffer(string: StringBuffer, encoding?: BufferEncoding): Buf
                                                             ~~~~~~~~~~~~~~
     at file://<tmpdir>/src/encoding.ts:2:61
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
 export function wantBuffer(string: StringBuffer, encoding?: BufferEncoding): Buffer {
                                                                              ~~~~~~
     at file://<tmpdir>/src/encoding.ts:2:78
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
 export function base64Encode(string: StringBuffer): Buffer {
                                                     ~~~~~~
     at file://<tmpdir>/src/encoding.ts:5:53
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
 export function base64Decode(string: StringBuffer): Buffer {
                                                     ~~~~~~
     at file://<tmpdir>/src/encoding.ts:8:53
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
 export function intToBuffer(num: number | bigint): Buffer {
                                                    ~~~~~~
     at file://<tmpdir>/src/encoding.ts:11:52
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
 export function bufferToInt(buf: Buffer): number | bigint {
                                  ~~~~~~
     at file://<tmpdir>/src/encoding.ts:14:34
@@ -69,147 +69,147 @@ export { HMACAlgorithm, KeyDerivation, NoneAlgorithm, Signer, SignerOptions, Sig
                                                               ~~~~~~~~~~~~~
     at file://<tmpdir>/src/index.ts:4:63
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ declare secretKeys: Buffer[];
                           ~~~~~~
     at file://<tmpdir>/src/serializer.ts:52:27
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   declare salt: Buffer;
                 ~~~~~~
     at file://<tmpdir>/src/serializer.ts:53:17
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ parsePayload(payload: Buffer, serializer?: DefaultSerializer): any {
                             ~~~~~~
     at file://<tmpdir>/src/serializer.ts:64:29
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ stringifyPayload(obj: any): Buffer {
                                   ~~~~~~
     at file://<tmpdir>/src/serializer.ts:70:35
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   getSignature(_key: Buffer, _value: Buffer): Buffer {
                      ~~~~~~
     at file://<tmpdir>/src/signer.ts:7:22
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   getSignature(_key: Buffer, _value: Buffer): Buffer {
                                      ~~~~~~
     at file://<tmpdir>/src/signer.ts:7:38
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   getSignature(_key: Buffer, _value: Buffer): Buffer {
                                               ~~~~~~
     at file://<tmpdir>/src/signer.ts:7:47
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   verifySignature(key: Buffer, value: Buffer, sig: Buffer): boolean {
                        ~~~~~~
     at file://<tmpdir>/src/signer.ts:10:24
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   verifySignature(key: Buffer, value: Buffer, sig: Buffer): boolean {
                                       ~~~~~~
     at file://<tmpdir>/src/signer.ts:10:39
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   verifySignature(key: Buffer, value: Buffer, sig: Buffer): boolean {
                                                    ~~~~~~
     at file://<tmpdir>/src/signer.ts:10:52
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override getSignature(_key: Buffer, _value: Buffer): Buffer {
                               ~~~~~~
     at file://<tmpdir>/src/signer.ts:18:31
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override getSignature(_key: Buffer, _value: Buffer): Buffer {
                                               ~~~~~~
     at file://<tmpdir>/src/signer.ts:18:47
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override getSignature(_key: Buffer, _value: Buffer): Buffer {
                                                        ~~~~~~
     at file://<tmpdir>/src/signer.ts:18:56
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override getSignature(key: Buffer, value: Buffer): Buffer {
                              ~~~~~~
     at file://<tmpdir>/src/signer.ts:33:30
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override getSignature(key: Buffer, value: Buffer): Buffer {
                                             ~~~~~~
     at file://<tmpdir>/src/signer.ts:33:45
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override getSignature(key: Buffer, value: Buffer): Buffer {
                                                      ~~~~~~
     at file://<tmpdir>/src/signer.ts:33:54
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ declare secretKeys: Buffer[];
                           ~~~~~~
     at file://<tmpdir>/src/signer.ts:88:27
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   declare sep: Buffer;
                ~~~~~~
     at file://<tmpdir>/src/signer.ts:89:16
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   declare salt: Buffer;
                 ~~~~~~
     at file://<tmpdir>/src/signer.ts:90:17
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ deriveKey(secretKey?: StringBuffer): Buffer {
                                            ~~~~~~
     at file://<tmpdir>/src/signer.ts:103:44
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ getSignature(value: StringBuffer): Buffer {
                                          ~~~~~~
     at file://<tmpdir>/src/signer.ts:108:42
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ sign(value: StringBuffer): Buffer {
                                  ~~~~~~
     at file://<tmpdir>/src/signer.ts:113:34
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ unsign(signedValue: StringBuffer): Buffer {
                                          ~~~~~~
     at file://<tmpdir>/src/signer.ts:123:42
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ override sign(value: StringBuffer): Buffer {
                                           ~~~~~~
     at file://<tmpdir>/src/timed.ts:21:43
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ override unsign(signedValue: StringBuffer, maxAge?: number, returnTimestamp?: false): Buffer;
                                                                                             ~~~~~~
     at file://<tmpdir>/src/timed.ts:29:93
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override unsign(signedValue: StringBuffer, maxAge?: number, returnTimestamp?: true): [Buffer, Date];
                                                                                         ~~~~~~
     at file://<tmpdir>/src/timed.ts:30:89
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
 export type StringBuffer = string | Buffer;
                                     ~~~~~~
     at file://<tmpdir>/src/types.ts:1:37
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override parsePayload(payload: Buffer, serializer?: DefaultSerializer): any {
                                  ~~~~~~
     at file://<tmpdir>/src/url-safe.ts:9:34
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override stringifyPayload(obj: any): Buffer {
                                        ~~~~~~
     at file://<tmpdir>/src/url-safe.ts:12:40

--- a/tests/specs/ecosystem/hampus/itsdangerous/1_1_1.test
+++ b/tests/specs/ecosystem/hampus/itsdangerous/1_1_1.test
@@ -29,172 +29,172 @@ export function wantBuffer(string: StringBuffer, encoding?: BufferEncoding): Buf
                                                             ~~~~~~~~~~~~~~
     at file://<tmpdir>/src/encoding.ts:2:61
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
 export function wantBuffer(string: StringBuffer, encoding?: BufferEncoding): Buffer {
                                                                              ~~~~~~
     at file://<tmpdir>/src/encoding.ts:2:78
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
 export function base64Encode(string: StringBuffer): Buffer {
                                                     ~~~~~~
     at file://<tmpdir>/src/encoding.ts:5:53
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
 export function base64Decode(string: StringBuffer): Buffer {
                                                     ~~~~~~
     at file://<tmpdir>/src/encoding.ts:8:53
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
 export function intToBuffer(num: number | bigint): Buffer {
                                                    ~~~~~~
     at file://<tmpdir>/src/encoding.ts:11:52
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
 export function bufferToInt(buf: Buffer): number | bigint {
                                  ~~~~~~
     at file://<tmpdir>/src/encoding.ts:14:34
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ declare secretKeys: Buffer[];
                           ~~~~~~
     at file://<tmpdir>/src/serializer.ts:52:27
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   declare salt: Buffer;
                 ~~~~~~
     at file://<tmpdir>/src/serializer.ts:53:17
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ parsePayload(payload: Buffer, serializer?: DefaultSerializer): any {
                             ~~~~~~
     at file://<tmpdir>/src/serializer.ts:64:29
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ stringifyPayload(obj: any): Buffer {
                                   ~~~~~~
     at file://<tmpdir>/src/serializer.ts:70:35
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   getSignature(_key: Buffer, _value: Buffer): Buffer {
                      ~~~~~~
     at file://<tmpdir>/src/signer.ts:7:22
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   getSignature(_key: Buffer, _value: Buffer): Buffer {
                                      ~~~~~~
     at file://<tmpdir>/src/signer.ts:7:38
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   getSignature(_key: Buffer, _value: Buffer): Buffer {
                                               ~~~~~~
     at file://<tmpdir>/src/signer.ts:7:47
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   verifySignature(key: Buffer, value: Buffer, sig: Buffer): boolean {
                        ~~~~~~
     at file://<tmpdir>/src/signer.ts:10:24
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   verifySignature(key: Buffer, value: Buffer, sig: Buffer): boolean {
                                       ~~~~~~
     at file://<tmpdir>/src/signer.ts:10:39
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   verifySignature(key: Buffer, value: Buffer, sig: Buffer): boolean {
                                                    ~~~~~~
     at file://<tmpdir>/src/signer.ts:10:52
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override getSignature(_key: Buffer, _value: Buffer): Buffer {
                               ~~~~~~
     at file://<tmpdir>/src/signer.ts:18:31
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override getSignature(_key: Buffer, _value: Buffer): Buffer {
                                               ~~~~~~
     at file://<tmpdir>/src/signer.ts:18:47
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override getSignature(_key: Buffer, _value: Buffer): Buffer {
                                                        ~~~~~~
     at file://<tmpdir>/src/signer.ts:18:56
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override getSignature(key: Buffer, value: Buffer): Buffer {
                              ~~~~~~
     at file://<tmpdir>/src/signer.ts:33:30
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override getSignature(key: Buffer, value: Buffer): Buffer {
                                             ~~~~~~
     at file://<tmpdir>/src/signer.ts:33:45
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override getSignature(key: Buffer, value: Buffer): Buffer {
                                                      ~~~~~~
     at file://<tmpdir>/src/signer.ts:33:54
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ declare secretKeys: Buffer[];
                           ~~~~~~
     at file://<tmpdir>/src/signer.ts:88:27
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   declare sep: Buffer;
                ~~~~~~
     at file://<tmpdir>/src/signer.ts:89:16
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   declare salt: Buffer;
                 ~~~~~~
     at file://<tmpdir>/src/signer.ts:90:17
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ deriveKey(secretKey?: StringBuffer): Buffer {
                                            ~~~~~~
     at file://<tmpdir>/src/signer.ts:103:44
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ getSignature(value: StringBuffer): Buffer {
                                          ~~~~~~
     at file://<tmpdir>/src/signer.ts:108:42
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ sign(value: StringBuffer): Buffer {
                                  ~~~~~~
     at file://<tmpdir>/src/signer.ts:113:34
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ unsign(signedValue: StringBuffer): Buffer {
                                          ~~~~~~
     at file://<tmpdir>/src/signer.ts:123:42
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ override sign(value: StringBuffer): Buffer {
                                           ~~~~~~
     at file://<tmpdir>/src/timed.ts:21:43
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ override unsign(signedValue: StringBuffer, maxAge?: number, returnTimestamp?: false): Buffer;
                                                                                             ~~~~~~
     at file://<tmpdir>/src/timed.ts:29:93
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override unsign(signedValue: StringBuffer, maxAge?: number, returnTimestamp?: true): [Buffer, Date];
                                                                                         ~~~~~~
     at file://<tmpdir>/src/timed.ts:30:89
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
 export type StringBuffer = string | Buffer;
                                     ~~~~~~
     at file://<tmpdir>/src/types.ts:1:37
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override parsePayload(payload: Buffer, serializer?: DefaultSerializer): any {
                                  ~~~~~~
     at file://<tmpdir>/src/url-safe.ts:9:34
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override stringifyPayload(obj: any): Buffer {
                                        ~~~~~~
     at file://<tmpdir>/src/url-safe.ts:12:40

--- a/tests/specs/ecosystem/hampus/itsdangerous/1_1_2.test
+++ b/tests/specs/ecosystem/hampus/itsdangerous/1_1_2.test
@@ -29,172 +29,172 @@ TS2304 [ERROR]: Cannot find name 'BufferEncoding'.
                                                                 ~~~~~~~~~~~~~~
     at file://<tmpdir>/src/encoding.ts:9:65
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
  */ export function wantBuffer(string: StringBuffer, encoding?: BufferEncoding): Buffer {
                                                                                  ~~~~~~
     at file://<tmpdir>/src/encoding.ts:9:82
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
  */ export function base64Encode(string: StringBuffer): Buffer {
                                                         ~~~~~~
     at file://<tmpdir>/src/encoding.ts:17:57
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
  */ export function base64Decode(string: StringBuffer): Buffer {
                                                         ~~~~~~
     at file://<tmpdir>/src/encoding.ts:25:57
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
  */ export function intToBuffer(num: number | bigint): Buffer {
                                                        ~~~~~~
     at file://<tmpdir>/src/encoding.ts:33:56
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
  */ export function bufferToInt(buf: Buffer): number | bigint {
                                      ~~~~~~
     at file://<tmpdir>/src/encoding.ts:41:38
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ declare secretKeys: Buffer[];
                           ~~~~~~
     at file://<tmpdir>/src/serializer.ts:52:27
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   declare salt: Buffer;
                 ~~~~~~
     at file://<tmpdir>/src/serializer.ts:53:17
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ parsePayload(payload: Buffer, serializer?: DefaultSerializer): any {
                             ~~~~~~
     at file://<tmpdir>/src/serializer.ts:64:29
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ stringifyPayload(obj: any): Buffer {
                                   ~~~~~~
     at file://<tmpdir>/src/serializer.ts:70:35
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   getSignature(_key: Buffer, _value: Buffer): Buffer {
                      ~~~~~~
     at file://<tmpdir>/src/signer.ts:7:22
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   getSignature(_key: Buffer, _value: Buffer): Buffer {
                                      ~~~~~~
     at file://<tmpdir>/src/signer.ts:7:38
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   getSignature(_key: Buffer, _value: Buffer): Buffer {
                                               ~~~~~~
     at file://<tmpdir>/src/signer.ts:7:47
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   verifySignature(key: Buffer, value: Buffer, sig: Buffer): boolean {
                        ~~~~~~
     at file://<tmpdir>/src/signer.ts:10:24
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   verifySignature(key: Buffer, value: Buffer, sig: Buffer): boolean {
                                       ~~~~~~
     at file://<tmpdir>/src/signer.ts:10:39
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   verifySignature(key: Buffer, value: Buffer, sig: Buffer): boolean {
                                                    ~~~~~~
     at file://<tmpdir>/src/signer.ts:10:52
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override getSignature(_key: Buffer, _value: Buffer): Buffer {
                               ~~~~~~
     at file://<tmpdir>/src/signer.ts:18:31
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override getSignature(_key: Buffer, _value: Buffer): Buffer {
                                               ~~~~~~
     at file://<tmpdir>/src/signer.ts:18:47
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override getSignature(_key: Buffer, _value: Buffer): Buffer {
                                                        ~~~~~~
     at file://<tmpdir>/src/signer.ts:18:56
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override getSignature(key: Buffer, value: Buffer): Buffer {
                              ~~~~~~
     at file://<tmpdir>/src/signer.ts:33:30
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override getSignature(key: Buffer, value: Buffer): Buffer {
                                             ~~~~~~
     at file://<tmpdir>/src/signer.ts:33:45
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override getSignature(key: Buffer, value: Buffer): Buffer {
                                                      ~~~~~~
     at file://<tmpdir>/src/signer.ts:33:54
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ declare secretKeys: Buffer[];
                           ~~~~~~
     at file://<tmpdir>/src/signer.ts:88:27
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   declare sep: Buffer;
                ~~~~~~
     at file://<tmpdir>/src/signer.ts:89:16
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   declare salt: Buffer;
                 ~~~~~~
     at file://<tmpdir>/src/signer.ts:90:17
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ deriveKey(secretKey?: StringBuffer): Buffer {
                                            ~~~~~~
     at file://<tmpdir>/src/signer.ts:103:44
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ getSignature(value: StringBuffer): Buffer {
                                          ~~~~~~
     at file://<tmpdir>/src/signer.ts:108:42
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ sign(value: StringBuffer): Buffer {
                                  ~~~~~~
     at file://<tmpdir>/src/signer.ts:113:34
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ unsign(signedValue: StringBuffer): Buffer {
                                          ~~~~~~
     at file://<tmpdir>/src/signer.ts:123:42
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ override sign(value: StringBuffer): Buffer {
                                           ~~~~~~
     at file://<tmpdir>/src/timed.ts:21:43
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ override unsign(signedValue: StringBuffer, maxAge?: number, returnTimestamp?: false): Buffer;
                                                                                             ~~~~~~
     at file://<tmpdir>/src/timed.ts:29:93
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override unsign(signedValue: StringBuffer, maxAge?: number, returnTimestamp?: true): [Buffer, Date];
                                                                                         ~~~~~~
     at file://<tmpdir>/src/timed.ts:30:89
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
 export type StringBuffer = string | Buffer;
                                     ~~~~~~
     at file://<tmpdir>/src/types.ts:1:37
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override parsePayload(payload: Buffer, serializer?: DefaultSerializer): any {
                                  ~~~~~~
     at file://<tmpdir>/src/url-safe.ts:9:34
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   override stringifyPayload(obj: any): Buffer {
                                        ~~~~~~
     at file://<tmpdir>/src/url-safe.ts:12:40

--- a/tests/specs/ecosystem/lightbery/dynamic_cli/1_0_0.test
+++ b/tests/specs/ecosystem/lightbery/dynamic_cli/1_0_0.test
@@ -13,7 +13,7 @@ lightbery/dynamic-cli/1.0.0
 -- stdout --
 
 -- stderr --
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   public simulateInput(data: Buffer): void {}
                              ~~~~~~
     at file://<tmpdir>/DynamicCLI.ts:45:30

--- a/tests/specs/ecosystem/lightbery/dynamic_cli/1_0_1.test
+++ b/tests/specs/ecosystem/lightbery/dynamic_cli/1_0_1.test
@@ -13,7 +13,7 @@ lightbery/dynamic-cli/1.0.1
 -- stdout --
 
 -- stderr --
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   public simulateInput(data: Buffer): void {}
                              ~~~~~~
     at file://<tmpdir>/DynamicCLI.ts:45:30

--- a/tests/specs/ecosystem/lightbery/dynamic_cli/1_0_2.test
+++ b/tests/specs/ecosystem/lightbery/dynamic_cli/1_0_2.test
@@ -13,7 +13,7 @@ lightbery/dynamic-cli/1.0.2
 -- stdout --
 
 -- stderr --
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   public simulateInput(data: Buffer): void {}
                              ~~~~~~
     at file://<tmpdir>/DynamicCLI.ts:45:30

--- a/tests/specs/ecosystem/lightbery/dynamic_cli/1_0_3.test
+++ b/tests/specs/ecosystem/lightbery/dynamic_cli/1_0_3.test
@@ -13,7 +13,7 @@ lightbery/dynamic-cli/1.0.3
 -- stdout --
 
 -- stderr --
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   public simulateInput(data: Buffer): void {}
                              ~~~~~~
     at file://<tmpdir>/DynamicCLI.ts:45:30

--- a/tests/specs/ecosystem/lightbery/dynamic_cli/1_0_4.test
+++ b/tests/specs/ecosystem/lightbery/dynamic_cli/1_0_4.test
@@ -13,12 +13,12 @@ lightbery/dynamic-cli/1.0.4
 -- stdout --
 
 -- stderr --
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   public simulateInput(data: Buffer): void {}
                              ~~~~~~
     at file://<tmpdir>/DynamicCLI.ts:45:30
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   public listen(name: 'input', callback: (key?: Buffer) => any): void;
                                                 ~~~~~~
     at file://<tmpdir>/DynamicCLI.ts:54:49

--- a/tests/specs/ecosystem/lightbery/dynamic_cli/1_0_5.test
+++ b/tests/specs/ecosystem/lightbery/dynamic_cli/1_0_5.test
@@ -13,12 +13,12 @@ lightbery/dynamic-cli/1.0.5
 -- stdout --
 
 -- stderr --
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   public simulateInput(input: string, key: Buffer): void {}
                                            ~~~~~~
     at file://<tmpdir>/DynamicCLI.ts:45:44
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   public listen(name: 'input', callback: (key?: Buffer) => any): void;
                                                 ~~~~~~
     at file://<tmpdir>/DynamicCLI.ts:54:49

--- a/tests/specs/ecosystem/lightbery/dynamic_cli/1_0_6.test
+++ b/tests/specs/ecosystem/lightbery/dynamic_cli/1_0_6.test
@@ -13,12 +13,12 @@ lightbery/dynamic-cli/1.0.6
 -- stdout --
 
 -- stderr --
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   public simulateInput(input: string, key: Buffer): void {}
                                            ~~~~~~
     at file://<tmpdir>/DynamicCLI.ts:49:44
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   public listen(name: 'input', callback: (key?: Buffer) => any): void;
                                                 ~~~~~~
     at file://<tmpdir>/DynamicCLI.ts:58:49

--- a/tests/specs/ecosystem/lightbery/virtual_file_tree/1_0_0.test
+++ b/tests/specs/ecosystem/lightbery/virtual_file_tree/1_0_0.test
@@ -13,7 +13,7 @@ lightbery/virtual-file-tree/1.0.0
 -- stdout --
 
 -- stderr --
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   public writeFile(virtualPath: string, data: Buffer, options?: {
                                               ~~~~~~
     at file://<tmpdir>/Virtual-File-Tree.ts:10:47

--- a/tests/specs/ecosystem/lilith/hypixel_plugin_message/0_3_0.test
+++ b/tests/specs/ecosystem/lilith/hypixel_plugin_message/0_3_0.test
@@ -13,37 +13,37 @@ lilith/hypixel-plugin-message/0.3.0
 -- stdout --
 
 -- stderr --
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   read(buffer: Buffer): T;
                ~~~~~~
     at file://<tmpdir>/mod.ts:9:16
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   write(packet: T): Buffer;
                     ~~~~~~
     at file://<tmpdir>/mod.ts:10:21
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
 export function readClientboundPacket<T extends VersionedPacket>(name: string, buffer: Buffer): T | FailedPacket {
                                                                                        ~~~~~~
     at file://<tmpdir>/mod.ts:15:88
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
 export function writeClientboundPacket<T extends VersionedPacket>(name: string, packet: T): Buffer {
                                                                                             ~~~~~~
     at file://<tmpdir>/mod.ts:18:93
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
 export function writeClientboundError(error: PacketError): Buffer {
                                                            ~~~~~~
     at file://<tmpdir>/mod.ts:21:60
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
 export function readServerboundPacket<T extends VersionedPacket>(name: string, buffer: Buffer): T {
                                                                                        ~~~~~~
     at file://<tmpdir>/mod.ts:24:88
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
 export function writeServerboundPacket<T extends VersionedPacket>(name: string, packet: T): Buffer {
                                                                                             ~~~~~~
     at file://<tmpdir>/mod.ts:27:93

--- a/tests/specs/ecosystem/lilith/hypixel_plugin_message/0_3_1.test
+++ b/tests/specs/ecosystem/lilith/hypixel_plugin_message/0_3_1.test
@@ -13,37 +13,37 @@ lilith/hypixel-plugin-message/0.3.1
 -- stdout --
 
 -- stderr --
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   read(buffer: Buffer): T;
                ~~~~~~
     at file://<tmpdir>/mod.ts:17:16
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   write(packet: T): Buffer;
                     ~~~~~~
     at file://<tmpdir>/mod.ts:18:21
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
  */ export function readClientboundPacket<T extends VersionedPacket>(name: string, buffer: Buffer): T | FailedPacket {
                                                                                            ~~~~~~
     at file://<tmpdir>/mod.ts:33:92
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
  */ export function writeClientboundPacket<T extends VersionedPacket>(name: string, packet: T): Buffer {
                                                                                                 ~~~~~~
     at file://<tmpdir>/mod.ts:40:97
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
  */ export function writeClientboundError(error: PacketError | PacketErrorId): Buffer {
                                                                                ~~~~~~
     at file://<tmpdir>/mod.ts:47:80
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
  */ export function readServerboundPacket<T extends VersionedPacket>(name: string, buffer: Buffer): T {
                                                                                            ~~~~~~
     at file://<tmpdir>/mod.ts:55:92
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
  */ export function writeServerboundPacket<T extends VersionedPacket>(name: string, packet: T): Buffer {
                                                                                                 ~~~~~~
     at file://<tmpdir>/mod.ts:63:97

--- a/tests/specs/ecosystem/lilith/hypixel_plugin_message/0_3_2.test
+++ b/tests/specs/ecosystem/lilith/hypixel_plugin_message/0_3_2.test
@@ -13,37 +13,37 @@ lilith/hypixel-plugin-message/0.3.2
 -- stdout --
 
 -- stderr --
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   read(buffer: Buffer): T;
                ~~~~~~
     at file://<tmpdir>/mod.ts:17:16
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   write(packet: T): Buffer;
                     ~~~~~~
     at file://<tmpdir>/mod.ts:18:21
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
  */ export function readClientboundPacket<T extends VersionedPacket>(name: string, buffer: Buffer): T | FailedPacket {
                                                                                            ~~~~~~
     at file://<tmpdir>/mod.ts:33:92
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
  */ export function writeClientboundPacket<T extends VersionedPacket>(name: string, packet: T): Buffer {
                                                                                                 ~~~~~~
     at file://<tmpdir>/mod.ts:40:97
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
  */ export function writeClientboundError(error: PacketError | PacketErrorId): Buffer {
                                                                                ~~~~~~
     at file://<tmpdir>/mod.ts:47:80
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
  */ export function readServerboundPacket<T extends VersionedPacket>(name: string, buffer: Buffer): T {
                                                                                            ~~~~~~
     at file://<tmpdir>/mod.ts:55:92
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
  */ export function writeServerboundPacket<T extends VersionedPacket>(name: string, packet: T): Buffer {
                                                                                                 ~~~~~~
     at file://<tmpdir>/mod.ts:63:97

--- a/tests/specs/ecosystem/lilith/hypixel_plugin_message/0_3_3.test
+++ b/tests/specs/ecosystem/lilith/hypixel_plugin_message/0_3_3.test
@@ -13,37 +13,37 @@ lilith/hypixel-plugin-message/0.3.3
 -- stdout --
 
 -- stderr --
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   read(buffer: Buffer): T;
                ~~~~~~
     at file://<tmpdir>/mod.ts:17:16
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   write(packet: T): Buffer;
                     ~~~~~~
     at file://<tmpdir>/mod.ts:18:21
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
  */ export function readClientboundPacket<T extends VersionedPacket>(name: string, buffer: Buffer): T | FailedPacket {
                                                                                            ~~~~~~
     at file://<tmpdir>/mod.ts:33:92
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
  */ export function writeClientboundPacket<T extends VersionedPacket>(name: string, packet: T): Buffer {
                                                                                                 ~~~~~~
     at file://<tmpdir>/mod.ts:40:97
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
  */ export function writeClientboundError(error: PacketError | PacketErrorId): Buffer {
                                                                                ~~~~~~
     at file://<tmpdir>/mod.ts:47:80
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
  */ export function readServerboundPacket<T extends VersionedPacket>(name: string, buffer: Buffer): T {
                                                                                            ~~~~~~
     at file://<tmpdir>/mod.ts:55:92
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
  */ export function writeServerboundPacket<T extends VersionedPacket>(name: string, packet: T): Buffer {
                                                                                                 ~~~~~~
     at file://<tmpdir>/mod.ts:63:97

--- a/tests/specs/ecosystem/llamaindex/env/0_0_4.test
+++ b/tests/specs/ecosystem/llamaindex/env/0_0_4.test
@@ -13,12 +13,12 @@ llamaindex/env/0.0.4
 -- stdout --
 
 -- stderr --
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ readRawFile(path: string): Promise<Buffer>;
                                          ~~~~~~
     at file://<tmpdir>/src/type.ts:10:42
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   readRawFile(path: string): Promise<Buffer> {
                                      ~~~~~~
     at file://<tmpdir>/src/type.ts:47:38

--- a/tests/specs/ecosystem/llamaindex/env/0_0_5.test
+++ b/tests/specs/ecosystem/llamaindex/env/0_0_5.test
@@ -13,12 +13,12 @@ llamaindex/env/0.0.5
 -- stdout --
 
 -- stderr --
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ readRawFile(path: string): Promise<Buffer>;
                                          ~~~~~~
     at file://<tmpdir>/src/type.ts:10:42
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   readRawFile(path: string): Promise<Buffer> {
                                      ~~~~~~
     at file://<tmpdir>/src/type.ts:47:38

--- a/tests/specs/ecosystem/llamaindex/env/0_0_6.test
+++ b/tests/specs/ecosystem/llamaindex/env/0_0_6.test
@@ -13,12 +13,12 @@ llamaindex/env/0.0.6
 -- stdout --
 
 -- stderr --
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ readRawFile(path: string): Promise<Buffer>;
                                          ~~~~~~
     at file://<tmpdir>/src/type.ts:10:42
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   readRawFile(path: string): Promise<Buffer> {
                                      ~~~~~~
     at file://<tmpdir>/src/type.ts:47:38

--- a/tests/specs/ecosystem/llamaindex/env/0_1_0.test
+++ b/tests/specs/ecosystem/llamaindex/env/0_1_0.test
@@ -13,12 +13,12 @@ llamaindex/env/0.1.0
 -- stdout --
 
 -- stderr --
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
    */ readRawFile(path: string): Promise<Buffer>;
                                          ~~~~~~
     at file://<tmpdir>/src/type.ts:9:42
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   readRawFile(path: string): Promise<Buffer> {
                                      ~~~~~~
     at file://<tmpdir>/src/type.ts:46:38

--- a/tests/specs/ecosystem/molikodev/twitchts/0_1_3.test
+++ b/tests/specs/ecosystem/molikodev/twitchts/0_1_3.test
@@ -268,7 +268,7 @@ TS4114 [ERROR]: This member must have an 'override' modifier because it override
   ~~
     at file://<tmpdir>/src/irc/IrcBase.ts:21:3
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   Close(code?: number | undefined, data?: string | Buffer | undefined): Promise<void> {
                                                    ~~~~~~
     at file://<tmpdir>/src/irc/IrcBase.ts:25:52

--- a/tests/specs/ecosystem/molikodev/twitchts/0_1_4.test
+++ b/tests/specs/ecosystem/molikodev/twitchts/0_1_4.test
@@ -268,7 +268,7 @@ TS4114 [ERROR]: This member must have an 'override' modifier because it override
   ~~
     at file://<tmpdir>/src/irc/IrcBase.ts:21:3
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   Close(code?: number | undefined, data?: string | Buffer | undefined): Promise<void> {
                                                    ~~~~~~
     at file://<tmpdir>/src/irc/IrcBase.ts:25:52

--- a/tests/specs/ecosystem/molikodev/twitchts/0_1_5.test
+++ b/tests/specs/ecosystem/molikodev/twitchts/0_1_5.test
@@ -268,7 +268,7 @@ TS4114 [ERROR]: This member must have an 'override' modifier because it override
   ~~
     at file://<tmpdir>/src/irc/IrcBase.ts:21:3
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   Close(code?: number | undefined, data?: string | Buffer | undefined): Promise<void> {
                                                    ~~~~~~
     at file://<tmpdir>/src/irc/IrcBase.ts:25:52

--- a/tests/specs/ecosystem/molikodev/twitchts/0_1_6.test
+++ b/tests/specs/ecosystem/molikodev/twitchts/0_1_6.test
@@ -273,7 +273,7 @@ TS4114 [ERROR]: This member must have an 'override' modifier because it override
   ~~
     at file://<tmpdir>/src/irc/IrcBase.ts:22:3
 
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
   public Close(code?: number | undefined, data?: string | Buffer | undefined): Promise<void> {
                                                           ~~~~~~
     at file://<tmpdir>/src/irc/IrcBase.ts:26:59

--- a/tests/specs/ecosystem/teapot/insomnia_plugin_aws/0_1_0.test
+++ b/tests/specs/ecosystem/teapot/insomnia_plugin_aws/0_1_0.test
@@ -13,7 +13,7 @@ teapot/insomnia-plugin-aws/0.1.0
 -- stdout --
 
 -- stderr --
-TS2580 [ERROR]: Cannot find name 'Buffer'.
+TS2591 [ERROR]: Cannot find name 'Buffer'.
         getBodyBuffer: (response: Response, fallback?: any) => Promise<Buffer | null>;
                                                                        ~~~~~~
     at file://<tmpdir>/src/types/template.ts:60:72


### PR DESCRIPTION
The ecosystem suite runs against Deno canary, and a recent canary change
switched the TypeScript error code emitted for "Cannot find name 'Buffer'"
from `TS2580` to `TS2591`. The 24 snapshots that exercise packages depending
on Node's `Buffer` (hampus/itsdangerous, lightbery/dynamic_cli,
lightbery/virtual_file_tree, lilith/hypixel_plugin_message, llamaindex/env,
molikodev/twitchts, teapot/insomnia_plugin_aws) all drifted at once and are
now failing CI on unrelated PRs. This updates just that one error code on
the affected lines; no other test output changed.