### PR TITLE
fix(fast_check): infer literal types for substitution-less template literals

### DIFF
--- a/src/fast_check/swc_helpers.rs
+++ b/src/fast_check/swc_helpers.rs
@@ -184,6 +184,29 @@ pub enum DeclMutabilityKind {
   Mutable,
 }
 
+/// Gets the type of an untagged template literal expression.
+///
+/// A template literal without substitutions is equivalent to a string
+/// literal, so it keeps its literal type in a const position. Otherwise
+/// the type depends on the substituted expressions, which TypeScript only
+/// evaluates in a const assertion (that case is handled by leaving the
+/// expression as-is instead of inferring a type from it).
+pub fn tpl_to_ts_type(tpl: &Tpl, decl_kind: DeclMutabilityKind) -> TsType {
+  if let DeclMutabilityKind::Const = decl_kind
+    && tpl.exprs.is_empty()
+    && let Some(quasi) = tpl.quasis.first()
+    && let Some(cooked) = &quasi.cooked
+  {
+    return ts_lit_type(TsLit::Str(Str {
+      span: DUMMY_SP,
+      value: cooked.clone(),
+      raw: None,
+    }));
+  }
+
+  ts_keyword_type(TsKeywordTypeKind::TsStringKeyword)
+}
+
 pub fn maybe_lit_to_ts_type(
   lit: &Lit,
   decl_kind: DeclMutabilityKind,

--- a/src/fast_check/transform.rs
+++ b/src/fast_check/transform.rs
@@ -44,6 +44,7 @@ use super::swc_helpers::any_type_ann;
 use super::swc_helpers::is_void_type;
 use super::swc_helpers::maybe_lit_to_ts_type;
 use super::swc_helpers::new_ident;
+use super::swc_helpers::tpl_to_ts_type;
 use super::swc_helpers::ts_keyword_type;
 use super::transform_dts::FastCheckDtsDiagnostic;
 use super::transform_dts::FastCheckDtsTransformer;
@@ -1846,7 +1847,8 @@ impl<'a> FastCheckTransformer<'a> {
         true
       }
       Expr::Tpl(n) => {
-        // Untagged template literals always produce strings and are leavable.
+        // Untagged template literals are inferrable by TypeScript as long
+        // as their substitutions are.
         let mut is_leavable = true;
         for expr in &mut n.exprs {
           is_leavable = recurse(expr)?;
@@ -1899,13 +1901,7 @@ impl<'a> FastCheckTransformer<'a> {
           None
         }
       }
-      Expr::Tpl(_) => {
-        // Untagged template literals always produce strings.
-        Some(TsType::TsKeywordType(TsKeywordType {
-          span: DUMMY_SP,
-          kind: TsKeywordTypeKind::TsStringKeyword,
-        }))
-      }
+      Expr::Tpl(tpl) => Some(tpl_to_ts_type(tpl, decl_kind)),
       Expr::TsSatisfies(n) => {
         self.maybe_infer_type_from_expr(&n.expr, decl_kind)
       }

--- a/src/fast_check/transform_dts.rs
+++ b/src/fast_check/transform_dts.rs
@@ -11,6 +11,7 @@ use super::range_finder::ModulePublicRanges;
 use super::swc_helpers::DeclMutabilityKind;
 use super::swc_helpers::any_type_ann;
 use super::swc_helpers::maybe_lit_to_ts_type;
+use super::swc_helpers::tpl_to_ts_type;
 use super::swc_helpers::ts_readonly;
 use super::swc_helpers::ts_tuple_element;
 use super::swc_helpers::type_ann;
@@ -470,13 +471,13 @@ impl<'a> FastCheckDtsTransformer<'a> {
           }),
         ))
       }
-      Expr::Tpl(_) => {
-        // Untagged template literals always produce strings.
-        Some(TsType::TsKeywordType(TsKeywordType {
-          kind: TsKeywordTypeKind::TsStringKeyword,
-          span: DUMMY_SP,
-        }))
-      }
+      Expr::Tpl(tpl) => Some(tpl_to_ts_type(
+        &tpl,
+        match as_const {
+          true => DeclMutabilityKind::Const,
+          false => DeclMutabilityKind::Mutable,
+        },
+      )),
       // Since fast check requires explicit type annotations these
       // can be dropped as they are not part of an export declaration
       Expr::This(_)

--- a/tests/specs/graph/fast_check/template_literals.txt
+++ b/tests/specs/graph/fast_check/template_literals.txt
@@ -5,9 +5,36 @@
 { "exports": { ".": "./mod.ts" } }
 
 # https://jsr.io/@scope/a/1.0.0/mod.ts
+export const foobar: "F" = "F";
+export const str: string = "";
+
+// no substitutions
 export const a = `hello world`;
-export const b = `hello ${1 + 2} world`;
-export let c = `hello`;
+export let b = `hello world`;
+export const c = `hello world` as const;
+export const d = `multi
+line`;
+
+// with substitutions
+export const e = `hello ${1 + 2} world`;
+export let f = `hello ${foobar} world`;
+export const g = `hello ${foobar} world`;
+export const h = `hello ${str} world`;
+
+// const asserted with substitutions
+export const i = `hello ${foobar} world` as const;
+export const j = `hello ${str} world` as const;
+
+// class members
+export class C {
+  readonly a = `hello world`;
+  b = `hello world`;
+  static readonly c = `hello world`;
+  readonly d = `hello ${str} world`;
+}
+
+// default export
+export default `hello world`;
 
 # mod.ts
 import 'jsr:@scope/a'
