### PR TITLE
chore: update ecosystem test expectations for current canary

### DIFF
--- a/tests/specs/ecosystem/bureaudouble/sonner/0_0_1.test
+++ b/tests/specs/ecosystem/bureaudouble/sonner/0_0_1.test
@@ -86,7 +86,7 @@ TS2552 [ERROR]: Cannot find name 'MouseEvent'. Did you mean 'CloseEvent'?
     at file://<tmpdir>/src/types.ts:38:56
 
     'CloseEvent' is declared here.
-    declare var CloseEvent: {
+    declare var CloseEvent: typeof globalThis extends
                 ~~~~~~~~~~
         at asset:///lib.deno.websocket.d.ts:88:13
 

--- a/tests/specs/ecosystem/ipinfo/client/1_0_1.test
+++ b/tests/specs/ecosystem/ipinfo/client/1_0_1.test
@@ -680,14 +680,4 @@ ipinfo/client/1.0.1
 
 == FAST CHECK EMIT PASSED ==
 
-== TYPE CHECK FAILED ==
--- stdout --
-
--- stderr --
-TS2503 [ERROR]: Cannot find namespace 'puppeteer'.
-    browser: puppeteer.Browser;
-             ~~~~~~~~~
-    at file://<tmpdir>/mod.ts:18:14
-
-error: Type checking failed.
-
+== TYPE CHECK PASSED ==

--- a/tests/specs/ecosystem/ipinfo/client/1_0_2.test
+++ b/tests/specs/ecosystem/ipinfo/client/1_0_2.test
@@ -680,14 +680,4 @@ ipinfo/client/1.0.2
 
 == FAST CHECK EMIT PASSED ==
 
-== TYPE CHECK FAILED ==
--- stdout --
-
--- stderr --
-TS2503 [ERROR]: Cannot find namespace 'puppeteer'.
-    browser: puppeteer.Browser;
-             ~~~~~~~~~
-    at file://<tmpdir>/mod.ts:18:14
-
-error: Type checking failed.
-
+== TYPE CHECK PASSED ==

--- a/tests/specs/ecosystem/ipinfo/client/1_0_3.test
+++ b/tests/specs/ecosystem/ipinfo/client/1_0_3.test
@@ -680,14 +680,4 @@ ipinfo/client/1.0.3
 
 == FAST CHECK EMIT PASSED ==
 
-== TYPE CHECK FAILED ==
--- stdout --
-
--- stderr --
-TS2503 [ERROR]: Cannot find namespace 'puppeteer'.
-    browser: puppeteer.Browser;
-             ~~~~~~~~~
-    at file://<tmpdir>/mod.ts:18:14
-
-error: Type checking failed.
-
+== TYPE CHECK PASSED ==

--- a/tests/specs/ecosystem/ipinfo/client/1_0_4.test
+++ b/tests/specs/ecosystem/ipinfo/client/1_0_4.test
@@ -680,14 +680,4 @@ ipinfo/client/1.0.4
 
 == FAST CHECK EMIT PASSED ==
 
-== TYPE CHECK FAILED ==
--- stdout --
-
--- stderr --
-TS2503 [ERROR]: Cannot find namespace 'puppeteer'.
-    browser: puppeteer.Browser;
-             ~~~~~~~~~
-    at file://<tmpdir>/mod.ts:18:14
-
-error: Type checking failed.
-
+== TYPE CHECK PASSED ==

--- a/tests/specs/ecosystem/ipinfo/client/1_0_5.test
+++ b/tests/specs/ecosystem/ipinfo/client/1_0_5.test
@@ -680,14 +680,4 @@ ipinfo/client/1.0.5
 
 == FAST CHECK EMIT PASSED ==
 
-== TYPE CHECK FAILED ==
--- stdout --
-
--- stderr --
-TS2503 [ERROR]: Cannot find namespace 'puppeteer'.
-    browser: () => Promise<puppeteer.Browser>;
-                           ~~~~~~~~~
-    at file://<tmpdir>/mod.ts:20:28
-
-error: Type checking failed.
-
+== TYPE CHECK PASSED ==

--- a/tests/specs/ecosystem/ipinfo/client/1_0_6.test
+++ b/tests/specs/ecosystem/ipinfo/client/1_0_6.test
@@ -680,14 +680,4 @@ ipinfo/client/1.0.6
 
 == FAST CHECK EMIT PASSED ==
 
-== TYPE CHECK FAILED ==
--- stdout --
-
--- stderr --
-TS2503 [ERROR]: Cannot find namespace 'puppeteer'.
-    browser: () => Promise<puppeteer.Browser>;
-                           ~~~~~~~~~
-    at file://<tmpdir>/mod.ts:20:28
-
-error: Type checking failed.
-
+== TYPE CHECK PASSED ==

--- a/tests/specs/ecosystem/ipinfo/client/1_0_7.test
+++ b/tests/specs/ecosystem/ipinfo/client/1_0_7.test
@@ -680,14 +680,4 @@ ipinfo/client/1.0.7
 
 == FAST CHECK EMIT PASSED ==
 
-== TYPE CHECK FAILED ==
--- stdout --
-
--- stderr --
-TS2503 [ERROR]: Cannot find namespace 'puppeteer'.
-    browser: () => Promise<puppeteer.Browser>;
-                           ~~~~~~~~~
-    at file://<tmpdir>/mod.ts:20:28
-
-error: Type checking failed.
-
+== TYPE CHECK PASSED ==

--- a/tests/specs/ecosystem/mebus/mebus/1_0_1.test
+++ b/tests/specs/ecosystem/mebus/mebus/1_0_1.test
@@ -20,19 +20,4 @@ mebus/mebus/1.0.1
 
 == FAST CHECK EMIT PASSED ==
 
-== TYPE CHECK FAILED ==
--- stdout --
-
--- stderr --
-TS1192 [ERROR]: Module '"file:<global_npm_dir>/zod/3.23.8/index.d.ts"' has no default export.
-import z from "npm:zod@^3.22.4";
-       ^
-    at file://<tmpdir>/index.ts:1:8
-
-TS1195 [ERROR]:     'export *' does not re-export a default.
-    export * from "./lib";
-    ~~~~~~~~~~~~~~~~~~~~~~
-        at file:<global_npm_dir>/zod/3.23.8/index.d.ts:1:1
-
-error: Type checking failed.
-
+== TYPE CHECK PASSED ==

--- a/tests/specs/ecosystem/mebus/mebus/1_0_2.test
+++ b/tests/specs/ecosystem/mebus/mebus/1_0_2.test
@@ -20,19 +20,4 @@ mebus/mebus/1.0.2
 
 == FAST CHECK EMIT PASSED ==
 
-== TYPE CHECK FAILED ==
--- stdout --
-
--- stderr --
-TS1192 [ERROR]: Module '"file:<global_npm_dir>/zod/3.23.8/index.d.ts"' has no default export.
- */ import z from "npm:zod@^3.22.4";
-           ^
-    at file://<tmpdir>/index.ts:4:12
-
-TS1195 [ERROR]:     'export *' does not re-export a default.
-    export * from "./lib";
-    ~~~~~~~~~~~~~~~~~~~~~~
-        at file:<global_npm_dir>/zod/3.23.8/index.d.ts:1:1
-
-error: Type checking failed.
-
+== TYPE CHECK PASSED ==


### PR DESCRIPTION
Refreshes the ecosystem snapshots that are currently red on CI (surfaced on #658, 2026-07-09). Regenerated with `UPDATE=1 cargo test --test ecosystem <spec>` against canary `4064da2bee25c414481dc7985e474b62da497066`, and verified green without `UPDATE` afterwards.

Specs refreshed:

- `bureaudouble/sonner@0.0.1`
- `ipinfo/client@1.0.1` … `1.0.7`
- `mebus/mebus@1.0.1`, `@1.0.2`

All are **canary drift**, not registry drift (an earlier attribution in #659 was wrong — see the correction comment there):

- **`bureaudouble/sonner@0.0.1`** — bisected to denoland/deno#35639 ("defer web-platform globals to lib.dom in deno libs"): the error set (TS2304/TS2552) is unchanged, but the TS2552 related-information snippet quotes `CloseEvent`'s declaration, whose text changed with the lib restructuring (`declare var CloseEvent: { ... }` → `typeof globalThis extends ...` form).
- **`ipinfo/client` and `mebus/mebus`** — `TYPE CHECK FAILED` → `PASSED` from the Deno 2.8 → 2.9 transition (npm types resolution improved: `mebus` no longer errors on `zod@3.23.8`'s default import, TS1192; `ipinfo` no longer errors on the `puppeteer` namespace, TS2503). The minimal repro fails on Deno 2.8.3 (matching the old snapshots) and passes on 2.9.1+. The main ecosystem workflow has in fact been red for these since 2026-06-22 (last green: 2026-06-10) — it went unnoticed because it isn't a required check.

Note: beyond the snapshot refresh, the process problem is that the ecosystem workflow stayed red on main for weeks without anyone noticing — #659's correction comment discusses that; this PR just brings the snapshots in line with what CI observes today.

Closes #659