### PR TITLE
feat: unstable config imports (yaml/toml/json5/jsonc)

### DIFF
--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -314,6 +314,7 @@ pub async fn js_create_graph(
         unstable_bytes_imports: true,
         unstable_text_imports: true,
         unstable_css_imports: true,
+        unstable_config_imports: true,
         resolver: maybe_resolver.as_ref().map(|r| r as &dyn Resolver),
         // todo(dsherret): actually implement this for Wasm users
         // and don't just use a RealSys here as it would be better

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -3217,35 +3217,53 @@ impl ConfigImportKind {
     }
   }
 
-  /// Renders a JavaScript module that parses `text` and exposes the result as
-  /// the default export. The parser is imported from the registry, so it only
-  /// becomes a graph dependency when a file of this kind is actually imported,
-  /// which keeps the feature zero-cost when unused.
+  /// Renders a JavaScript module that imports the original file as text, parses
+  /// it with a parser pulled from the registry on demand, and exposes the
+  /// result as the default export:
   ///
-  /// The file contents are inlined as a string literal rather than imported via
-  /// `with { type: "text" }`: the transformed module occupies the file's
-  /// specifier in the graph, so a self text-import would read back this
-  /// generated source instead of the original bytes.
-  fn render_module(&self, text: &str) -> String {
+  /// ```js
+  /// import source from "<raw_specifier>" with { type: "text" };
+  /// import { parse } from "jsr:@std/yaml@^1";
+  /// export default parse(source);
+  /// ```
+  ///
+  /// The file contents are imported as text rather than inlined as a string
+  /// literal, so the original bytes flow through the normal text-import path (a
+  /// real graph node, cached and lockfile-tracked, not embedded in the
+  /// generated source). `raw_specifier` is the file's own specifier with a
+  /// marker query, so the wrapper (which occupies the file's plain specifier)
+  /// and the raw text module are distinct graph nodes rather than colliding.
+  ///
+  /// The parser is imported from the registry, so it only becomes a graph
+  /// dependency when a file of this kind is actually imported, which keeps the
+  /// feature zero-cost when unused.
+  fn render_module(&self, raw_specifier: &str) -> String {
     // `serde_json::to_string` produces a valid JS string literal (it is a
-    // subset of JS), so this safely escapes arbitrary file contents.
-    let source = serde_json::to_string(text).unwrap();
+    // subset of JS), so this safely escapes the specifier.
+    let raw = serde_json::to_string(raw_specifier).unwrap();
+    let import_source =
+      format!("import source from {raw} with {{ type: \"text\" }};\n");
     match self {
       Self::Yaml => format!(
-        "import {{ parse }} from \"jsr:@std/yaml@^1\";\nexport default parse({source});\n"
+        "{import_source}import {{ parse }} from \"jsr:@std/yaml@^1\";\nexport default parse(source);\n"
       ),
       Self::Toml => format!(
-        "import {{ parse }} from \"jsr:@std/toml@^1\";\nexport default parse({source});\n"
+        "{import_source}import {{ parse }} from \"jsr:@std/toml@^1\";\nexport default parse(source);\n"
       ),
       Self::Jsonc => format!(
-        "import {{ parse }} from \"jsr:@std/jsonc@^1\";\nexport default parse({source});\n"
+        "{import_source}import {{ parse }} from \"jsr:@std/jsonc@^1\";\nexport default parse(source);\n"
       ),
       // There is no `@std/json5`, so use the ubiquitous npm package.
       Self::Json5 => format!(
-        "import JSON5 from \"npm:json5@^2\";\nexport default JSON5.parse({source});\n"
+        "{import_source}import JSON5 from \"npm:json5@^2\";\nexport default JSON5.parse(source);\n"
       ),
     }
   }
+
+  /// The marker query appended to a config file's specifier to form the raw
+  /// text module's specifier, keeping it distinct from the wrapper module that
+  /// occupies the plain specifier.
+  const RAW_QUERY_MARKER: &'static str = "deno-config-raw";
 }
 
 /// With the provided information, parse a module and return its "module slot"
@@ -3301,21 +3319,21 @@ pub(crate) async fn parse_module_source_and_info(
   }
 
   // Config imports (yaml/toml/json5/jsonc) are transformed into JavaScript
