### PR TITLE
fix: prefer cached jsr versions when resolving under cached-only

### DIFF
--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -315,6 +315,7 @@ pub async fn js_create_graph(
         unstable_text_imports: true,
         unstable_css_imports: true,
         unstable_config_imports: true,
+        prefer_cached_jsr_versions: false,
         resolver: maybe_resolver.as_ref().map(|r| r as &dyn Resolver),
         // todo(dsherret): actually implement this for Wasm users
         // and don't just use a RealSys here as it would be better

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -53,6 +53,7 @@ use deno_semver::package::PackageReq;
 use deno_semver::package::PackageReqReferenceParseError;
 use futures::FutureExt;
 use futures::future::LocalBoxFuture;
+use futures::future::join_all;
 use futures::stream::FuturesOrdered;
 use futures::stream::FuturesUnordered;
 use futures::stream::StreamExt;
@@ -4532,6 +4533,20 @@ struct PendingJsrReqResolutionItem {
   is_root: bool,
 }
 
+/// Memoizes the results of cache-only JSR version-manifest probes for a
+/// single package within one `resolve_pending_jsr_specifiers` pass, so that
+/// multiple pending reqs on the same package don't repeat the (cache-only)
+/// manifest existence checks. Only populated when `prefer_cached_jsr_versions`
+/// is enabled.
+#[derive(Debug, Default)]
+struct CachedJsrVersionProbe {
+  /// Versions whose manifest cache presence has already been checked in this
+  /// pass (regardless of whether it was found in the cache).
+  probed: HashSet<Version>,
+  /// Subset of `probed` whose version manifest was found in the cache.
+  cached: HashSet<Version>,
+}
+
 #[derive(Debug)]
 struct PendingJsrNvResolutionItem {
   specifier: ModuleSpecifier,
@@ -4899,6 +4914,15 @@ impl<'a, 'graph> Builder<'a, 'graph> {
         && self.graph.graph_kind.include_types();
     // don't bother pre-allocating because adding to this should be rare
     let mut restarted_pkgs = HashSet::new();
+    // Memoizes cache-only version-manifest probe results per package name for
+    // the duration of this pass so multiple pending reqs on the same package
+    // don't repeat probes. Only populated when `prefer_cached_jsr_versions` is
+    // enabled and in-graph unification isn't going to decide the version.
+    let empty_cached_versions = HashSet::new();
+    let mut cached_versions_by_package: HashMap<
+      StackString,
+      CachedJsrVersionProbe,
+    > = HashMap::new();
     while let Some(pending_resolution) = pending_resolutions.pop_front() {
       let package_name = &pending_resolution.package_ref.req().name;
       let fut = self
@@ -4910,14 +4934,27 @@ impl<'a, 'graph> Builder<'a, 'graph> {
       match fut.await {
         Ok(info) => {
           let package_req = pending_resolution.package_ref.req();
-          let cached_versions = if self.prefer_cached_jsr_versions {
-            self
-              .load_cached_jsr_version_manifests(package_req, &info)
-              .await
+          let cached_versions = if !self.prefer_cached_jsr_versions
+            || self.jsr_unification_decides(package_req)
+          {
+            // Either the feature is off, or in-graph version unification
+            // (step 1 of `resolve_version`) is going to decide this req, in
+            // which case the cached-manifest probe would be pure waste.
+            &empty_cached_versions
           } else {
-            Default::default()
+            self
+              .probe_cached_jsr_version_manifests(
+                package_req,
+                &info,
+                &mut cached_versions_by_package,
+              )
+              .await;
+            &cached_versions_by_package
+              .get(&package_req.name)
+              .unwrap()
+              .cached
           };
-          match self.resolve_jsr_nv(package_req, &info, &cached_versions) {
+          match self.resolve_jsr_nv(package_req, &info, cached_versions) {
             Ok(package_nv) => {
               // now queue a pending load for that version information
               self.queue_load_package_version_info(&package_nv);
@@ -5309,40 +5346,81 @@ impl<'a, 'graph> Builder<'a, 'graph> {
     async move { self.build(roots, imports).await }.boxed_local()
   }
 
-  /// Finds the versions of a package that match the package requirement
-  /// and already have their version manifest (`<version>_meta.json`) in
-  /// the cache. Only called when `prefer_cached_jsr_versions` is enabled.
-  async fn load_cached_jsr_version_manifests(
+  /// Whether step 1 of `resolve_version` (in-graph version unification) will
+  /// already decide `package_req`. When it will, the cached-manifest probe is
+  /// unnecessary because step 1 runs before the cached versions are ever read.
+  fn jsr_unification_decides(&self, package_req: &PackageReq) -> bool {
+    self
+      .graph
+      .packages
+      .versions_by_name(&package_req.name)
+      .into_iter()
+      .flatten()
+      .any(|nv| package_req.version_req.matches(&nv.version))
+  }
+
+  /// Probes which versions of `package_req` that match the requirement already
+  /// have their version manifest (`<version>_meta.json`) in the cache, using
+  /// cache-only loads issued concurrently. Results are memoized per package
+  /// name in `memo` so that multiple pending reqs on the same package don't
+  /// repeat probes within a single resolution pass. Only called when
+  /// `prefer_cached_jsr_versions` is enabled and in-graph unification isn't
+  /// going to decide the version.
+  async fn probe_cached_jsr_version_manifests(
     &self,
     package_req: &PackageReq,
     package_info: &JsrPackageInfo,
-  ) -> HashSet<Version> {
-    let mut cached_versions = HashSet::new();
-    for (version, version_info) in &package_info.versions {
-      if version_info.yanked || !package_req.version_req.matches(version) {
-        continue;
-      }
-      let specifier = self
-        .jsr_url_provider
-        .url()
-        .join(&format!("{}/{}_meta.json", package_req.name, version))
-        .unwrap();
-      let fut = self.loader.load(
-        &specifier,
-        LoadOptions {
-          in_dynamic_branch: false,
-          was_dynamic_root: false,
-          cache_setting: CacheSetting::Only,
-          maybe_checksum: None,
-        },
-      );
-      // the loader contract for `CacheSetting::Only` is to return
-      // `Ok(None)` when the specifier is not found in the cache
-      if matches!(fut.await, Ok(Some(LoadResponse::Module { .. }))) {
-        cached_versions.insert(version.clone());
-      }
+    memo: &mut HashMap<StackString, CachedJsrVersionProbe>,
+  ) {
+    let probe = memo.entry(package_req.name.clone()).or_default();
+    // Only probe unyanked versions that match this req and haven't been probed
+    // yet in this pass. `resolve_version` still applies the version req (and
+    // newest dependency date) to the memoized cached set, so accumulating
+    // results across reqs on the same package is safe.
+    let candidates = package_info
+      .versions
+      .iter()
+      .filter(|(version, version_info)| {
+        !version_info.yanked
+          && package_req.version_req.matches(version)
+          && !probe.probed.contains(*version)
+      })
+      .map(|(version, _)| {
+        let specifier = self
+          .jsr_url_provider
+          .url()
+          .join(&format!("{}/{}_meta.json", package_req.name, version))
+          .unwrap();
+        (version.clone(), specifier)
+      })
+      .collect::<Vec<_>>();
+    if candidates.is_empty() {
+      return;
     }
-    cached_versions
+    // the per-version loads are independent cache reads, so issue them
+    // concurrently rather than awaiting one at a time
+    let results =
+      join_all(candidates.iter().map(|(_, specifier)| async move {
+        let fut = self.loader.load(
+          specifier,
+          LoadOptions {
+            in_dynamic_branch: false,
+            was_dynamic_root: false,
+            cache_setting: CacheSetting::Only,
+            maybe_checksum: None,
+          },
+        );
+        // the loader contract for `CacheSetting::Only` is to return `Ok(None)`
+        // when the specifier is not found in the cache
+        matches!(fut.await, Ok(Some(LoadResponse::Module { .. })))
+      }))
+      .await;
+    for ((version, _), is_cached) in candidates.into_iter().zip(results) {
+      if is_cached {
+        probe.cached.insert(version.clone());
+      }
+      probe.probed.insert(version);
+    }
   }
 
   fn resolve_jsr_nv(

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1709,6 +1709,11 @@ pub struct BuildOptions<'a> {
   /// resolving them. This is useful in cases where you want to mark JSR
   /// specifiers as external.
   pub passthrough_jsr_specifiers: bool,
+  /// When resolving a `jsr:` semver range, prefer versions whose version
+  /// manifest is already cached. Intended for cached-only modes so
+  /// resolution matches what a previous cache-building command
+  /// materialized.
+  pub prefer_cached_jsr_versions: bool,
   pub module_analyzer: &'a dyn ModuleAnalyzer,
   pub module_info_cacher: &'a dyn ModuleInfoCacher,
   pub npm_resolver: Option<&'a dyn NpmResolver>,
@@ -1732,6 +1737,7 @@ impl Default for BuildOptions<'_> {
       jsr_url_provider: Default::default(),
       jsr_version_resolver: Default::default(),
       passthrough_jsr_specifiers: false,
+      prefer_cached_jsr_versions: false,
       module_analyzer: Default::default(),
       module_info_cacher: Default::default(),
       npm_resolver: None,
@@ -4621,6 +4627,7 @@ struct Builder<'a, 'graph> {
   jsr_url_provider: &'a dyn JsrUrlProvider,
   jsr_version_resolver: Cow<'a, JsrVersionResolver>,
   passthrough_jsr_specifiers: bool,
+  prefer_cached_jsr_versions: bool,
   loader: &'a dyn Loader,
   locker: Option<&'a mut dyn Locker>,
   resolver: Option<&'a dyn Resolver>,
@@ -4657,6 +4664,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
       jsr_url_provider: options.jsr_url_provider,
       jsr_version_resolver: options.jsr_version_resolver,
       passthrough_jsr_specifiers: options.passthrough_jsr_specifiers,
+      prefer_cached_jsr_versions: options.prefer_cached_jsr_versions,
       loader,
       locker: options.locker,
       resolver: options.resolver,
@@ -4902,7 +4910,14 @@ impl<'a, 'graph> Builder<'a, 'graph> {
       match fut.await {
         Ok(info) => {
           let package_req = pending_resolution.package_ref.req();
-          match self.resolve_jsr_nv(package_req, &info) {
+          let cached_versions = if self.prefer_cached_jsr_versions {
+            self
+              .load_cached_jsr_version_manifests(package_req, &info)
+              .await
+          } else {
+            Default::default()
+          };
+          match self.resolve_jsr_nv(package_req, &info, &cached_versions) {
             Ok(package_nv) => {
               // now queue a pending load for that version information
               self.queue_load_package_version_info(&package_nv);
@@ -5294,10 +5309,47 @@ impl<'a, 'graph> Builder<'a, 'graph> {
     async move { self.build(roots, imports).await }.boxed_local()
   }
 
+  /// Finds the versions of a package that match the package requirement
+  /// and already have their version manifest (`<version>_meta.json`) in
+  /// the cache. Only called when `prefer_cached_jsr_versions` is enabled.
+  async fn load_cached_jsr_version_manifests(
+    &self,
+    package_req: &PackageReq,
+    package_info: &JsrPackageInfo,
+  ) -> HashSet<Version> {
+    let mut cached_versions = HashSet::new();
+    for (version, version_info) in &package_info.versions {
+      if version_info.yanked || !package_req.version_req.matches(version) {
+        continue;
+      }
+      let specifier = self
+        .jsr_url_provider
+        .url()
+        .join(&format!("{}/{}_meta.json", package_req.name, version))
+        .unwrap();
+      let fut = self.loader.load(
+        &specifier,
+        LoadOptions {
+          in_dynamic_branch: false,
+          was_dynamic_root: false,
+          cache_setting: CacheSetting::Only,
+          maybe_checksum: None,
+        },
+      );
+      // the loader contract for `CacheSetting::Only` is to return
+      // `Ok(None)` when the specifier is not found in the cache
+      if matches!(fut.await, Ok(Some(LoadResponse::Module { .. }))) {
+        cached_versions.insert(version.clone());
+      }
+    }
+    cached_versions
+  }
+
   fn resolve_jsr_nv(
     &mut self,
     package_req: &PackageReq,
     package_info: &JsrPackageInfo,
+    cached_versions: &HashSet<Version>,
   ) -> Result<PackageNv, JsrPackageReqNotFoundError> {
     let version_resolver = self
       .jsr_version_resolver
@@ -5311,6 +5363,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
         .into_iter()
         .flatten()
         .map(|nv| &nv.version),
+      cached_versions,
     )?;
     let version = resolved_version.version.clone();
     if resolved_version.is_yanked {

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -355,6 +355,7 @@ impl<'a> JsrPackageVersionResolver<'a> {
     &'b self,
     package_req: &PackageReq,
     existing_versions: impl Iterator<Item = &'b Version>,
+    cached_versions: &HashSet<Version>,
   ) -> Result<JsrVersionResolverResolvedVersion<'b>, JsrPackageReqNotFoundError>
   {
     // 1. try to resolve with the list of existing versions
@@ -373,6 +374,45 @@ impl<'a> JsrPackageVersionResolver<'a> {
         .map(|i| i.yanked)
         .unwrap_or(false);
       return Ok(JsrVersionResolverResolvedVersion { is_yanked, version });
+    }
+
+    // 1.5. attempt to resolve with the versions whose version manifest is
+    // already cached (only populated when `prefer_cached_jsr_versions` is
+    // enabled). The placement of this step is important:
+    // - Step 1 must stay first so in-graph version unification still wins.
+    //   This matches online behavior when another package requirement
+    //   already selected a version in this graph.
+    // - This step must not be merged into step 1's iterator: if the graph
+    //   unified onto an older version, but a newer matching version is
+    //   also cached, chaining the two sets would resolve to the newer
+    //   version and diverge from what an online run resolves to.
+    // - Placing this before step 2 is strictly error-converting under
+    //   cached-only resolution: if step 2's best pick is cached, it equals
+    //   the best cached match here; if it's not cached, step 2's pick
+    //   would fail to load anyway.
+    // Yanked versions are excluded here, consistent with step 2 preceding
+    // step 3.
+    if !cached_versions.is_empty() {
+      let cached_unyanked_versions =
+        self.package_info.versions.iter().filter_map(|(v, i)| {
+          if !i.yanked && cached_versions.contains(v) {
+            Some((v, Some(i)))
+          } else {
+            None
+          }
+        });
+      if let ResolveVersionResult::Some(version) = resolve_version(
+        ResolveVersionOptions {
+          version_req: &package_req.version_req,
+          newest_dependency_date: self.newest_dependency_date,
+        },
+        cached_unyanked_versions,
+      ) {
+        return Ok(JsrVersionResolverResolvedVersion {
+          is_yanked: false,
+          version,
+        });
+      }
     }
 
     // 2. attempt to resolve with the unyanked versions

--- a/tests/ecosystem_test.rs
+++ b/tests/ecosystem_test.rs
@@ -310,6 +310,7 @@ async fn test_version(
         jsr_version_resolver: Default::default(),
         jsr_url_provider: &PassthroughJsrUrlProvider,
         passthrough_jsr_specifiers: true,
+        prefer_cached_jsr_versions: false,
         executor: Default::default(),
         jsr_metadata_store: None,
       },

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -1,8 +1,10 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
 use std::borrow::Cow;
+use std::cell::Cell;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -39,6 +41,31 @@ use futures::FutureExt;
 pub struct TestLoader {
   pub cache: MemoryLoader,
   pub remote: MemoryLoader,
+  /// Test-only instrumentation: counts cache-only (`CacheSetting::Only`) loads
+  /// of JSR version manifests (`<version>_meta.json`), i.e. the cached-version
+  /// probes performed when `prefer_cached_jsr_versions` is enabled. Package
+  /// `meta.json` loads are intentionally excluded.
+  pub cached_jsr_version_manifest_probe_count: Rc<Cell<usize>>,
+}
+
+fn is_jsr_version_manifest_probe(specifier: &ModuleSpecifier) -> bool {
+  if specifier.scheme() != "https" || specifier.host_str() != Some("jsr.io") {
+    return false;
+  }
+  let Some(path_segments) = specifier.path_segments() else {
+    return false;
+  };
+  let path_segments = path_segments.collect::<Vec<_>>();
+  let [scope, package, manifest] = path_segments.as_slice() else {
+    return false;
+  };
+  if !scope.starts_with('@') || package.is_empty() {
+    return false;
+  }
+  let Some(version) = manifest.strip_suffix("_meta.json") else {
+    return false;
+  };
+  Version::parse_standard(version).is_ok()
 }
 
 impl Loader for TestLoader {
@@ -51,6 +78,13 @@ impl Loader for TestLoader {
     specifier: &ModuleSpecifier,
     options: LoadOptions,
   ) -> LoadFuture {
+    if matches!(options.cache_setting, CacheSetting::Only)
+      && is_jsr_version_manifest_probe(specifier)
+    {
+      self
+        .cached_jsr_version_manifest_probe_count
+        .set(self.cached_jsr_version_manifest_probe_count.get() + 1);
+    }
     let checksum = options.maybe_checksum.clone();
     let future = match options.cache_setting {
       // todo(dsherret): in the future, actually make this use the cache
@@ -243,6 +277,14 @@ impl TestBuilder {
   pub fn prefer_cached_jsr_versions(&mut self, value: bool) -> &mut Self {
     self.prefer_cached_jsr_versions = value;
     self
+  }
+
+  /// Test-only instrumentation: the number of cache-only JSR version-manifest
+  /// (`<version>_meta.json`) probes performed by the most recent build. See
+  /// [`TestLoader::cached_jsr_version_manifest_probe_count`].
+  #[allow(unused)]
+  pub fn cached_jsr_version_manifest_probe_count(&self) -> usize {
+    self.loader.cached_jsr_version_manifest_probe_count.get()
   }
 
   #[allow(unused)]

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -154,6 +154,7 @@ pub struct TestBuilder {
   fast_check_cache: bool,
   lockfile_jsr_packages: BTreeMap<PackageReq, PackageNv>,
   newest_dependency_date: NewestDependencyDateOptions,
+  prefer_cached_jsr_versions: bool,
   resolver: Option<Box<dyn deno_graph::source::Resolver>>,
   skip_dynamic_deps: bool,
   workspace_members: Vec<WorkspaceMember>,
@@ -174,6 +175,7 @@ impl TestBuilder {
       fast_check_cache: false,
       lockfile_jsr_packages: Default::default(),
       newest_dependency_date: Default::default(),
+      prefer_cached_jsr_versions: false,
       skip_dynamic_deps: false,
       resolver: None,
       workspace_members: Default::default(),
@@ -234,6 +236,12 @@ impl TestBuilder {
     resolver: impl deno_graph::source::Resolver + 'static,
   ) -> &mut Self {
     self.resolver = Some(Box::new(resolver));
+    self
+  }
+
+  #[allow(unused)]
+  pub fn prefer_cached_jsr_versions(&mut self, value: bool) -> &mut Self {
+    self.prefer_cached_jsr_versions = value;
     self
   }
 
@@ -335,6 +343,7 @@ impl TestBuilder {
           } else {
             &workspace_resolver
           }),
+          prefer_cached_jsr_versions: self.prefer_cached_jsr_versions,
           skip_dynamic_deps: self.skip_dynamic_deps,
           unstable_bytes_imports: self.unstable_bytes_imports,
           unstable_text_imports: self.unstable_text_imports,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7,6 +7,8 @@
 // out of deno_graph that should be public
 
 use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 use deno_ast::ModuleSpecifier;
 use deno_error::JsErrorBox;
@@ -19,12 +21,14 @@ use deno_graph::Range;
 use deno_graph::packages::JsrPackageInfo;
 use deno_graph::packages::JsrPackageInfoVersion;
 use deno_graph::packages::JsrPackageVersionInfo;
+use deno_graph::packages::JsrPackageVersionManifestEntry;
 use deno_graph::source::CacheSetting;
 use deno_graph::source::ChecksumIntegrityError;
 use deno_graph::source::LoadError;
 use deno_graph::source::LoadFuture;
 use deno_graph::source::LoadOptions;
 use deno_graph::source::LoadResponse;
+use deno_graph::source::LoaderChecksum;
 use deno_graph::source::MemoryLoader;
 use deno_graph::source::NpmResolver;
 use deno_graph::source::ResolutionKind;
@@ -40,6 +44,7 @@ use sys_traits::impls::InMemorySys;
 use url::Url;
 
 use crate::helpers::TestBuilder;
+use crate::helpers::TestLoader;
 
 use self::helpers::TestNpmResolver;
 
@@ -824,6 +829,148 @@ async fn test_fill_from_lockfile() {
       .get(&PackageReq::from_str("@scope/example").unwrap())
       .unwrap(),
     PackageNv::from_str("@scope/example@1.0.1").unwrap(),
+  );
+}
+
+/// Registers a JSR package with the given versions in both the remote and the
+/// cache of a [`TestLoader`], including each version's manifest and an (empty)
+/// `mod.ts`. Every version manifest is present in the cache so that a cached
+/// probe of it would succeed, which is what makes the probe-count assertions
+/// in the tests below meaningful.
+fn add_cached_jsr_package(
+  loader: &mut TestLoader,
+  name: &str,
+  versions: &[&str],
+) {
+  let package_info = JsrPackageInfo {
+    versions: versions
+      .iter()
+      .map(|v| {
+        (
+          deno_semver::Version::parse_standard(v).unwrap(),
+          JsrPackageInfoVersion::default(),
+        )
+      })
+      .collect(),
+    latest: None,
+  };
+  // the package `meta.json` is not a version manifest and must never be
+  // counted as a probe
+  loader.remote.add_jsr_package_info(name, &package_info);
+  loader.cache.add_jsr_package_info(name, &package_info);
+  for version in versions {
+    let content = "";
+    let manifest = HashMap::from([(
+      "/mod.ts".to_string(),
+      JsrPackageVersionManifestEntry {
+        checksum: format!(
+          "sha256-{}",
+          LoaderChecksum::r#gen(content.as_bytes())
+        ),
+      },
+    )]);
+    let version_info = JsrPackageVersionInfo {
+      exports: serde_json::json!({ ".": "./mod.ts" }),
+      manifest,
+      ..Default::default()
+    };
+    loader
+      .remote
+      .add_jsr_version_info(name, version, &version_info);
+    loader
+      .cache
+      .add_jsr_version_info(name, version, &version_info);
+    let mod_url = format!("https://jsr.io/{name}/{version}/mod.ts");
+    loader.remote.add_source_with_text(&mod_url, content);
+    loader.cache.add_source_with_text(&mod_url, content);
+  }
+}
+
+// When in-graph version unification (step 1 of `resolve_version`) already
+// decides a req, `prefer_cached_jsr_versions` must not probe the cached
+// version manifests: the probe would be pure waste. Here the lockfile pins
+// `@scope/a` to an in-graph version satisfying the req, so the probe count
+// must be zero even though 10 matching manifests are sitting in the cache.
+#[tokio::test]
+async fn test_prefer_cached_jsr_versions_skips_probe_on_unification() {
+  let versions = [
+    "1.0.0", "1.0.1", "1.0.2", "1.0.3", "1.0.4", "1.0.5", "1.0.6", "1.0.7",
+    "1.0.8", "1.0.9",
+  ];
+  let mut builder = TestBuilder::new();
+  builder
+    .with_loader(|loader| {
+      loader.remote.add_source_with_text(
+        "file:///mod.ts",
+        "import \"jsr:@scope/a@^1.0.0\";",
+      );
+      add_cached_jsr_package(loader, "@scope/a", &versions);
+    })
+    .prefer_cached_jsr_versions(true)
+    .lockfile_jsr_packages(BTreeMap::from([(
+      PackageReq::from_str("@scope/a@^1.0.0").unwrap(),
+      PackageNv::from_str("@scope/a@1.0.5").unwrap(),
+    )]));
+  let result = builder.build().await;
+  result.graph.valid().unwrap();
+
+  assert_eq!(builder.cached_jsr_version_manifest_probe_count(), 0);
+  assert_eq!(
+    result
+      .graph
+      .packages
+      .mappings()
+      .get(&PackageReq::from_str("@scope/a@^1.0.0").unwrap())
+      .unwrap()
+      .to_string(),
+    "@scope/a@1.0.5",
+  );
+}
+
+// Multiple pending reqs on the same package within a single resolution pass
+// must not re-probe version manifests that were already probed. The package
+// has 10 versions across the 1.0.x and 1.1.x series. The first req (`^1.0.0`)
+// matches all 10 and resolves to `1.1.4`, probing all 10. The second req
+// (`~1.0.0`) matches only the five 1.0.x versions and does *not* unify with
+// `1.1.4`, so it takes the cached-probe path — but all five were already
+// probed, so it adds nothing. Total probes are 10 (once per version) rather
+// than 10 + 5 = 15.
+#[tokio::test]
+async fn test_prefer_cached_jsr_versions_memoizes_probes_per_package() {
+  let versions = [
+    "1.0.0", "1.0.1", "1.0.2", "1.0.3", "1.0.4", "1.1.0", "1.1.1", "1.1.2",
+    "1.1.3", "1.1.4",
+  ];
+  let mut builder = TestBuilder::new();
+  builder
+    .with_loader(|loader| {
+      // `^1.0.0` is intentionally first so it is processed first and seeds the
+      // graph with `1.1.4`, which `~1.0.0` does not unify with.
+      loader.remote.add_source_with_text(
+        "file:///mod.ts",
+        "import \"jsr:@scope/a@^1.0.0\";\nimport \"jsr:@scope/a@~1.0.0\";",
+      );
+      add_cached_jsr_package(loader, "@scope/a", &versions);
+    })
+    .prefer_cached_jsr_versions(true);
+  let result = builder.build().await;
+  result.graph.valid().unwrap();
+
+  assert_eq!(builder.cached_jsr_version_manifest_probe_count(), 10);
+  let mappings = result.graph.packages.mappings();
+  assert_eq!(
+    mappings
+      .get(&PackageReq::from_str("@scope/a@^1.0.0").unwrap())
+      .unwrap()
+      .to_string(),
+    "@scope/a@1.1.4",
+  );
+  assert_eq!(
+    mappings
+      .get(&PackageReq::from_str("@scope/a@~1.0.0").unwrap())
+      .unwrap()
+      .to_string(),
+    "@scope/a@1.0.4",
   );
 }
 

--- a/tests/specs/graph/jsr/prefer_cached_version.txt
+++ b/tests/specs/graph/jsr/prefer_cached_version.txt
@@ -1,0 +1,81 @@
+~~ {"preferCachedJsrVersions":true} ~~
+# https://jsr.io/@scope/a/meta.json
+{
+  "versions": {
+    "1.0.10": {},
+    "1.0.11": {}
+  }
+}
+
+# https://jsr.io/@scope/a/1.0.10_meta.json
+{
+  "exports": {
+    ".": "./mod.ts"
+  }
+}
+
+# cache:https://jsr.io/@scope/a/1.0.10_meta.json
+{
+  "exports": {
+    ".": "./mod.ts"
+  }
+}
+
+# https://jsr.io/@scope/a/1.0.10/mod.ts
+console.log("Hello, world!");
+
+# cache:https://jsr.io/@scope/a/1.0.10/mod.ts
+console.log("Hello, world!");
+
+# mod.ts
+import "jsr:@scope/a@^1.0.10";
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "jsr:@scope/a@^1.0.10",
+          "code": {
+            "specifier": "jsr:@scope/a@^1.0.10",
+            "resolutionMode": "import",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 7
+              },
+              "end": {
+                "line": 0,
+                "character": 29
+              }
+            }
+          }
+        }
+      ],
+      "size": 31,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 30,
+      "mediaType": "TypeScript",
+      "specifier": "https://jsr.io/@scope/a/1.0.10/mod.ts"
+    }
+  ],
+  "redirects": {
+    "jsr:@scope/a@^1.0.10": "https://jsr.io/@scope/a/1.0.10/mod.ts"
+  },
+  "packages": {
+    "@scope/a@^1.0.10": "@scope/a@1.0.10"
+  }
+}
+
+Fast check https://jsr.io/@scope/a/1.0.10/mod.ts:
+  {}
+  <empty>

--- a/tests/specs/graph/jsr/prefer_cached_version_off.txt
+++ b/tests/specs/graph/jsr/prefer_cached_version_off.txt
@@ -1,0 +1,72 @@
+# https://jsr.io/@scope/a/meta.json
+{
+  "versions": {
+    "1.0.10": {},
+    "1.0.11": {}
+  }
+}
+
+# https://jsr.io/@scope/a/1.0.10_meta.json
+{
+  "exports": {
+    ".": "./mod.ts"
+  }
+}
+
+# cache:https://jsr.io/@scope/a/1.0.10_meta.json
+{
+  "exports": {
+    ".": "./mod.ts"
+  }
+}
+
+# https://jsr.io/@scope/a/1.0.10/mod.ts
+console.log("Hello, world!");
+
+# cache:https://jsr.io/@scope/a/1.0.10/mod.ts
+console.log("Hello, world!");
+
+# mod.ts
+import "jsr:@scope/a@^1.0.10";
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "jsr:@scope/a@^1.0.10",
+          "code": {
+            "specifier": "jsr:@scope/a@^1.0.10",
+            "resolutionMode": "import",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 7
+              },
+              "end": {
+                "line": 0,
+                "character": 29
+              }
+            }
+          }
+        }
+      ],
+      "size": 31,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    },
+    {
+      "specifier": "jsr:@scope/a@^1.0.10",
+      "error": "JSR package version not found: @scope/a@1.0.11"
+    }
+  ],
+  "redirects": {},
+  "packages": {
+    "@scope/a@^1.0.10": "@scope/a@1.0.11"
+  }
+}

--- a/tests/specs/graph/jsr/prefer_cached_version_unification.txt
+++ b/tests/specs/graph/jsr/prefer_cached_version_unification.txt
@@ -1,0 +1,108 @@
+~~ {"preferCachedJsrVersions":true} ~~
+# https://jsr.io/@scope/a/meta.json
+{
+  "versions": {
+    "1.0.10": {},
+    "1.0.11": {}
+  }
+}
+
+# https://jsr.io/@scope/a/1.0.10_meta.json
+{
+  "exports": {
+    ".": "./mod.ts"
+  }
+}
+
+# cache:https://jsr.io/@scope/a/1.0.10_meta.json
+{
+  "exports": {
+    ".": "./mod.ts"
+  }
+}
+
+# cache:https://jsr.io/@scope/a/1.0.11_meta.json
+{
+  "exports": {
+    ".": "./mod.ts"
+  }
+}
+
+# https://jsr.io/@scope/a/1.0.10/mod.ts
+console.log("Hello, world!");
+
+# cache:https://jsr.io/@scope/a/1.0.10/mod.ts
+console.log("Hello, world!");
+
+# mod.ts
+import "jsr:@scope/a@1.0.10";
+import "jsr:@scope/a@^1.0.10";
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "jsr:@scope/a@1.0.10",
+          "code": {
+            "specifier": "jsr:@scope/a@1.0.10",
+            "resolutionMode": "import",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 7
+              },
+              "end": {
+                "line": 0,
+                "character": 28
+              }
+            }
+          }
+        },
+        {
+          "specifier": "jsr:@scope/a@^1.0.10",
+          "code": {
+            "specifier": "jsr:@scope/a@^1.0.10",
+            "resolutionMode": "import",
+            "span": {
+              "start": {
+                "line": 1,
+                "character": 7
+              },
+              "end": {
+                "line": 1,
+                "character": 29
+              }
+            }
+          }
+        }
+      ],
+      "size": 61,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 30,
+      "mediaType": "TypeScript",
+      "specifier": "https://jsr.io/@scope/a/1.0.10/mod.ts"
+    }
+  ],
+  "redirects": {
+    "jsr:@scope/a@1.0.10": "https://jsr.io/@scope/a/1.0.10/mod.ts",
+    "jsr:@scope/a@^1.0.10": "https://jsr.io/@scope/a/1.0.10/mod.ts"
+  },
+  "packages": {
+    "@scope/a@1.0.10": "@scope/a@1.0.10",
+    "@scope/a@^1.0.10": "@scope/a@1.0.10"
+  }
+}
+
+Fast check https://jsr.io/@scope/a/1.0.10/mod.ts:
+  {}
+  <empty>

--- a/tests/specs_test.rs
+++ b/tests/specs_test.rs
@@ -104,6 +104,7 @@ fn run_graph_test(test: &CollectedTest) {
     builder.newest_dependency_date(
       options.newest_dependency_date.clone().unwrap_or_default(),
     );
+    builder.prefer_cached_jsr_versions(options.prefer_cached_jsr_versions);
     builder.skip_dynamic_deps(options.skip_dynamic_deps);
     builder.unstable_bytes_imports(options.unstable_bytes_imports);
     builder.unstable_text_imports(options.unstable_text_imports);
@@ -351,6 +352,9 @@ pub struct SpecOptions {
   #[serde(default)]
   #[serde(skip_serializing_if = "is_false")]
   pub fast_check_cache: bool,
+  #[serde(default)]
+  #[serde(skip_serializing_if = "is_false")]
+  pub prefer_cached_jsr_versions: bool,
   #[serde(default)]
   #[serde(skip_serializing_if = "is_false")]
   pub skip_dynamic_deps: bool,


### PR DESCRIPTION
First half of the fix for denoland/deno#35879 (`deno run --cached-only` can fail after a successful `deno cache` due to JSR resolution divergence with type-only imports). The second half is a small deno CLI change that sets the new flag when running with `--cached-only`.

## Problem

`deno cache` resolves the type-inclusive graph; `deno run` (no type-checking) resolves a code-only graph. When an exact JSR pin is reachable **only** through a type-only import and another dependency requires a semver range on the same package, the cache-building command unifies the range onto the pinned (older) version and materializes only that version. The runtime graph doesn't contain the pin, re-resolves the range against the cached package `meta.json` to the newest matching version, and fails under `--cached-only` because that version's manifest was never fetched:

```
JSR package version manifest for '@std/encoding@1.0.11' failed to load:
Specifier not found in cache: "https://jsr.io/@std/encoding/1.0.11_meta.json", --cached-only is specified.
```

(Real-world instance in denoland/deno#35879: Lume pins `jsr:@std/encoding@1.0.10` on a type-only path while `jsr:@std/http@1.0.22/etag.ts` requires `^1.0.10`; the moment `1.0.11` was published, every lockfile-less build/run pair broke with no change to the project.)

## Change

Adds an opt-in `BuildOptions::prefer_cached_jsr_versions` (default `false`, so nothing changes for existing consumers). When enabled, resolving a `jsr:` semver range inserts a new step **1.5** into `JsrPackageVersionResolver::resolve_version`, between in-graph unification (step 1) and unyanked registry versions (step 2): resolve the range against the set of matching, unyanked versions whose `<version>_meta.json` is already in the cache (probed via `Loader::load` with `CacheSetting::Only`, which by contract returns `Ok(None)` when not cached).

The placement makes the flag strictly error-converting for cached-only consumers (rationale also in a code comment):

- Step 1 stays first, so in-graph unification still wins — matching online behavior when a code-edge pin exists in the graph.
- 1.5 is not merged into step 1's candidate iterator: if the graph unified onto an older version while a newer matching version is also cached, chaining would diverge from what an online run resolves.
- Before step 2, the change can only convert errors into successes: if step 2's best pick is cached it equals the best cached match here; if it isn't cached, step 2's pick fails to load today.
- Yanked versions are never selected from the cached set (consistent with step 2 preceding step 3).

## Tests

- `tests/specs/graph/jsr/prefer_cached_version.txt` — `meta.json` lists 1.0.10/1.0.11, only 1.0.10's manifest cached, flag on → range resolves to 1.0.10.
- `tests/specs/graph/jsr/prefer_cached_version_off.txt` — same fixture, flag off → today's behavior (resolves 1.0.11 and fails to load it).
- `tests/specs/graph/jsr/prefer_cached_version_unification.txt` — code-edge exact pin + range with **both** versions cached, flag on → unification wins (both resolve to the pin).

`cargo test --locked --all-features --all-targets`, `cargo fmt --check`, and `cargo clippy --locked --all-features --all-targets -- -D clippy::all` are green.

## Notes for review

- The cached-manifest probe runs per pending req when the flag is on (one cache-only load per matching version), even when step 1 unification would decide. Probes are local cache reads, so this is kept simple; it could be skipped when the graph already has a matching selection or memoized per package if you'd prefer.
- `newest_dependency_date` is applied in step 1.5 the same way as step 2 (unlike step 1, which ignores it), keeping 1.5's candidate set a strict subset of step 2's.
