### PR TITLE
feat: support excluding packages by name prefix in NewestDependencyDateOptions

### DIFF
--- a/src/packages.rs
+++ b/src/packages.rs
@@ -42,6 +42,10 @@ pub struct NewestDependencyDateOptions {
   /// JSR packages to exclude from the newest dependency date checks.
   #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
   pub exclude_jsr_pkgs: BTreeSet<PackageName>,
+  /// JSR package name prefixes to exclude from the newest dependency date
+  /// checks (e.g. `@scope/` from a `@scope/*` wildcard entry).
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub exclude_jsr_pkg_prefixes: Vec<PackageName>,
 }
 
 impl NewestDependencyDateOptions {
@@ -49,6 +53,7 @@ impl NewestDependencyDateOptions {
     Self {
       date: Some(NewestDependencyDate(date)),
       exclude_jsr_pkgs: Default::default(),
+      exclude_jsr_pkg_prefixes: Default::default(),
     }
   }
 
@@ -57,7 +62,12 @@ impl NewestDependencyDateOptions {
     package_name: &PackageName,
   ) -> Option<NewestDependencyDate> {
     let date = self.date?;
-    if self.exclude_jsr_pkgs.contains(package_name) {
+    if self.exclude_jsr_pkgs.contains(package_name)
+      || self
+        .exclude_jsr_pkg_prefixes
+        .iter()
+        .any(|prefix| package_name.starts_with(prefix.as_str()))
+    {
       None
     } else {
       Some(date)

--- a/tests/specs/graph/jsr/minimum_dependency_date_exclude_prefix.txt
+++ b/tests/specs/graph/jsr/minimum_dependency_date_exclude_prefix.txt
@@ -1,0 +1,128 @@
+~~ {"newestDependencyDate":{"date":"2022-11-07T00:00:00Z","excludeJsrPkgPrefixes":["@other/"]}} ~~
+# https://jsr.io/@scope/a/meta.json
+{
+  "versions": {
+    "1.0.0": {
+      "createdAt": "2020-11-07T00:00:00.000Z"
+    },
+    "1.0.1": {
+      "createdAt": "2023-11-07T00:00:00.000Z"
+    }
+  }
+}
+
+# https://jsr.io/@scope/a/1.0.0_meta.json
+{
+  "manifest": {},
+  "exports": {
+    ".": "./main.ts"
+  }
+}
+
+# https://jsr.io/@scope/a/1.0.0/main.ts
+console.log("HI");
+
+# https://jsr.io/@other/b/meta.json
+{
+  "versions": {
+    "1.0.0": {
+      "createdAt": "2020-11-07T00:00:00.000Z"
+    },
+    "1.0.1": {
+      "createdAt": "2023-11-07T00:00:00.000Z"
+    }
+  }
+}
+
+# https://jsr.io/@other/b/1.0.1_meta.json
+{
+  "manifest": {},
+  "exports": {
+    ".": "./main.ts"
+  }
+}
+
+# https://jsr.io/@other/b/1.0.1/main.ts
+console.log("B");
+
+# mod.ts
+import 'jsr:@scope/a';
+import 'jsr:@other/b';
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "jsr:@scope/a",
+          "code": {
+            "specifier": "jsr:@scope/a",
+            "resolutionMode": "import",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 7
+              },
+              "end": {
+                "line": 0,
+                "character": 21
+              }
+            }
+          }
+        },
+        {
+          "specifier": "jsr:@other/b",
+          "code": {
+            "specifier": "jsr:@other/b",
+            "resolutionMode": "import",
+            "span": {
+              "start": {
+                "line": 1,
+                "character": 7
+              },
+              "end": {
+                "line": 1,
+                "character": 21
+              }
+            }
+          }
+        }
+      ],
+      "size": 46,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 18,
+      "mediaType": "TypeScript",
+      "specifier": "https://jsr.io/@other/b/1.0.1/main.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 19,
+      "mediaType": "TypeScript",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/main.ts"
+    }
+  ],
+  "redirects": {
+    "jsr:@other/b": "https://jsr.io/@other/b/1.0.1/main.ts",
+    "jsr:@scope/a": "https://jsr.io/@scope/a/1.0.0/main.ts"
+  },
+  "packages": {
+    "@other/b@*": "@other/b@1.0.1",
+    "@scope/a@*": "@scope/a@1.0.0"
+  }
+}
+
+Fast check https://jsr.io/@other/b/1.0.1/main.ts:
+  {}
+  <empty>
+Fast check https://jsr.io/@scope/a/1.0.0/main.ts:
+  {}
+  <empty>


### PR DESCRIPTION
Adds an `exclude_jsr_pkg_prefixes` option to `NewestDependencyDateOptions` so
that consumers can exempt all packages sharing a name prefix (e.g. `@scope/`
derived from a `jsr:@scope/*` wildcard entry in `minimumDependencyAge.exclude`)
from the newest dependency date check, in addition to the existing exact-name
`exclude_jsr_pkgs` set.

This is the deno_graph half of denoland/deno#35743 (scope/wildcard patterns in
`minimumDependencyAge.exclude`); the npm half lives in the deno repo's
`deno_npm` crate. Once this is released, the CLI will start passing wildcard
`jsr:` entries through as prefixes.