-  // modules that parse the file contents with a parser pulled from the
-  // registry on demand. This keeps the feature zero-cost when unused: the
-  // parser only enters the module graph when such a file is actually imported.
+  // modules that text-import the file contents and parse them with a parser
+  // pulled from the registry on demand. This keeps the feature zero-cost when
+  // unused: the parser only enters the module graph when such a file is
+  // actually imported. The wrapper occupies the file's plain specifier; the
+  // raw text module lives at the same specifier with a marker query so the two
+  // are distinct graph nodes.
   if opts.unstable_config_imports
     && let Some(kind) = ConfigImportKind::detect(
       opts.maybe_attribute_type.map(|t| t.kind.as_str()),
     )
   {
-    let raw = new_source_with_text(
-      &opts.specifier,
-      opts.content,
-      maybe_charset,
-      opts.mtime,
-    )?;
-    let wrapper: Arc<[u8]> = kind.render_module(&raw.text).into_bytes().into();
+    let mut raw_specifier = opts.specifier.clone();
+    raw_specifier.set_query(Some(ConfigImportKind::RAW_QUERY_MARKER));
+    let wrapper: Arc<[u8]> =
+      kind.render_module(raw_specifier.as_str()).into_bytes().into();
     let source = new_source_with_text(
       &opts.specifier,
       wrapper,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -8911,4 +8911,112 @@ export class Auth {
       vec![0xEF, 0xBB, 0xBF, b't', b'e', b's', b't']
     )
   }
+
+  #[tokio::test]
+  async fn config_import_redirected_by_resolver_hook() {
+    // With `unstable_config_imports` enabled and a resolver that claims the
+    // `yaml` attribute, a `with { type: "yaml" }` import is redirected to the
+    // wrapper module the resolver returns rather than the file itself.
+    let mut mem_loader = MemoryLoader::default();
+    mem_loader.add_source_with_text(
+      "file:///main.js",
+      "import data from \"./config.yaml\" with { type: \"yaml\" };\nconsole.log(data);\n",
+    );
+    mem_loader
+      .add_source_with_text("file:///wrapper.js", "export default 1;\n");
+    // `file:///config.yaml` is intentionally not provided: if the redirect did
+    // not happen the build would surface a missing-module error and
+    // `graph.valid()` below would fail.
+
+    #[derive(Debug)]
+    struct ConfigImportResolver;
+    impl Resolver for ConfigImportResolver {
+      fn resolve_attribute_type_import(
+        &self,
+        _specifier_text: &str,
+        _referrer_range: &Range,
+        _kind: ResolutionKind,
+        attribute_type: &str,
+      ) -> Option<Result<ModuleSpecifier, ResolveError>> {
+        matches!(attribute_type, "yaml" | "toml" | "json5" | "jsonc")
+          .then(|| Ok(ModuleSpecifier::parse("file:///wrapper.js").unwrap()))
+      }
+    }
+
+    let resolver = ConfigImportResolver;
+    let mut graph = ModuleGraph::new(GraphKind::All);
+    graph
+      .build(
+        vec![Url::parse("file:///main.js").unwrap()],
+        Vec::new(),
+        &mem_loader,
+        BuildOptions {
+          resolver: Some(&resolver),
+          unstable_config_imports: true,
+          ..Default::default()
+        },
+      )
+      .await;
+    graph.valid().unwrap();
+
+    let module = graph
+      .get(&Url::parse("file:///main.js").unwrap())
+      .unwrap()
+      .js()
+      .unwrap();
+    let dep = module.dependencies.get("./config.yaml").unwrap();
+    // The code dependency points at the wrapper, not the config file.
+    assert_eq!(
+      dep.maybe_code.maybe_specifier().unwrap().as_str(),
+      "file:///wrapper.js"
+    );
+    // The type resolution is redirected to the same wrapper, so no separate
+    // type dependency is recorded and the original file is never pulled in as a
+    // typed dependency.
+    assert!(dep.maybe_type.maybe_specifier().is_none());
+    // The wrapper is in the graph; the config file was never loaded.
+    assert!(
+      graph
+        .get(&Url::parse("file:///wrapper.js").unwrap())
+        .is_some()
+    );
+    assert!(
+      graph
+        .get(&Url::parse("file:///config.yaml").unwrap())
+        .is_none()
+    );
+  }
+
+  #[tokio::test]
+  async fn config_import_attribute_rejected_without_unstable_flag() {
+    // Without `unstable_config_imports` (and with no resolver hook to claim it),
+    // a config attribute type is unsupported, matching the behaviour for any
+    // unknown attribute kind.
+    let mut mem_loader = MemoryLoader::default();
+    mem_loader.add_source_with_text(
+      "file:///main.js",
+      "import data from \"./config.yaml\" with { type: \"yaml\" };\n",
+    );
+    mem_loader.add_source_with_text("file:///config.yaml", "name: deno\n");
+
+    let mut graph = ModuleGraph::new(GraphKind::All);
+    graph
+      .build(
+        vec![Url::parse("file:///main.js").unwrap()],
+        Vec::new(),
+        &mem_loader,
+        Default::default(),
+      )
+      .await;
+
+    let errors = graph.module_errors().collect::<Vec<_>>();
+    assert!(
+      errors.iter().any(|e| matches!(
+        e.as_kind(),
+        ModuleErrorKind::UnsupportedImportAttributeType { kind, .. }
+          if kind == "yaml"
+      )),
+      "expected an UnsupportedImportAttributeType error for the yaml attribute, got: {errors:?}"
+    );
+  }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1696,6 +1696,10 @@ pub struct BuildOptions<'a> {
   pub unstable_text_imports: bool,
   /// Support unstable css imports.
   pub unstable_css_imports: bool,
+  /// Support unstable config imports (yaml/toml/json5/jsonc), which are
+  /// transformed into JavaScript modules that parse the file with a parser
+  /// pulled from the registry on demand.
+  pub unstable_config_imports: bool,
   pub executor: &'a dyn Executor,
   pub locker: Option<&'a mut dyn Locker>,
   pub file_system: &'a FileSystem,
@@ -1721,6 +1725,7 @@ impl Default for BuildOptions<'_> {
       unstable_bytes_imports: false,
       unstable_text_imports: false,
       unstable_css_imports: false,
+      unstable_config_imports: false,
       executor: Default::default(),
       locker: None,
       file_system: &NullFileSystem,
@@ -3171,6 +3176,102 @@ pub(crate) struct ParseModuleAndSourceInfoOptions<'a> {
   pub maybe_source_phase_referrer: Option<&'a Range>,
   pub is_root: bool,
   pub is_dynamic_branch: bool,
+  pub unstable_config_imports: bool,
+}
+
+/// A configuration file format that can be imported as a module. Each variant
+/// maps to a registry package whose `parse` is used to turn the file contents
+/// into the module's default export.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConfigImportKind {
+  Yaml,
+  Toml,
+  Json5,
+  Jsonc,
+}
+
+impl ConfigImportKind {
+  /// Determines the config import kind from the file extension / media type and
+  /// the optional `type` import attribute. An explicit attribute takes
+  /// precedence; `type: "json"` is additionally accepted for JSON5/JSONC files.
+  ///
+  /// YAML and TOML are detected from the specifier's extension rather than a
+  /// dedicated media type, so that adding the feature does not require new
+  /// `MediaType` variants (which would ripple across the ecosystem).
+  fn detect(
+    specifier: &ModuleSpecifier,
+    media_type: MediaType,
+    attribute_type: Option<&str>,
+  ) -> Option<Self> {
+    match attribute_type {
+      Some("yaml") => Some(Self::Yaml),
+      Some("toml") => Some(Self::Toml),
+      Some("json5") => Some(Self::Json5),
+      Some("jsonc") => Some(Self::Jsonc),
+      // JSON5/JSONC are supersets of JSON, so they satisfy `type: "json"`.
+      Some("json") => match Self::from_extension(specifier, media_type) {
+        kind @ (Some(Self::Json5) | Some(Self::Jsonc)) => kind,
+        _ => None,
+      },
+      Some(_) => None,
+      None => Self::from_extension(specifier, media_type),
+    }
+  }
+
+  fn from_extension(
+    specifier: &ModuleSpecifier,
+    media_type: MediaType,
+  ) -> Option<Self> {
+    // JSON5/JSONC have dedicated media types, so they may also be identified
+    // via a remote `content-type` header even without a matching extension.
+    match media_type {
+      MediaType::Json5 => return Some(Self::Json5),
+      MediaType::Jsonc => return Some(Self::Jsonc),
+      _ => {}
+    }
+    let path = specifier.path().to_ascii_lowercase();
+    if path.ends_with(".yaml") || path.ends_with(".yml") {
+      Some(Self::Yaml)
+    } else if path.ends_with(".toml") {
+      Some(Self::Toml)
+    } else if path.ends_with(".json5") {
+      Some(Self::Json5)
+    } else if path.ends_with(".jsonc") {
+      Some(Self::Jsonc)
+    } else {
+      None
+    }
+  }
+
+  /// Renders a JavaScript module that parses `text` and exposes the result as
+  /// the default export. The parser is imported from the registry, so it only
+  /// becomes a graph dependency when a file of this kind is actually imported,
+  /// which keeps the feature zero-cost when unused.
+  ///
+  /// The file contents are inlined as a string literal rather than imported via
+  /// `with { type: "text" }`: the transformed module occupies the file's
+  /// specifier in the graph, so a self text-import would read back this
+  /// generated source instead of the original bytes.
+  fn render_module(&self, text: &str) -> String {
+    // `serde_json::to_string` produces a valid JS string literal (it is a
+    // subset of JS), so this safely escapes arbitrary file contents.
+    let source = serde_json::to_string(text).unwrap();
+    match self {
+      Self::Yaml => format!(
+        "import {{ parse }} from \"jsr:@std/yaml@^1\";\nexport default parse({source});\n"
+      ),
+      Self::Toml => format!(
+        "import {{ parse }} from \"jsr:@std/toml@^1\";\nexport default parse({source});\n"
+      ),
+      Self::Jsonc => format!(
+        "import {{ parse }} from \"jsr:@std/jsonc@^1\";\nexport default parse({source});\n"
+      ),
+      // There is no `@std/json5`, so use the ubiquitous npm package.
+      Self::Json5 => format!(
+        "import JSON5 from \"npm:json5@^2\";\nexport default JSON5.parse({source});\n"
+      ),
+    }
+  }
 }
 
 /// With the provided information, parse a module and return its "module slot"
