### PR TITLE
feat(source): expose import attribute type in LoadOptions

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -5558,6 +5558,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
           was_dynamic_root: self.was_dynamic_root,
           cache_setting: CacheSetting::Only,
           maybe_checksum: Some(checksum.clone()),
+          maybe_attribute_type: None,
         },
       );
       let is_dynamic_branch = self.in_dynamic_branch;
@@ -5965,6 +5966,9 @@ impl<'a, 'graph> Builder<'a, 'graph> {
           was_dynamic_root,
           cache_setting: CacheSetting::Use,
           maybe_checksum: maybe_checksum.clone(),
+          maybe_attribute_type: maybe_attribute_type
+            .as_ref()
+            .map(|t| t.kind.clone()),
         };
 
         let handle_redirect =
@@ -6051,6 +6055,9 @@ impl<'a, 'graph> Builder<'a, 'graph> {
                       was_dynamic_root,
                       cache_setting: CacheSetting::Reload,
                       maybe_checksum: maybe_checksum.clone(),
+                      maybe_attribute_type: maybe_attribute_type
+                        .as_ref()
+                        .map(|t| t.kind.clone()),
                     },
                   )
                   .await;
@@ -6144,6 +6151,9 @@ impl<'a, 'graph> Builder<'a, 'graph> {
                     was_dynamic_root,
                     cache_setting: CacheSetting::Reload,
                     maybe_checksum: maybe_checksum.clone(),
+                    maybe_attribute_type: maybe_attribute_type
+                      .as_ref()
+                      .map(|t| t.kind.clone()),
                   },
                 )
                 .await;
@@ -6325,6 +6335,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
                 was_dynamic_root: self.was_dynamic_root,
                 cache_setting: CacheSetting::Use,
                 maybe_checksum: Some(checksum.clone()),
+                maybe_attribute_type: None,
               },
             );
             async move {

--- a/src/jsr.rs
+++ b/src/jsr.rs
@@ -211,6 +211,7 @@ impl JsrMetadataStore {
         was_dynamic_root: false,
         cache_setting,
         maybe_checksum: maybe_expected_checksum,
+        maybe_attribute_type: None,
       },
     );
     let fut = spawn(

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -309,6 +309,13 @@ pub struct LoadOptions {
   ///
   /// The source may be verified by running `checksum.check_source(content)?`.
   pub maybe_checksum: Option<LoaderChecksum>,
+  /// The `type` import attribute the module is being loaded with, if any
+  /// (e.g. `"json"`, `"text"`, `"bytes"`).
+  ///
+  /// Loaders may use this to set an appropriate `Accept` header on remote
+  /// requests. For example, JSON modules should be fetched with
+  /// `Accept: application/json,*/*;q=0.5` per the HTML specification.
+  pub maybe_attribute_type: Option<String>,
 }
 
 /// A trait which allows asynchronous loading of source files into a module


### PR DESCRIPTION
Adds a `maybe_attribute_type` field to the public `LoadOptions` struct that is
passed to `Loader::load` / `Loader::ensure_cached`. It carries the `type` import
attribute the module is being loaded with (e.g. `"json"`, `"text"`, `"bytes"`),
which deno_graph already tracks internally but did not expose to loaders.

This lets a `Loader` set an appropriate `Accept` header on remote requests. In
particular, JSON modules should be fetched with `Accept: application/json,*/*;q=0.5`
per the updated HTML/Fetch specifications (whatwg/html#9486, whatwg/fetch#1691).
The field is populated for the HTTP(S) module load path and left `None` for JSR
registry/content loads where it does not apply. The addition is additive and
does not change the JS loader signature.

Needed by denoland/deno to fix denoland/deno#20866.