### PR TITLE
ci: unblock the ecosystem suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,4 @@ jobs:
       - name: Test
         run: deno task test
       - name: Publish JSR
-        run: cd js && deno run -A jsr:@david/publish-on-tag@0.1.3
+        run: cd js && deno run -A --no-lock jsr:@david/publish-on-tag@0.1.3

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -34,7 +34,11 @@ jobs:
       - name: Install up Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: canary
+          # pinned to an exact stable release: `deno check` output feeds
+          # directly into the expectations here, so any Deno or TypeScript
+          # version drift turns the whole suite red. Bump deliberately and
+          # regenerate the expectations with `UPDATE=1` in the same commit.
+          deno-version: 2.9.5
 
       - name: Cache JSR mirror
         uses: actions/cache@v4

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "build": "cp LICENSE js/LICENSE && deno run -A jsr:@deno/wasmbuild@0.19.2 --no-default-features --project deno_graph_wasm --out js",
+    "build": "cp LICENSE js/LICENSE && deno run -A --no-lock jsr:@deno/wasmbuild@0.19.2 --no-default-features --project deno_graph_wasm --out js",
     "build:npm": "deno run -A _build_npm.ts",
     "test": "deno test --allow-read --allow-net"
   },

--- a/tests/ecosystem/jsr_mirror.ts
+++ b/tests/ecosystem/jsr_mirror.ts
@@ -7,25 +7,20 @@ const ROOT_DIR = path.dirname(path.fromFileUrl(import.meta.url));
 const VERSIONS_JSON = path.join(ROOT_DIR, "jsr_versions.json");
 
 const MIRROR_DIR = path.join(ROOT_DIR, "jsr_mirror");
-try {
-  await Deno.mkdir(MIRROR_DIR, { recursive: true });
-} catch (err) {
-  if (err instanceof Deno.errors.AlreadyExists) {
-    // Ignore
-  } else {
-    throw err;
-  }
-}
+await Deno.mkdir(MIRROR_DIR, { recursive: true });
 
 const VERSIONS: { scope: string; name: string; version: string }[] = JSON.parse(
   await Deno.readTextFile(VERSIONS_JSON),
 );
 
+/** How many package versions to mirror at once. */
+const PACKAGE_CONCURRENCY = 128;
+/** How many files to download at once within a single package version. */
+const FILE_CONCURRENCY = 8;
+
 let packagesDone = 0;
 let filesDone = 0;
 let sizeTotal = 0;
-
-let downloadFailures = 0;
 
 const start = performance.now();
 
@@ -52,9 +47,19 @@ const interval = setInterval(() => {
   }
 }, CI ? 2000 : 100);
 