@@ -3209,6 +3310,11 @@ pub(crate) async fn parse_module_source_and_info(
 
   if let Some(attribute_type) = opts.maybe_attribute_type
     && !matches!(attribute_type.kind.as_str(), "json" | "text" | "bytes")
+    && !(opts.unstable_config_imports
+      && matches!(
+        attribute_type.kind.as_str(),
+        "yaml" | "toml" | "json5" | "jsonc"
+      ))
   {
     return Err(
       ModuleErrorKind::UnsupportedImportAttributeType {
@@ -3218,6 +3324,53 @@ pub(crate) async fn parse_module_source_and_info(
       }
       .into_box(),
     );
+  }
+
+  // Config imports (yaml/toml/json5/jsonc) are transformed into JavaScript
+  // modules that parse the file contents with a parser pulled from the
+  // registry on demand. This keeps the feature zero-cost when unused: the
+  // parser only enters the module graph when such a file is actually imported.
+  if opts.unstable_config_imports
+    && let Some(kind) = ConfigImportKind::detect(
+      &opts.specifier,
+      media_type,
+      opts.maybe_attribute_type.map(|t| t.kind.as_str()),
+    )
+  {
+    let raw = new_source_with_text(
+      &opts.specifier,
+      opts.content,
+      maybe_charset,
+      opts.mtime,
+    )?;
+    let wrapper: Arc<[u8]> = kind.render_module(&raw.text).into_bytes().into();
+    let source = new_source_with_text(
+      &opts.specifier,
+      wrapper,
+      Some("utf-8"),
+      opts.mtime,
+    )?;
+    return match module_analyzer
+      .analyze(&opts.specifier, source.text.clone(), MediaType::JavaScript)
+      .await
+    {
+      Ok(module_info) => Ok(ModuleSourceAndInfo::Js {
+        specifier: opts.specifier,
+        media_type: MediaType::JavaScript,
+        mtime: opts.mtime,
+        source,
+        maybe_headers: opts.maybe_headers,
+        module_info: Box::new(module_info),
+      }),
+      Err(diagnostic) => Err(
+        ModuleErrorKind::Parse {
+          specifier: opts.specifier,
+          mtime: opts.mtime,
+          diagnostic: Arc::new(diagnostic),
+        }
+        .into_box(),
+      ),
+    };
   }
 
   // here we check any media types that should have assertions made against them
@@ -4562,6 +4715,7 @@ struct Builder<'a, 'graph> {
   unstable_bytes_imports: bool,
   unstable_text_imports: bool,
   unstable_css_imports: bool,
+  unstable_config_imports: bool,
   file_system: &'a FileSystem,
   jsr_url_provider: &'a dyn JsrUrlProvider,
   jsr_version_resolver: Cow<'a, JsrVersionResolver>,
@@ -4597,6 +4751,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
       unstable_bytes_imports: options.unstable_bytes_imports,
       unstable_text_imports: options.unstable_text_imports,
       unstable_css_imports: options.unstable_css_imports,
+      unstable_config_imports: options.unstable_config_imports,
       file_system: options.file_system,
       jsr_url_provider: options.jsr_url_provider,
       jsr_version_resolver: options.jsr_version_resolver,
@@ -5568,6 +5723,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
       );
       let is_dynamic_branch = self.in_dynamic_branch;
       let module_analyzer = self.module_analyzer;
+      let unstable_config_imports = self.unstable_config_imports;
       self.state.pending.push_back({
         let requested_specifier = specifier.clone();
         let maybe_range = options.maybe_range.cloned();
@@ -5605,6 +5761,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
                     .as_ref(),
                   is_root: options.is_root,
                   is_dynamic_branch,
+                  unstable_config_imports,
                 },
               )
               .await
@@ -5651,6 +5808,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
                     .as_ref(),
                   is_root: options.is_root,
                   is_dynamic_branch,
+                  unstable_config_imports,
                 },
               )
               .await