@@ -45,7 +72,7 @@ import 'jsr:@scope/a'
     },
     {
       "kind": "esm",
-      "size": 97,
+      "size": 751,
       "mediaType": "TypeScript",
       "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
     }
@@ -60,10 +87,43 @@ import 'jsr:@scope/a'
 
 Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
   {}
-  export const a: string = {} as never;
-  export const b: string = {} as never;
-  export let c: string = {} as never;
+  export const foobar: "F" = {} as never;
+  export const str: string = {} as never;
+  export const a: "hello world" = {} as never;
+  export let b: string = {} as never;
+  export const c = `hello world` as const;
+  export const d: "multi\nline" = {} as never;
+  export const e: string = {} as never;
+  export let f: string = {} as never;
+  export const g: string = {} as never;
+  export const h: string = {} as never;
+  export const i = `hello ${foobar} world` as const;
+  export const j = `hello ${str} world` as const;
+  export class C {
+    declare readonly a: "hello world";
+    declare b: string;
+    declare static readonly c: "hello world";
+    declare readonly d: string;
+  }
+  export default `hello world`;
   --- DTS ---
-  export declare const a: string;
-  export declare const b: string;
-  export declare let c: string;
+  export declare const foobar: "F";
+  export declare const str: string;
+  export declare const a: "hello world";
+  export declare let b: string;
+  export declare const c: "hello world";
+  export declare const d: "multi\nline";
+  export declare const e: string;
+  export declare let f: string;
+  export declare const g: string;
+  export declare const h: string;
+  export declare const i: string;
+  export declare const j: string;
+  export declare class C {
+    readonly a: "hello world";
+    b: string;
+    static readonly c: "hello world";
+    readonly d: string;
+  }
+  declare const _dts_1: string;
+  export default _dts_1;

--- a/tests/specs/graph/fast_check/template_literals_tagged.txt
+++ b/tests/specs/graph/fast_check/template_literals_tagged.txt
@@ -1,0 +1,74 @@
+# https://jsr.io/@scope/a/meta.json
+{"versions": { "1.0.0": {} } }
+
+# https://jsr.io/@scope/a/1.0.0_meta.json
+{ "exports": { ".": "./mod.ts" } }
+
+# https://jsr.io/@scope/a/1.0.0/mod.ts
+export function tpl(strings: TemplateStringsArray): string {
+  return strings.join("");
+}
+
+// tagged template literals require type checking the tag function
+export const a = tpl`hello world`;
+
+# mod.ts
+import 'jsr:@scope/a'
+
+# output
+{
+  "roots": [
+    "file:///mod.ts"
+  ],
+  "modules": [
+    {
+      "kind": "esm",
+      "dependencies": [
+        {
+          "specifier": "jsr:@scope/a",
+          "code": {
+            "specifier": "jsr:@scope/a",
+            "resolutionMode": "import",
+            "span": {
+              "start": {
+                "line": 0,
+                "character": 7
+              },
+              "end": {
+                "line": 0,
+                "character": 21
+              }
+            }
+          }
+        }
+      ],
+      "size": 22,
+      "mediaType": "TypeScript",
+      "specifier": "file:///mod.ts"
+    },
+    {
+      "kind": "esm",
+      "size": 193,
+      "mediaType": "TypeScript",
+      "specifier": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+    }
+  ],
+  "redirects": {
+    "jsr:@scope/a": "https://jsr.io/@scope/a/1.0.0/mod.ts"
+  },
+  "packages": {
+    "@scope/a@*": "@scope/a@1.0.0"
+  }
+}
+
+Fast check https://jsr.io/@scope/a/1.0.0/mod.ts:
+  error[missing-explicit-type]: missing explicit type in the public API
+   --> https://jsr.io/@scope/a/1.0.0/mod.ts:6:14
+    |
+  6 | export const a = tpl`hello world`;
+    |              ^ this symbol is missing an explicit type
+    |
+    = hint: add an explicit type annotation to the symbol
+
+    info: all symbols in the public API must have an explicit type
+    docs: https://jsr.io/go/slow-type-missing-explicit-type


### PR DESCRIPTION
Untagged template literals were always inferred as `string`, but in a const position TypeScript infers the string literal type:

| source | tsc | before |
| --- | --- | --- |
| ``const a = `hello world` `` | `"hello world"` | `string` |
| ``const b = `hello world` as const`` | `"hello world"` | `string` (dts) |
| ``let c = `hello world` `` | `string` | `string` |
| ``const d = `hi ${foobar}` `` | `string` | `string` |
| ``readonly e = `hello` `` (class prop) | `"hello"` | `string` |

Adds `tpl_to_ts_type()` in `swc_helpers.rs`, used by both the fast check transform and the dts transform, which returns the string literal type of the cooked value for a substitution-free template in a const position and `string` otherwise.

Template literals with substitutions keep producing `string` (matching TypeScript), and tagged template literals remain slow types.

One known gap: the `.d.ts` for a const-asserted template *with* substitutions still widens to `string`, since the real type (`` `hi ${string}` ``) can't be computed without a type checker. The fast check `.ts` emit leaves the expression as-is, so it stays correct there.

Closes https://github.com/jsr-io/jsr/issues/453
Closes #458