+const failures: string[] = [];
+
 for await (
-  const _ of pooledMap(1024, tasks(), async (task) => {
-    await task.promise;
+  const _ of pooledMap(PACKAGE_CONCURRENCY, VERSIONS, async (row) => {
+    const { scope, name, version } = row;
+    try {
+      await mirrorPackageVersion(scope, name, version);
+    } catch (err) {
+      // Keep going so that one bad package version doesn't abandon the rest of
+      // the mirror; every failure is reported together at the end.
+      failures.push(`@${scope}/${name}@${version}: ${describeError(err)}`);
+    }
+    packagesDone++;
   })
 ) {
   // Empty
@@ -62,28 +67,55 @@ for await (
 
 clearInterval(interval);
 
-async function* tasks() {
-  const manifests = pooledMap(128, VERSIONS, async (row) => {
-    const { scope, name, version } = row;
-    const manifest = await retry(async () => {
-      try {
-        return await fetchManifest(scope, name, version);
-      } catch (err) {
-        downloadFailures++;
-        throw err;
-      }
-    });
-    return { scope, name, version, manifest };
-  });
-
-  for await (const { scope, name, version, manifest } of manifests) {
-    yield* downloadPackageVersion(scope, name, version, manifest);
+if (failures.length > 0) {
+  console.error(`Failed to mirror ${failures.length} package versions:`);
+  for (const failure of failures.slice(0, 50)) {
+    console.error(`  ${failure}`);
   }
+  if (failures.length > 50) {
+    console.error(`  ... and ${failures.length - 50} more`);
+  }
+  Deno.exit(1);
 }
 
 interface Manifest {
   manifest: Record<string, { size: number; checksum: string }>;
   exports: Record<string, string>;
+}
+
+async function mirrorPackageVersion(
+  scope: string,
+  name: string,
+  version: string,
+): Promise<void> {
+  const packageDir = path.join(MIRROR_DIR, scope, name);
+  const versionDir = path.join(packageDir, version);
+  const manifestFile = path.join(packageDir, `${version}_meta.json`);
+
+  if (await exists(manifestFile)) {
+    return; // Already mirrored, skip package
+  }
+
+  const manifest = await retry(() => fetchManifest(scope, name, version));
+
+  await Deno.mkdir(versionDir, { recursive: true });
+
+  const files = Object.entries(manifest.manifest);
+  for await (
+    const _ of pooledMap(
+      FILE_CONCURRENCY,
+      files,
+      ([file, { size }]) =>
+        retry(() => downloadFile(scope, name, version, versionDir, file, size)),
+    )
+  ) {
+    // Empty
+  }
+
+  // Written only once every file above is on disk: the presence of this file is
+  // what marks the version as mirrored, so writing it any earlier would make an
+  // interrupted run skip a package whose files never finished downloading.
+  await Deno.writeTextFile(manifestFile, JSON.stringify(manifest, null, 2));
 }
 
 async function fetchManifest(
@@ -95,72 +127,12 @@ async function fetchManifest(
     `https://jsr.io/@${scope}/${name}/${version}_meta.json`,
   );
   if (!resp.ok) {
+    await resp.body?.cancel();
     throw new Error(
       `Failed to fetch manifest for ${scope}/${name}@${version}: ${resp.statusText}`,
     );
   }
   return await resp.json();
-}
-
-async function* downloadPackageVersion(
-  scope: string,
-  name: string,
-  version: string,
-  manifest: Manifest,
-): AsyncGenerator<{ promise: Promise<void> }, void, void> {
-  const packageDir = path.join(MIRROR_DIR, scope, name);
-  const versionDir = path.join(packageDir, version);
-  const manifestFile = path.join(packageDir, `${version}_meta.json`);
-
-  try {
-    await Deno.mkdir(versionDir, { recursive: true });
-  } catch (err) {
-    if (err instanceof Deno.errors.AlreadyExists) {
-      // Ignore
-    } else {
-      throw err;
-    }
-  }
-
-  try {
-    await Deno.stat(manifestFile);
-    return; // Already downloaded, skip package
-  } catch (err) {
-    if (err instanceof Deno.errors.NotFound) {
-      // Ignore
-    } else {
-      throw err;
-    }
-  }
-
-  const files: [string, { size: number; checksum: string }][] = Object.entries(
-    manifest.manifest,
-  );
-
-  for (const [file, { size, checksum }] of files) {
-    yield {
-      promise: retry(async () => {
-        try {
-          await downloadFile(
-            scope,
-            name,
-            version,
-            versionDir,
-            file,
-            size,
-            checksum,
-          );
-        } catch (err) {
-          downloadFailures++;
-          throw err;
-        }
-      }),
-    };
-  }
-
-  await Deno.writeTextFile(manifestFile, JSON.stringify(manifest, null, 2));
-
-  packagesDone++;
 }
 
 async function downloadFile(
@@ -170,29 +142,60 @@ async function downloadFile(
   versionDir: string,
   file: string,
   size: number,
-  _checksum: string,
 ): Promise<void> {
   const fileUrl = `https://jsr.io/@${scope}/${name}/${version}/${file}`;
   const resp = await fetch(fileUrl);
   if (!resp.ok) {
+    await resp.body?.cancel();
     throw new Error(
       `Failed to fetch file ${fileUrl}: ${resp.statusText}`,
     );
   }
 
   const fileDest = path.join(versionDir, file);
-  const fileDir = path.dirname(fileDest);
-  try {
-    await Deno.mkdir(fileDir, { recursive: true });
-  } catch (err) {
-    if (err instanceof Deno.errors.AlreadyExists) {
-      // Ignore
-    } else {
-      throw err;
-    }
-  }
+  await Deno.mkdir(path.dirname(fileDest), { recursive: true });
   await Deno.writeFile(fileDest, resp.body!);
 
+  // A connection dropped mid-body still writes a well-formed but truncated
+  // file, which surfaces much later as a bogus syntax error in some spec far
+  // away from the actual problem. Only a short file means a truncated transfer:
+  // jsr serves a handful of files (readmes, mostly) that are larger than the
+  // size their manifest records, so this deliberately isn't an equality check.
+  const written = await Deno.stat(fileDest);
+  if (written.size < size) {
+    await Deno.remove(fileDest);
+    throw new Error(
+      `Truncated download of ${fileUrl}: expected ${size} bytes, got ${written.size}`,
+    );
+  }
+
   filesDone++;
-  sizeTotal += size;
+  sizeTotal += written.size;
+}
+
+/**
+ * `pooledMap` wraps whatever an item threw in an `AggregateError` and `retry`
+ * wraps it again in a `RetryError`, so the message that actually says what went
+ * wrong is a couple of layers down.
+ */
+function describeError(err: unknown): string {
+  if (err instanceof AggregateError) {
+    return err.errors.map(describeError).join("; ");
+  }
+  if (err instanceof Error && err.cause !== undefined) {
+    return `${err.message}: ${describeError(err.cause)}`;
+  }
+  return String(err);
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await Deno.stat(filePath);
+    return true;
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) {
+      return false;
+    }
+    throw err;
+  }
 }

--- a/tests/specs/ecosystem/bureaudouble/sonner/0_0_1.test
+++ b/tests/specs/ecosystem/bureaudouble/sonner/0_0_1.test
@@ -86,7 +86,7 @@ TS2552 [ERROR]: Cannot find name 'MouseEvent'. Did you mean 'CloseEvent'?
     at file://<tmpdir>/src/types.ts:38:56
 
     'CloseEvent' is declared here.
-    declare var CloseEvent: typeof globalThis extends
+    declare var CloseEvent: {
                 ~~~~~~~~~~
         at asset:///lib.deno.websocket.d.ts:88:13
 


### PR DESCRIPTION
Three independent reasons CI has been red, none of them a real test failure.

### Pin the ecosystem suite to a stable Deno release

The ecosystem expectations capture `deno check` output verbatim, so they are coupled to whatever TypeScript version the Deno binary ships. Running the suite against `canary` meant every upstream change to type checking turned all 12 shards red without anything in this repo changing.

The current instance is denoland/deno#35938, which switched `deno check` over to native tsc — that landed 8 days after the last green ecosystem run, and it rewrites diagnostics across ~950 spec files. It has not shipped in a stable release yet: 2.9.5 stable passes the current expectations, only canary fails.

Pinning to an exact stable release rather than tracking `canary` or `v2.x` makes a Deno bump a deliberate change that lands together with the regenerated expectations in the same commit. #663 holds the regenerated-for-native-tsc expectations for whenever that behaviour does reach stable.

One spec (`bureaudouble/sonner@0.0.1`) is regenerated here: it was last generated against canary, which renders the `CloseEvent` declaration quoted in a TS2552 hint differently. A full local run confirms it is the only one of the 7555 that differs between canary and 2.9.5 stable.

### Stop tooling deps from dirtying the workspace lockfile

Recent Deno versions record the deps of a remote `deno run jsr:...` script in the enclosing workspace lockfile. Both `deno task build` (wasmbuild) and the `publish-on-tag` script did that during the `javascript` job, so the `deno publish --dry-run` inside `publish-on-tag` aborted with "Aborting due to uncommitted changes". Both are tooling deps rather than project deps, so they now run with `--no-lock`.

### Make the JSR mirror robust

With the two above fixed, the remaining red shards all failed in `Mirror JSR` rather than in a test. Three bugs there:

- **`Uncaught (in promise) undefined`.** Download tasks were built as `yield { promise: retry(...) }`, so the promise started running the moment the generator yielded it. When the manifest-fetch pool feeding that generator threw, the outer pool tore down and every already-yielded promise was left with nobody awaiting it. Package versions are now mirrored as self-contained units, so no promise outlives its consumer.
- **Versions marked complete before their files existed.** `<version>_meta.json` — the marker a later run checks to decide a version is already mirrored — was written before the file downloads it had yielded finished, so a cached mirror could skip a package whose files were never written. That surfaces much later as "Module not found" in some unrelated spec. The marker is now written after the downloads it covers complete.
- **Silently truncated files.** A connection dropped mid-body left a well-formed but short file behind, surfacing as a bogus syntax error elsewhere. Downloads are now checked against the size the manifest records.

A single bad package version also no longer abandons the rest of the mirror: failures are collected and reported together at the end, unwrapped from the `AggregateError`/`RetryError` layers that were hiding the actual message.