@@ -5868,6 +6026,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
     let module_analyzer = self.module_analyzer;
     let jsr_url_provider = self.jsr_url_provider;
     let was_dynamic_root = self.was_dynamic_root;
+    let unstable_config_imports = self.unstable_config_imports;
     let maybe_nv_when_no_version_info = if maybe_version_info.is_none() {
       self
         .jsr_url_provider
@@ -5914,6 +6073,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
         loader: &dyn Loader,
         jsr_url_provider: &dyn JsrUrlProvider,
         module_analyzer: &dyn ModuleAnalyzer,
+        unstable_config_imports: bool,
       ) -> Result<PendingInfoResponse, ModuleError> {
         async fn handle_success(
           module_analyzer: &dyn ModuleAnalyzer,
@@ -6127,6 +6287,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
                   maybe_source_phase_referrer,
                   is_root,
                   is_dynamic_branch: in_dynamic_branch,
+                  unstable_config_imports,
                 },
               )
               .await
@@ -6173,6 +6334,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
                     maybe_source_phase_referrer,
                     is_root,
                     is_dynamic_branch: in_dynamic_branch,
+                    unstable_config_imports,
                   },
                 )
                 .await;
@@ -6223,6 +6385,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
         loader,
         jsr_url_provider,
         module_analyzer,
+        unstable_config_imports,
       )
       .await;
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1696,17 +1696,10 @@ pub struct BuildOptions<'a> {
   pub unstable_text_imports: bool,
   /// Support unstable css imports.
   pub unstable_css_imports: bool,
-  /// Support unstable config imports (yaml/toml/json5/jsonc), which are
-  /// transformed into JavaScript modules that parse the file with a parser
-  /// pulled from the registry on demand.
+  /// Permit the `yaml`/`toml`/`json5`/`jsonc` import attribute types. deno_graph
+  /// does not interpret them itself; the embedder's [`Resolver`] is expected to
+  /// redirect such imports (see [`Resolver::resolve_attribute_type_import`]).
   pub unstable_config_imports: bool,
