### PR TITLE
feat: resolve wildcard requirements to the newest prerelease for packages with only prerelease versions

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -27,6 +27,8 @@ use crate::module_specifier::resolve_import;
 use crate::packages::JsrPackageInfo;
 use crate::packages::JsrPackageVersionInfo;
 use crate::packages::PackageSpecifiers;
+use crate::packages::prerelease_fallback_applies;
+use crate::packages::version_matches;
 use crate::rt::Executor;
 
 use crate::source::*;
@@ -4935,7 +4937,7 @@ impl<'a, 'graph> Builder<'a, 'graph> {
         Ok(info) => {
           let package_req = pending_resolution.package_ref.req();
           let cached_versions = if !self.prefer_cached_jsr_versions
-            || self.jsr_unification_decides(package_req)
+            || self.jsr_unification_decides(package_req, &info)
           {
             // Either the feature is off, or in-graph version unification
             // (step 1 of `resolve_version`) is going to decide this req, in
@@ -5349,14 +5351,27 @@ impl<'a, 'graph> Builder<'a, 'graph> {
   /// Whether step 1 of `resolve_version` (in-graph version unification) will
   /// already decide `package_req`. When it will, the cached-manifest probe is
   /// unnecessary because step 1 runs before the cached versions are ever read.
-  fn jsr_unification_decides(&self, package_req: &PackageReq) -> bool {
+  fn jsr_unification_decides(
+    &self,
+    package_req: &PackageReq,
+    package_info: &JsrPackageInfo,
+  ) -> bool {
+    // mirrors what step 1 itself considers a candidate
+    let include_all_prereleases =
+      prerelease_fallback_applies(&package_req.version_req, package_info);
     self
       .graph
       .packages
       .versions_by_name(&package_req.name)
       .into_iter()
       .flatten()
-      .any(|nv| package_req.version_req.matches(&nv.version))
+      .any(|nv| {
+        version_matches(
+          &package_req.version_req,
+          &nv.version,
+          include_all_prereleases,
+        )
+      })
   }
 
   /// Probes which versions of `package_req` that match the requirement already
@@ -5377,12 +5392,18 @@ impl<'a, 'graph> Builder<'a, 'graph> {
     // yet in this pass. `resolve_version` still applies the version req (and
     // newest dependency date) to the memoized cached set, so accumulating
     // results across reqs on the same package is safe.
+    let include_all_prereleases =
+      prerelease_fallback_applies(&package_req.version_req, package_info);
     let candidates = package_info
       .versions
       .iter()
       .filter(|(version, version_info)| {
         !version_info.yanked
-          && package_req.version_req.matches(version)
+          && version_matches(
+            &package_req.version_req,
+            version,
+            include_all_prereleases,
+          )
           && !probe.probed.contains(*version)
       })
       .map(|(version, _)| {

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -8,6 +8,7 @@ use std::collections::HashSet;
 use deno_semver::StackString;
 use deno_semver::Version;
 use deno_semver::VersionReq;
+use deno_semver::WILDCARD_VERSION_REQ;
 use deno_semver::jsr::JsrDepPackageReq;
 use deno_semver::package::PackageName;
 use deno_semver::package::PackageNv;
@@ -358,56 +359,18 @@ impl<'a> JsrPackageVersionResolver<'a> {
     cached_versions: &HashSet<Version>,
   ) -> Result<JsrVersionResolverResolvedVersion<'b>, JsrPackageReqNotFoundError>
   {
-    let existing_versions = existing_versions.collect::<Vec<_>>();
-    match self.resolve_version_inner(
-      package_req,
-      &existing_versions,
-      cached_versions,
-      false,
-    ) {
-      Ok(resolved) => Ok(resolved),
-      Err(err) => {
-        // A `*` version requirement never matches pre-release versions, so a
-        // package that only has pre-release versions would never resolve.
-        // Mirror npm's behavior for such packages (where a `*` requirement
-        // resolves to the `latest` dist-tag, even when that is a pre-release)
-        // by retrying with pre-release versions included. Only do so when no
-        // version matched at all: if versions merely got excluded by the
-        // newest dependency date, the error carries that date and falling
-        // back to an unrelated pre-release would be surprising.
-        if package_req.version_req.version_text() == "*"
-          && err.newest_dependency_date.is_none()
-        {
-          self.resolve_version_inner(
-            package_req,
-            &existing_versions,
-            cached_versions,
-            true,
-          )
-        } else {
-          Err(err)
-        }
-      }
-    }
-  }
+    let include_all_prereleases =
+      prerelease_fallback_applies(&package_req.version_req, self.package_info);
 
-  fn resolve_version_inner<'b>(
-    &'b self,
-    package_req: &PackageReq,
-    existing_versions: &[&'b Version],
-    cached_versions: &HashSet<Version>,
-    include_prerelease: bool,
-  ) -> Result<JsrVersionResolverResolvedVersion<'b>, JsrPackageReqNotFoundError>
-  {
     // 1. try to resolve with the list of existing versions
     if let ResolveVersionResult::Some(version) = resolve_version(
       ResolveVersionOptions {
         version_req: &package_req.version_req,
         // don't use this here because existing versions are ok to resolve to
         newest_dependency_date: None,
-        include_prerelease,
+        include_all_prereleases,
       },
-      existing_versions.iter().map(|v| (*v, None)),
+      existing_versions.map(|v| (v, None)),
     ) {
       let is_yanked = self
         .package_info
@@ -447,7 +410,7 @@ impl<'a> JsrPackageVersionResolver<'a> {
         ResolveVersionOptions {
           version_req: &package_req.version_req,
           newest_dependency_date: self.newest_dependency_date,
-          include_prerelease,
+          include_all_prereleases,
         },
         cached_unyanked_versions,
       ) {
@@ -469,7 +432,7 @@ impl<'a> JsrPackageVersionResolver<'a> {
       ResolveVersionOptions {
         version_req: &package_req.version_req,
         newest_dependency_date: self.newest_dependency_date,
-        include_prerelease,
+        include_all_prereleases,
       },
       unyanked_versions,
     ) {
@@ -496,7 +459,7 @@ impl<'a> JsrPackageVersionResolver<'a> {
       ResolveVersionOptions {
         version_req: &package_req.version_req,
         newest_dependency_date: self.newest_dependency_date,
-        include_prerelease,
+        include_all_prereleases,
       },
       yanked_versions,
     ) {
@@ -537,10 +500,45 @@ impl<'a> JsrPackageVersionResolver<'a> {
 pub struct ResolveVersionOptions<'a> {
   pub version_req: &'a VersionReq,
   pub newest_dependency_date: Option<NewestDependencyDate>,
-  /// Whether to additionally consider pre-release versions the version
-  /// requirement does not match. Used to resolve a `*` requirement for
-  /// packages that only have pre-release versions.
-  pub include_prerelease: bool,
+  /// When enabled, **every** pre-release version is a candidate, regardless of
+  /// whether `version_req` matches it.
+  ///
+  /// This deliberately bypasses the version requirement, so only enable it for
+  /// the case it exists for. Derive it with [`prerelease_fallback_applies`]
+  /// rather than setting it directly.
+  pub include_all_prereleases: bool,
+}
+
+/// Whether resolving `version_req` against `package_info` should additionally
+/// consider pre-release versions.
+///
+/// A `*` requirement never matches a pre-release version, so a package with no
+/// usable stable release — it only ever published pre-releases, or its stable
+/// releases were all yanked — could never be resolved by `jsr:@scope/pkg`.
+/// Mirror npm's behavior for such packages, where `*` resolves to the `latest`
+/// dist-tag even when that is a pre-release.
+pub fn prerelease_fallback_applies(
+  version_req: &VersionReq,
+  package_info: &JsrPackageInfo,
+) -> bool {
+  // `*`, `x`, `X` and an absent requirement all parse to the same wildcard
+  *version_req == *WILDCARD_VERSION_REQ
+    && !package_info
+      .versions
+      .iter()
+      .any(|(version, info)| version.pre.is_empty() && !info.yanked)
+}
+
+/// Whether `version` is a candidate for `version_req`, taking the pre-release
+/// fallback into account. `include_all_prereleases` must come from
+/// [`prerelease_fallback_applies`].
+pub fn version_matches(
+  version_req: &VersionReq,
+  version: &Version,
+  include_all_prereleases: bool,
+) -> bool {
+  version_req.matches(version)
+    || (include_all_prereleases && !version.pre.is_empty())
 }
 
 pub enum ResolveVersionResult<'a> {
@@ -555,9 +553,11 @@ pub fn resolve_version<'a>(
   let mut maybe_best_version: Option<&Version> = None;
   let mut had_higher_date_version = false;
   for (version, version_info) in versions {
-    if options.version_req.matches(version)
-      || (options.include_prerelease && !version.pre.is_empty())
-    {
+    if version_matches(
+      options.version_req,
+      version,
+      options.include_all_prereleases,
+    ) {
       had_higher_date_version = true;
       if matches_newest_dependency_date(
         version_info,

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -358,14 +358,56 @@ impl<'a> JsrPackageVersionResolver<'a> {
     cached_versions: &HashSet<Version>,
   ) -> Result<JsrVersionResolverResolvedVersion<'b>, JsrPackageReqNotFoundError>
   {
+    let existing_versions = existing_versions.collect::<Vec<_>>();
+    match self.resolve_version_inner(
+      package_req,
+      &existing_versions,
+      cached_versions,
+      false,
+    ) {
+      Ok(resolved) => Ok(resolved),
+      Err(err) => {
+        // A `*` version requirement never matches pre-release versions, so a
+        // package that only has pre-release versions would never resolve.
+        // Mirror npm's behavior for such packages (where a `*` requirement
+        // resolves to the `latest` dist-tag, even when that is a pre-release)
+        // by retrying with pre-release versions included. Only do so when no
+        // version matched at all: if versions merely got excluded by the
+        // newest dependency date, the error carries that date and falling
+        // back to an unrelated pre-release would be surprising.
+        if package_req.version_req.version_text() == "*"
+          && err.newest_dependency_date.is_none()
+        {
+          self.resolve_version_inner(
+            package_req,
+            &existing_versions,
+            cached_versions,
+            true,
+          )
+        } else {
+          Err(err)
+        }
+      }
+    }
+  }
+
+  fn resolve_version_inner<'b>(
+    &'b self,
+    package_req: &PackageReq,
+    existing_versions: &[&'b Version],
+    cached_versions: &HashSet<Version>,
+    include_prerelease: bool,
+  ) -> Result<JsrVersionResolverResolvedVersion<'b>, JsrPackageReqNotFoundError>
+  {
     // 1. try to resolve with the list of existing versions
     if let ResolveVersionResult::Some(version) = resolve_version(
       ResolveVersionOptions {
         version_req: &package_req.version_req,
         // don't use this here because existing versions are ok to resolve to
         newest_dependency_date: None,
+        include_prerelease,
       },
-      existing_versions.map(|v| (v, None)),
+      existing_versions.iter().map(|v| (*v, None)),
     ) {
       let is_yanked = self
         .package_info
@@ -405,6 +447,7 @@ impl<'a> JsrPackageVersionResolver<'a> {
         ResolveVersionOptions {
           version_req: &package_req.version_req,
           newest_dependency_date: self.newest_dependency_date,
+          include_prerelease,
         },
         cached_unyanked_versions,
       ) {
@@ -426,6 +469,7 @@ impl<'a> JsrPackageVersionResolver<'a> {
       ResolveVersionOptions {
         version_req: &package_req.version_req,
         newest_dependency_date: self.newest_dependency_date,
+        include_prerelease,
       },
       unyanked_versions,
     ) {
@@ -452,6 +496,7 @@ impl<'a> JsrPackageVersionResolver<'a> {
       ResolveVersionOptions {
         version_req: &package_req.version_req,
         newest_dependency_date: self.newest_dependency_date,
+        include_prerelease,
       },
       yanked_versions,
     ) {
@@ -492,6 +537,10 @@ impl<'a> JsrPackageVersionResolver<'a> {
 pub struct ResolveVersionOptions<'a> {
   pub version_req: &'a VersionReq,
   pub newest_dependency_date: Option<NewestDependencyDate>,
+  /// Whether to additionally consider pre-release versions the version
+  /// requirement does not match. Used to resolve a `*` requirement for
+  /// packages that only have pre-release versions.
+  pub include_prerelease: bool,
 }
 
 pub enum ResolveVersionResult<'a> {
@@ -506,7 +555,9 @@ pub fn resolve_version<'a>(
   let mut maybe_best_version: Option<&Version> = None;
   let mut had_higher_date_version = false;
   for (version, version_info) in versions {
-    if options.version_req.matches(version) {
+    if options.version_req.matches(version)
+      || (options.include_prerelease && !version.pre.is_empty())
+    {
       had_higher_date_version = true;
       if matches_newest_dependency_date(
         version_info,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -15,13 +15,17 @@ use deno_error::JsErrorBox;
 use deno_graph::BuildOptions;
 use deno_graph::FillFromLockfileOptions;
 use deno_graph::GraphKind;
+use deno_graph::JsrLoadError;
+use deno_graph::ModuleErrorKind;
 use deno_graph::ModuleGraph;
+use deno_graph::ModuleLoadError;
 use deno_graph::NpmResolvePkgReqsResult;
 use deno_graph::Range;
 use deno_graph::packages::JsrPackageInfo;
 use deno_graph::packages::JsrPackageInfoVersion;
 use deno_graph::packages::JsrPackageVersionInfo;
 use deno_graph::packages::JsrPackageVersionManifestEntry;
+use deno_graph::packages::NewestDependencyDateOptions;
 use deno_graph::source::CacheSetting;
 use deno_graph::source::ChecksumIntegrityError;
 use deno_graph::source::LoadError;
@@ -832,23 +836,74 @@ async fn test_fill_from_lockfile() {
   );
 }
 
-/// Registers a JSR package with the given versions in both the remote and the
-/// cache of a [`TestLoader`], including each version's manifest and an (empty)
-/// `mod.ts`. Every version manifest is present in the cache so that a cached
-/// probe of it would succeed, which is what makes the probe-count assertions
-/// in the tests below meaningful.
-fn add_cached_jsr_package(
+/// A newest-dependency-date cutoff from an RFC 3339 timestamp. `chrono` is not
+/// a dev-dependency, so go through serde.
+fn newest_dependency_date(date: &str) -> NewestDependencyDateOptions {
+  NewestDependencyDateOptions {
+    date: Some(serde_json::from_value(serde_json::json!(date)).unwrap()),
+    ..Default::default()
+  }
+}
+
+/// A version of a test JSR package. Defaults to unyanked, undated, and with
+/// its version manifest present in the cache.
+struct TestJsrVersion<'a> {
+  version: &'a str,
+  yanked: bool,
+  created_at: Option<&'a str>,
+  cached: bool,
+}
+
+impl<'a> TestJsrVersion<'a> {
+  fn new(version: &'a str) -> Self {
+    Self {
+      version,
+      yanked: false,
+      created_at: None,
+      cached: true,
+    }
+  }
+
+  fn yanked(mut self) -> Self {
+    self.yanked = true;
+    self
+  }
+
+  /// RFC 3339 publish date, used by the newest dependency date checks.
+  fn created_at(mut self, created_at: &'a str) -> Self {
+    self.created_at = Some(created_at);
+    self
+  }
+
+  /// Leaves this version's manifest out of the cache, so a cached probe of it
+  /// fails.
+  fn uncached(mut self) -> Self {
+    self.cached = false;
+    self
+  }
+}
+
+/// Registers a JSR package in the remote of a [`TestLoader`], including each
+/// version's manifest and an (empty) `mod.ts`, plus whichever versions are
+/// cached.
+fn add_jsr_package(
   loader: &mut TestLoader,
   name: &str,
-  versions: &[&str],
+  versions: &[TestJsrVersion],
 ) {
   let package_info = JsrPackageInfo {
     versions: versions
       .iter()
       .map(|v| {
         (
-          deno_semver::Version::parse_standard(v).unwrap(),
-          JsrPackageInfoVersion::default(),
+          deno_semver::Version::parse_standard(v.version).unwrap(),
+          JsrPackageInfoVersion {
+            // `chrono` is not a dev-dependency, so go through serde
+            created_at: v
+              .created_at
+              .map(|d| serde_json::from_value(serde_json::json!(d)).unwrap()),
+            yanked: v.yanked,
+          },
         )
       })
       .collect(),
@@ -874,16 +929,33 @@ fn add_cached_jsr_package(
       manifest,
       ..Default::default()
     };
+    let mod_url = format!("https://jsr.io/{name}/{}/mod.ts", version.version);
     loader
       .remote
-      .add_jsr_version_info(name, version, &version_info);
-    loader
-      .cache
-      .add_jsr_version_info(name, version, &version_info);
-    let mod_url = format!("https://jsr.io/{name}/{version}/mod.ts");
+      .add_jsr_version_info(name, version.version, &version_info);
     loader.remote.add_source_with_text(&mod_url, content);
-    loader.cache.add_source_with_text(&mod_url, content);
+    if version.cached {
+      loader
+        .cache
+        .add_jsr_version_info(name, version.version, &version_info);
+      loader.cache.add_source_with_text(&mod_url, content);
+    }
   }
+}
+
+/// [`add_jsr_package`] with every version unyanked, undated and cached, so
+/// that a cached probe of any of them would succeed — which is what makes the
+/// probe-count assertions in the tests below meaningful.
+fn add_cached_jsr_package(
+  loader: &mut TestLoader,
+  name: &str,
+  versions: &[&str],
+) {
+  let versions = versions
+    .iter()
+    .map(|v| TestJsrVersion::new(v))
+    .collect::<Vec<_>>();
+  add_jsr_package(loader, name, &versions);
 }
 
 // When in-graph version unification (step 1 of `resolve_version`) already
@@ -1003,8 +1075,43 @@ async fn test_jsr_package_with_only_prerelease_versions() {
   );
 }
 
-// The pre-release fallback only applies to `*` requirements: a constrained
-// requirement on a package that only has pre-release versions still fails.
+// `x` and `X` parse to the same wildcard requirement as `*`, so they must take
+// the pre-release fallback too. Each spelling gets its own graph because
+// `PackageReq` compares the parsed requirement, not its text, so they would
+// otherwise collide in the mappings.
+#[tokio::test]
+async fn test_jsr_package_with_only_prerelease_versions_wildcard_spellings() {
+  for req in ["*", "x", "X"] {
+    let versions = ["1.0.0-rc.1", "1.0.0-rc.2"];
+    let mut builder = TestBuilder::new();
+    builder.with_loader(|loader| {
+      loader.remote.add_source_with_text(
+        "file:///mod.ts",
+        format!("import \"jsr:@scope/a@{req}\";"),
+      );
+      add_cached_jsr_package(loader, "@scope/a", &versions);
+    });
+    let result = builder.build().await;
+    result.graph.valid().unwrap_or_else(|err| {
+      panic!("`{req}` failed to resolve: {err:#}");
+    });
+    assert_eq!(
+      result
+        .graph
+        .packages
+        .mappings()
+        .get(&PackageReq::from_str(&format!("@scope/a@{req}")).unwrap())
+        .unwrap()
+        .to_string(),
+      "@scope/a@1.0.0-rc.2",
+      "for requirement `{req}`",
+    );
+  }
+}
+
+// The pre-release fallback only applies to wildcard requirements: a
+// constrained requirement on a package that only has pre-release versions
+// still fails to find a matching version.
 #[tokio::test]
 async fn test_jsr_package_with_only_prerelease_versions_constrained_req() {
   let versions = ["1.0.0-rc.1", "1.0.0-rc.2"];
@@ -1017,7 +1124,189 @@ async fn test_jsr_package_with_only_prerelease_versions_constrained_req() {
     add_cached_jsr_package(loader, "@scope/a", &versions);
   });
   let result = builder.build().await;
-  assert!(result.graph.valid().is_err());
+  let err = result.graph.valid().unwrap_err();
+  let Some(ModuleErrorKind::Load {
+    err: ModuleLoadError::Jsr(JsrLoadError::PackageReqNotFound(err)),
+    ..
+  }) = err.as_module_error_kind()
+  else {
+    panic!("unexpected error: {err:#?}");
+  };
+  assert_eq!(err.req.to_string(), "@scope/a@^1.0.0");
+}
+
+// A package with a usable stable release resolves to it: the fallback must not
+// drag a wildcard requirement up to a newer pre-release.
+#[tokio::test]
+async fn test_jsr_package_prerelease_not_used_when_stable_exists() {
+  let mut builder = TestBuilder::new();
+  builder.with_loader(|loader| {
+    loader
+      .remote
+      .add_source_with_text("file:///mod.ts", "import \"jsr:@scope/a\";");
+    add_jsr_package(
+      loader,
+      "@scope/a",
+      &[
+        TestJsrVersion::new("1.0.0"),
+        TestJsrVersion::new("2.0.0-rc.1"),
+      ],
+    );
+  });
+  let result = builder.build().await;
+  result.graph.valid().unwrap();
+  assert_eq!(
+    result
+      .graph
+      .packages
+      .mappings()
+      .get(&PackageReq::from_str("@scope/a").unwrap())
+      .unwrap()
+      .to_string(),
+    "@scope/a@1.0.0",
+  );
+}
+
+// A yanked stable release is not a usable stable release, so the fallback
+// still applies and the unyanked pre-release wins over it. Resolving to the
+// yanked version instead would also mark the graph as using a yanked package.
+#[tokio::test]
+async fn test_jsr_package_with_only_yanked_stable_versions() {
+  let mut builder = TestBuilder::new();
+  builder.with_loader(|loader| {
+    loader
+      .remote
+      .add_source_with_text("file:///mod.ts", "import \"jsr:@scope/a\";");
+    add_jsr_package(
+      loader,
+      "@scope/a",
+      &[
+        TestJsrVersion::new("1.0.0").yanked(),
+        TestJsrVersion::new("2.0.0-rc.1"),
+      ],
+    );
+  });
+  let mut result = builder.build().await;
+  result.graph.valid().unwrap();
+  assert_eq!(
+    result
+      .graph
+      .packages
+      .mappings()
+      .get(&PackageReq::from_str("@scope/a").unwrap())
+      .unwrap()
+      .to_string(),
+    "@scope/a@2.0.0-rc.1",
+  );
+  assert_eq!(result.graph.packages.used_yanked_packages().count(), 0);
+}
+
+// The newest dependency date still excludes pre-releases picked up by the
+// fallback, so resolution falls back to the newest pre-release published
+// before the cutoff.
+#[tokio::test]
+async fn test_jsr_package_prerelease_fallback_respects_dependency_date() {
+  let mut builder = TestBuilder::new();
+  builder
+    .with_loader(|loader| {
+      loader
+        .remote
+        .add_source_with_text("file:///mod.ts", "import \"jsr:@scope/a\";");
+      add_jsr_package(
+        loader,
+        "@scope/a",
+        &[
+          TestJsrVersion::new("1.0.0-rc.1").created_at("2024-01-01T00:00:00Z"),
+          TestJsrVersion::new("1.0.0-rc.2").created_at("2025-06-01T00:00:00Z"),
+        ],
+      );
+    })
+    .newest_dependency_date(newest_dependency_date("2025-01-01T00:00:00Z"));
+  let result = builder.build().await;
+  result.graph.valid().unwrap();
+  assert_eq!(
+    result
+      .graph
+      .packages
+      .mappings()
+      .get(&PackageReq::from_str("@scope/a").unwrap())
+      .unwrap()
+      .to_string(),
+    "@scope/a@1.0.0-rc.1",
+  );
+}
+
+// When every pre-release is excluded by the newest dependency date, the error
+// must report the date rather than claiming nothing matched.
+#[tokio::test]
+async fn test_jsr_package_prerelease_fallback_all_excluded_by_date() {
+  let mut builder = TestBuilder::new();
+  builder
+    .with_loader(|loader| {
+      loader
+        .remote
+        .add_source_with_text("file:///mod.ts", "import \"jsr:@scope/a\";");
+      add_jsr_package(
+        loader,
+        "@scope/a",
+        &[
+          TestJsrVersion::new("1.0.0-rc.1").created_at("2025-06-01T00:00:00Z"),
+          TestJsrVersion::new("1.0.0-rc.2").created_at("2025-06-01T00:00:00Z"),
+        ],
+      );
+    })
+    .newest_dependency_date(newest_dependency_date("2025-01-01T00:00:00Z"));
+  let result = builder.build().await;
+  let err = result.graph.valid().unwrap_err();
+  let Some(ModuleErrorKind::Load {
+    err: ModuleLoadError::Jsr(JsrLoadError::PackageReqNotFound(err)),
+    ..
+  }) = err.as_module_error_kind()
+  else {
+    panic!("unexpected error: {err:#?}");
+  };
+  assert!(
+    err.newest_dependency_date.is_some(),
+    "expected the error to report the dependency date: {err}",
+  );
+}
+
+// `prefer_cached_jsr_versions` must probe the pre-releases the fallback will
+// consider: probing only the versions the requirement literally matches would
+// find nothing for a pre-release-only package, and resolution would then pick
+// a version whose manifest is not in the cache.
+#[tokio::test]
+async fn test_prefer_cached_jsr_versions_probes_prerelease_fallback() {
+  let mut builder = TestBuilder::new();
+  builder
+    .with_loader(|loader| {
+      loader
+        .remote
+        .add_source_with_text("file:///mod.ts", "import \"jsr:@scope/a\";");
+      add_jsr_package(
+        loader,
+        "@scope/a",
+        &[
+          TestJsrVersion::new("1.0.0-rc.1"),
+          TestJsrVersion::new("1.0.0-rc.2").uncached(),
+        ],
+      );
+    })
+    .prefer_cached_jsr_versions(true);
+  let result = builder.build().await;
+  result.graph.valid().unwrap();
+
+  assert_eq!(builder.cached_jsr_version_manifest_probe_count(), 2);
+  assert_eq!(
+    result
+      .graph
+      .packages
+      .mappings()
+      .get(&PackageReq::from_str("@scope/a").unwrap())
+      .unwrap()
+      .to_string(),
+    "@scope/a@1.0.0-rc.1",
+  );
 }
 
 #[tokio::test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -974,6 +974,52 @@ async fn test_prefer_cached_jsr_versions_memoizes_probes_per_package() {
   );
 }
 
+// A `*` requirement (e.g. `jsr:@scope/a` without a version) never matches
+// pre-release versions, so a package that only has pre-release versions
+// falls back to resolving to its newest pre-release instead of failing —
+// mirroring how npm resolves `*` to the `latest` dist-tag even when that is
+// a pre-release.
+#[tokio::test]
+async fn test_jsr_package_with_only_prerelease_versions() {
+  let versions = ["1.0.0-rc.1", "1.0.0-rc.2"];
+  let mut builder = TestBuilder::new();
+  builder.with_loader(|loader| {
+    loader
+      .remote
+      .add_source_with_text("file:///mod.ts", "import \"jsr:@scope/a\";");
+    add_cached_jsr_package(loader, "@scope/a", &versions);
+  });
+  let result = builder.build().await;
+  result.graph.valid().unwrap();
+  assert_eq!(
+    result
+      .graph
+      .packages
+      .mappings()
+      .get(&PackageReq::from_str("@scope/a").unwrap())
+      .unwrap()
+      .to_string(),
+    "@scope/a@1.0.0-rc.2",
+  );
+}
+
+// The pre-release fallback only applies to `*` requirements: a constrained
+// requirement on a package that only has pre-release versions still fails.
+#[tokio::test]
+async fn test_jsr_package_with_only_prerelease_versions_constrained_req() {
+  let versions = ["1.0.0-rc.1", "1.0.0-rc.2"];
+  let mut builder = TestBuilder::new();
+  builder.with_loader(|loader| {
+    loader.remote.add_source_with_text(
+      "file:///mod.ts",
+      "import \"jsr:@scope/a@^1.0.0\";",
+    );
+    add_cached_jsr_package(loader, "@scope/a", &versions);
+  });
+  let result = builder.build().await;
+  assert!(result.graph.valid().is_err());
+}
+
 #[tokio::test]
 async fn test_json_root() {
   let mut graph = ModuleGraph::new(GraphKind::All);


### PR DESCRIPTION
A `*` version requirement never matches a prerelease version, so a JSR package that has no stable release could never be resolved by `deno run jsr:@scope/pkg`, `deno add jsr:@scope/pkg`, etc. — the requirement matched nothing and resolution failed.

This mirrors npm's behavior for such packages, where `*` resolves to the `latest` dist-tag even when that is a prerelease.

## Behavior

Resolution additionally considers prerelease versions when **both** hold:

1. the requirement is a wildcard — `*`, `x`, `X`, or absent, as in `jsr:@scope/pkg`; and
2. the package has no *usable* stable release.

"Usable" excludes yanked versions: a package whose only stable release was yanked is in the same position as one that never published a stable release, and npm's `latest` points at the prerelease in that case too.

Everything else is unchanged. A constrained requirement (`^1.0.0`) never takes the fallback and still fails against a prerelease-only package. Versions excluded by the newest dependency date stay excluded, and the error still reports that date. Yanked prereleases are still only reached after unyanked ones, and still mark the graph as using a yanked package.

## Implementation

The decision is made once, up front, from the package's own versions:

```rust
pub fn prerelease_fallback_applies(
  version_req: &VersionReq,
  package_info: &JsrPackageInfo,
) -> bool {
  *version_req == *WILDCARD_VERSION_REQ
    && !package_info
      .versions
      .iter()
      .any(|(version, info)| version.pre.is_empty() && !info.yanked)
}
```

Comparing against `WILDCARD_VERSION_REQ` rather than the requirement's raw text means `x` and `X` are handled, since `deno_semver` parses all three spellings to the same range and compares `VersionReq` by parsed value.

The resulting flag is applied uniformly across all four steps of `resolve_version` (existing versions, cached versions, unyanked versions, yanked versions), so the fallback is a property of the package rather than of a particular step or a failed attempt.

`version_matches` is the single definition of "is this version a candidate", and `graph.rs` shares it. Without that, `prefer_cached_jsr_versions` would probe only the versions the requirement literally matches — none, for a prerelease-only package — and then resolve to a version whose manifest is not in the cache, defeating the point of the flag.

## Breaking change

`ResolveVersionOptions` gains a required public field, `include_all_prereleases`, so downstream struct literals stop compiling. **Release this as `minor`, not `patch`.**

The field deliberately bypasses the version requirement, which its docs say outright; derive it with `prerelease_fallback_applies` rather than setting it by hand.

## Tests

- resolves to the newest prerelease for a prerelease-only package
- the same for the `x` and `X` wildcard spellings
- a constrained requirement still fails, asserted on `JsrLoadError::PackageReqNotFound` rather than bare `is_err()`
- a package with a usable stable release resolves to it, not to a higher prerelease
- a yanked stable release does not suppress the fallback, and the graph is not marked as using a yanked package
- the newest dependency date still excludes prereleases, falling back to the newest one published before the cutoff
- when every prerelease is excluded by the date, the error reports the date
- `prefer_cached_jsr_versions` probes the prereleases the fallback will consider, and prefers the cached one

## Not addressed here

A lockfile pin of a wildcard requirement to a prerelease is dropped once upstream publishes a stable release (#666). It shares a code path with this change but is pre-existing, and the one-line fix — letting step 1 match prereleases for wildcard requirements — would also make a bare `jsr:@scope/pkg` unify onto a prerelease whenever any other import in the graph opted into one. That needs step 1 to distinguish a lockfile pin from a version resolved a moment earlier in the same pass.

---

Counterpart to the registry-side change in jsr-io/jsr#1497; the CLI side is in denoland/deno. Ref jsr-io/jsr#897.