-  /// The `type` import attribute to associate with the roots being built.
-  ///
-  /// Roots normally have no import attribute, but a non-analyzable dynamic
-  /// `import()` of a config file enters the graph as a root, so the caller
-  /// passes its `with { type: "..." }` attribute here to let it be recognized
-  /// as a config import (which requires an explicit attribute).
-  pub maybe_root_attribute_type: Option<String>,
   pub executor: &'a dyn Executor,
   pub locker: Option<&'a mut dyn Locker>,
   pub file_system: &'a FileSystem,
@@ -1733,7 +1726,6 @@ impl Default for BuildOptions<'_> {
       unstable_text_imports: false,
       unstable_css_imports: false,
       unstable_config_imports: false,
-      maybe_root_attribute_type: None,
       executor: Default::default(),
       locker: None,
       file_system: &NullFileSystem,
@@ -2968,6 +2960,42 @@ fn resolve(
   Resolution::from_resolve_result(response, specifier_text, referrer_range)
 }
 
+/// Like [`resolve`], but first consults [`Resolver::resolve_attribute_type_import`]
+/// when the import carries a `type` attribute. This lets an embedder redirect
+/// attribute imports (e.g. config-file imports) without deno_graph knowing about
+/// the attribute's meaning.
+fn resolve_with_attribute_type(
+  specifier_text: &str,
+  referrer_range: Range,
+  resolution_kind: ResolutionKind,
+  maybe_attribute_type: Option<&str>,
+  jsr_url_provider: &dyn JsrUrlProvider,
+  maybe_resolver: Option<&dyn Resolver>,
+) -> Resolution {
+  if let Some(attribute_type) = maybe_attribute_type
+    && let Some(resolver) = maybe_resolver
+    && let Some(response) = resolver.resolve_attribute_type_import(
+      specifier_text,
+      &referrer_range,
+      resolution_kind,
+      attribute_type,
+    )
+  {
+    return Resolution::from_resolve_result(
+      response,
+      specifier_text,
+      referrer_range,
+    );
+  }
+  resolve(
+    specifier_text,
+    referrer_range,
+    resolution_kind,
+    jsr_url_provider,
+    maybe_resolver,
+  )
+}
+
 struct NewSpecifier {
   specifier: ModuleSpecifier,
   maybe_range: Option<Range>,
@@ -3187,85 +3215,6 @@ pub(crate) struct ParseModuleAndSourceInfoOptions<'a> {
   pub unstable_config_imports: bool,
 }
 
-/// A configuration file format that can be imported as a module. Each variant
-/// maps to a registry package whose `parse` is used to turn the file contents
-/// into the module's default export.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ConfigImportKind {
-  Yaml,
-  Toml,
-  Json5,
-  Jsonc,
-}
-
-impl ConfigImportKind {
-  /// Determines the config import kind solely from the `type` import attribute.
-  ///
-  /// An explicit attribute is required: a config file is only treated as such
-  /// when imported with `with { type: "yaml" }` (or `"toml"`/`"json5"`/
-  /// `"jsonc"`). The file extension is deliberately not consulted, matching the
-  /// browser rule that a non-JS module type must be requested explicitly, and
-  /// `type: "json"` is intentionally not accepted for JSON5/JSONC since those
-  /// are not JSON per the JSON modules proposal.
-  fn detect(attribute_type: Option<&str>) -> Option<Self> {
-    match attribute_type {
-      Some("yaml") => Some(Self::Yaml),
-      Some("toml") => Some(Self::Toml),
-      Some("json5") => Some(Self::Json5),
-      Some("jsonc") => Some(Self::Jsonc),
-      _ => None,
-    }
-  }
-
-  /// Renders a JavaScript module that imports the original file as text, parses
-  /// it with a parser pulled from the registry on demand, and exposes the
-  /// result as the default export:
-  ///
-  /// ```js
-  /// import source from "<raw_specifier>" with { type: "text" };
-  /// import { parse } from "jsr:@std/yaml@^1";
-  /// export default parse(source);
-  /// ```
-  ///
-  /// The file contents are imported as text rather than inlined as a string
-  /// literal, so the original bytes flow through the normal text-import path (a
-  /// real graph node, cached and lockfile-tracked, not embedded in the
-  /// generated source). `raw_specifier` is the file's own specifier with a
-  /// marker query, so the wrapper (which occupies the file's plain specifier)
-  /// and the raw text module are distinct graph nodes rather than colliding.
-  ///
-  /// The parser is imported from the registry, so it only becomes a graph
-  /// dependency when a file of this kind is actually imported, which keeps the
-  /// feature zero-cost when unused.
-  fn render_module(&self, raw_specifier: &str) -> String {
-    // `serde_json::to_string` produces a valid JS string literal (it is a
-    // subset of JS), so this safely escapes the specifier.
-    let raw = serde_json::to_string(raw_specifier).unwrap();
-    let import_source =
-      format!("import source from {raw} with {{ type: \"text\" }};\n");
-    match self {
-      Self::Yaml => format!(
-        "{import_source}import {{ parse }} from \"jsr:@std/yaml@^1\";\nexport default parse(source);\n"
-      ),
-      Self::Toml => format!(
-        "{import_source}import {{ parse }} from \"jsr:@std/toml@^1\";\nexport default parse(source);\n"
-      ),
-      Self::Jsonc => format!(
-        "{import_source}import {{ parse }} from \"jsr:@std/jsonc@^1\";\nexport default parse(source);\n"
-      ),
-      // There is no `@std/json5`, so use the ubiquitous npm package.
-      Self::Json5 => format!(
-        "{import_source}import JSON5 from \"npm:json5@^2\";\nexport default JSON5.parse(source);\n"
-      ),
-    }
-  }
-
-  /// The marker query appended to a config file's specifier to form the raw
-  /// text module's specifier, keeping it distinct from the wrapper module that
-  /// occupies the plain specifier.
-  const RAW_QUERY_MARKER: &'static str = "deno-config-raw";
-}
-
 /// With the provided information, parse a module and return its "module slot"
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::result_large_err)]
@@ -3316,51 +3265,6 @@ pub(crate) async fn parse_module_source_and_info(
       }
       .into_box(),
     );
-  }
-
-  // Config imports (yaml/toml/json5/jsonc) are transformed into JavaScript
-  // modules that text-import the file contents and parse them with a parser
-  // pulled from the registry on demand. This keeps the feature zero-cost when
-  // unused: the parser only enters the module graph when such a file is
-  // actually imported. The wrapper occupies the file's plain specifier; the
-  // raw text module lives at the same specifier with a marker query so the two
-  // are distinct graph nodes.
-  if opts.unstable_config_imports
-    && let Some(kind) = ConfigImportKind::detect(
-      opts.maybe_attribute_type.map(|t| t.kind.as_str()),
-    )
-  {
-    let mut raw_specifier = opts.specifier.clone();
-    raw_specifier.set_query(Some(ConfigImportKind::RAW_QUERY_MARKER));
-    let wrapper: Arc<[u8]> =
-      kind.render_module(raw_specifier.as_str()).into_bytes().into();
-    let source = new_source_with_text(
-      &opts.specifier,
-      wrapper,
-      Some("utf-8"),
-      opts.mtime,
-    )?;
-    return match module_analyzer
-      .analyze(&opts.specifier, source.text.clone(), MediaType::JavaScript)
-      .await
-    {
-      Ok(module_info) => Ok(ModuleSourceAndInfo::Js {
-        specifier: opts.specifier,
-        media_type: MediaType::JavaScript,
-        mtime: opts.mtime,
-        source,
-        maybe_headers: opts.maybe_headers,
-        module_info: Box::new(module_info),
-      }),
-      Err(diagnostic) => Err(
-        ModuleErrorKind::Parse {
-          specifier: opts.specifier,
-          mtime: opts.mtime,
-          diagnostic: Arc::new(diagnostic),
-        }
-        .into_box(),
-      ),
-    };
   }
 
   // here we check any media types that should have assertions made against them
@@ -4195,10 +4099,11 @@ fn fill_module_dependencies(
         if dep.maybe_code.is_none() {
           // This is a code import, the first one of that specifier in this module.
           // Resolve and determine the initial `is_dynamic` value from it.
-          dep.maybe_code = resolve(
+          dep.maybe_code = resolve_with_attribute_type(
             &import.specifier,
             import.specifier_range.clone(),
             ResolutionKind::Execution,
+            dep.maybe_attribute_type.as_deref(),
             jsr_url_provider,
             maybe_resolver,
           );
@@ -4212,10 +4117,16 @@ fn fill_module_dependencies(
         }
       }
       if graph_kind.include_types() && dep.maybe_type.is_none() {
-        let maybe_type = resolve(
+        // Use the same attribute-aware resolution as the code dependency so an
+        // attribute import that the resolver redirects (e.g. a config import to
+        // a wrapper module) doesn't also pull in the original file as a typed
+        // dependency. The result matching `maybe_code` below means no separate
+        // type dependency is recorded.
+        let maybe_type = resolve_with_attribute_type(
           &import.specifier,
           import.specifier_range.clone(),
           ResolutionKind::Types,
+          dep.maybe_attribute_type.as_deref(),
           jsr_url_provider,
           maybe_resolver,
         );
@@ -4706,7 +4617,6 @@ struct Builder<'a, 'graph> {
   unstable_text_imports: bool,
   unstable_css_imports: bool,
   unstable_config_imports: bool,
-  maybe_root_attribute_type: Option<String>,
   file_system: &'a FileSystem,
   jsr_url_provider: &'a dyn JsrUrlProvider,
   jsr_version_resolver: Cow<'a, JsrVersionResolver>,
@@ -4743,7 +4653,6 @@ impl<'a, 'graph> Builder<'a, 'graph> {
       unstable_text_imports: options.unstable_text_imports,
       unstable_css_imports: options.unstable_css_imports,
       unstable_config_imports: options.unstable_config_imports,
-      maybe_root_attribute_type: options.maybe_root_attribute_type,
       file_system: options.file_system,
       jsr_url_provider: options.jsr_url_provider,
       jsr_version_resolver: options.jsr_version_resolver,
@@ -4792,21 +4701,6 @@ impl<'a, 'graph> Builder<'a, 'graph> {
     self.graph.roots.extend(roots.clone());
 
     for root in roots {
-      // A non-analyzable dynamic import of a config file enters the graph as a
-      // root carrying a `type` attribute; synthesize an attribute (with a
-      // zeroed range, since a root has no referrer position) so it can be
-      // recognized as a config import.
-      let maybe_attribute_type =
-        self.maybe_root_attribute_type.as_ref().map(|kind| {
-          AttributeTypeWithRange {
-            range: Range {
-              specifier: root.clone(),
-              range: PositionRange::zeroed(),
-              resolution_mode: None,
-            },
-            kind: kind.clone(),
-          }
-        });
       self.load(LoadOptionsRef {
         specifier: &root,
         maybe_range: None,
@@ -4814,7 +4708,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
         is_asset: false,
         in_dynamic_branch: self.in_dynamic_branch,
         is_root: true,
-        maybe_attribute_type,
+        maybe_attribute_type: None,
         maybe_version_info: None,
       });
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1700,6 +1700,13 @@ pub struct BuildOptions<'a> {
   /// transformed into JavaScript modules that parse the file with a parser
   /// pulled from the registry on demand.
   pub unstable_config_imports: bool,
+  /// The `type` import attribute to associate with the roots being built.
+  ///
+  /// Roots normally have no import attribute, but a non-analyzable dynamic
+  /// `import()` of a config file enters the graph as a root, so the caller
+  /// passes its `with { type: "..." }` attribute here to let it be recognized
+  /// as a config import (which requires an explicit attribute).
+  pub maybe_root_attribute_type: Option<String>,
   pub executor: &'a dyn Executor,
   pub locker: Option<&'a mut dyn Locker>,
   pub file_system: &'a FileSystem,
@@ -1726,6 +1733,7 @@ impl Default for BuildOptions<'_> {
       unstable_text_imports: false,
       unstable_css_imports: false,
       unstable_config_imports: false,
+      maybe_root_attribute_type: None,
       executor: Default::default(),
       locker: None,
       file_system: &NullFileSystem,
@@ -3191,55 +3199,21 @@ enum ConfigImportKind {
 }
 
 impl ConfigImportKind {
-  /// Determines the config import kind from the file extension / media type and
-  /// the optional `type` import attribute. An explicit attribute takes
-  /// precedence; `type: "json"` is additionally accepted for JSON5/JSONC files.
+  /// Determines the config import kind solely from the `type` import attribute.
   ///
-  /// YAML and TOML are detected from the specifier's extension rather than a
-  /// dedicated media type, so that adding the feature does not require new
-  /// `MediaType` variants (which would ripple across the ecosystem).
-  fn detect(
-    specifier: &ModuleSpecifier,
-    media_type: MediaType,
-    attribute_type: Option<&str>,
-  ) -> Option<Self> {
+  /// An explicit attribute is required: a config file is only treated as such
+  /// when imported with `with { type: "yaml" }` (or `"toml"`/`"json5"`/
+  /// `"jsonc"`). The file extension is deliberately not consulted, matching the
+  /// browser rule that a non-JS module type must be requested explicitly, and
+  /// `type: "json"` is intentionally not accepted for JSON5/JSONC since those
+  /// are not JSON per the JSON modules proposal.
+  fn detect(attribute_type: Option<&str>) -> Option<Self> {
     match attribute_type {
       Some("yaml") => Some(Self::Yaml),
       Some("toml") => Some(Self::Toml),
       Some("json5") => Some(Self::Json5),
       Some("jsonc") => Some(Self::Jsonc),
-      // JSON5/JSONC are supersets of JSON, so they satisfy `type: "json"`.
-      Some("json") => match Self::from_extension(specifier, media_type) {
-        kind @ (Some(Self::Json5) | Some(Self::Jsonc)) => kind,
-        _ => None,
-      },
-      Some(_) => None,
-      None => Self::from_extension(specifier, media_type),
-    }
-  }
-
-  fn from_extension(
-    specifier: &ModuleSpecifier,
-    media_type: MediaType,
-  ) -> Option<Self> {
-    // JSON5/JSONC have dedicated media types, so they may also be identified
-    // via a remote `content-type` header even without a matching extension.
-    match media_type {
-      MediaType::Json5 => return Some(Self::Json5),
-      MediaType::Jsonc => return Some(Self::Jsonc),
-      _ => {}
-    }
-    let path = specifier.path().to_ascii_lowercase();
-    if path.ends_with(".yaml") || path.ends_with(".yml") {
-      Some(Self::Yaml)
-    } else if path.ends_with(".toml") {
-      Some(Self::Toml)
-    } else if path.ends_with(".json5") {
-      Some(Self::Json5)
-    } else if path.ends_with(".jsonc") {
-      Some(Self::Jsonc)
-    } else {
-      None
+      _ => None,
     }
   }
 
@@ -3332,8 +3306,6 @@ pub(crate) async fn parse_module_source_and_info(
   // parser only enters the module graph when such a file is actually imported.
   if opts.unstable_config_imports
     && let Some(kind) = ConfigImportKind::detect(
-      &opts.specifier,
-      media_type,
       opts.maybe_attribute_type.map(|t| t.kind.as_str()),
     )
   {
@@ -4716,6 +4688,7 @@ struct Builder<'a, 'graph> {
   unstable_text_imports: bool,
   unstable_css_imports: bool,
   unstable_config_imports: bool,
+  maybe_root_attribute_type: Option<String>,
   file_system: &'a FileSystem,
   jsr_url_provider: &'a dyn JsrUrlProvider,
   jsr_version_resolver: Cow<'a, JsrVersionResolver>,
@@ -4752,6 +4725,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
       unstable_text_imports: options.unstable_text_imports,
       unstable_css_imports: options.unstable_css_imports,
       unstable_config_imports: options.unstable_config_imports,
+      maybe_root_attribute_type: options.maybe_root_attribute_type,
       file_system: options.file_system,
       jsr_url_provider: options.jsr_url_provider,
       jsr_version_resolver: options.jsr_version_resolver,
@@ -4800,6 +4774,21 @@ impl<'a, 'graph> Builder<'a, 'graph> {
     self.graph.roots.extend(roots.clone());
 
     for root in roots {
+      // A non-analyzable dynamic import of a config file enters the graph as a
+      // root carrying a `type` attribute; synthesize an attribute (with a
+      // zeroed range, since a root has no referrer position) so it can be
+      // recognized as a config import.
+      let maybe_attribute_type =
+        self.maybe_root_attribute_type.as_ref().map(|kind| {
+          AttributeTypeWithRange {
+            range: Range {
+              specifier: root.clone(),
+              range: PositionRange::zeroed(),
+              resolution_mode: None,
+            },
+            kind: kind.clone(),
+          }
+        });
       self.load(LoadOptionsRef {
         specifier: &root,
         maybe_range: None,
@@ -4807,7 +4796,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
         is_asset: false,
         in_dynamic_branch: self.in_dynamic_branch,
         is_root: true,
-        maybe_attribute_type: None,
+        maybe_attribute_type,
         maybe_version_info: None,
       });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,9 @@ pub async fn parse_module(
       maybe_source_phase_referrer: None,
       is_root: true,
       is_dynamic_branch: false,
+      // The one-off `parse_module` helper does not support config imports;
+      // they are driven through the full graph build (`BuildOptions`).
+      unstable_config_imports: false,
     },
   )
   .await?;

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -546,6 +546,24 @@ pub trait Resolver: fmt::Debug {
     Ok(resolve_import(specifier_text, &referrer_range.specifier)?)
   }
 
+  /// Optionally override how an import that carries a `type` import attribute
+  /// resolves. This lets an embedder redirect, for example, a
+  /// `import data from "./c.yaml" with { type: "yaml" }` to a generated wrapper
+  /// module rather than the file itself, keeping any such "config import"
+  /// semantics out of deno_graph.
+  ///
+  /// Returning `Some` overrides the normal [`Resolver::resolve`] result for this
+  /// import; returning `None` (the default) falls back to `resolve`.
+  fn resolve_attribute_type_import(
+    &self,
+    _specifier_text: &str,
+    _referrer_range: &Range,
+    _kind: ResolutionKind,
+    _attribute_type: &str,
+  ) -> Option<Result<ModuleSpecifier, ResolveError>> {
+    None
+  }
+
   /// Given a module specifier, return an optional tuple which provides a module
   /// specifier that contains the types for the module and an optional range
   /// which contains information about the source of the dependency. This will

--- a/tests/ecosystem_test.rs
+++ b/tests/ecosystem_test.rs
@@ -299,6 +299,8 @@ async fn test_version(
         unstable_bytes_imports: false,
         unstable_text_imports: false,
         unstable_css_imports: false,
+        unstable_config_imports: false,
+        maybe_root_attribute_type: None,
         module_analyzer: &module_analyzer,
         module_info_cacher: Default::default(),
         file_system: &NullFileSystem,

--- a/tests/ecosystem_test.rs
+++ b/tests/ecosystem_test.rs
@@ -300,7 +300,6 @@ async fn test_version(
         unstable_text_imports: false,
         unstable_css_imports: false,
         unstable_config_imports: false,
-        maybe_root_attribute_type: None,
         module_analyzer: &module_analyzer,
         module_info_cacher: Default::default(),
         file_system: &NullFileSystem,


### PR DESCRIPTION
Adds an `unstable_config_imports` build option that lets `.yaml`, `.yml`,
`.toml`, `.json5`, and `.jsonc` files be imported as modules.

When the option is enabled, such a file is rewritten into a JavaScript module
that parses its contents with a parser pulled from the registry on demand:

```js
import { parse } from "jsr:@std/yaml@^1";
export default parse("<file contents>");
```

Because the parser becomes an ordinary graph dependency, the feature is
zero-cost when unused: nothing about it enters the module graph (or a compiled
binary, or the lockfile) unless a config file is actually imported. yaml and
toml are detected from the file extension so no new `MediaType` variant is
needed; json5 and jsonc are detected from their extension or media type. The
`type` import attribute is honored (`with { type: "yaml" }` etc.), and json5
and jsonc additionally satisfy `with { type: "json" }`.

The mapping is yaml to `jsr:@std/yaml`, toml to `jsr:@std/toml`, jsonc to
`jsr:@std/jsonc`, and json5 to `npm:json5` (there is no `@std/json5`). The
contents are inlined as a string literal rather than imported via
`with { type: "text" }`, because the rewritten module occupies the file's
specifier in the graph, so a text self-import would read back the generated
source instead of the original bytes.

This is the deno_graph half of denoland/deno#35304; the deno side wires the
option to `--unstable-raw-imports` and handles the runtime module type.
